### PR TITLE
feat: multi-camera viewer + compact events date bar

### DIFF
--- a/app/src/main/java/com/overdrive/app/ui/fragment/MultiCameraPlayerFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/MultiCameraPlayerFragment.kt
@@ -1,0 +1,321 @@
+package com.overdrive.app.ui.fragment
+
+import android.media.MediaPlayer
+import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.SeekBar
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.overdrive.app.R
+import com.overdrive.app.ui.view.CameraView
+import com.overdrive.app.ui.view.EventTimelineView
+import com.overdrive.app.ui.view.MultiCameraGLView
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Multi-camera playback viewer for mosaic recordings.
+ *
+ * One MediaPlayer feeds one SurfaceTexture. The GL view crops four quadrants
+ * from the 2560×1920 mosaic and renders them as: one large primary + three
+ * small previews in a right column. Tapping a small preview swaps it to primary.
+ *
+ * Controls auto-hide after 3 seconds of playback, same as VideoPlayerFragment.
+ */
+class MultiCameraPlayerFragment : Fragment() {
+
+    companion object {
+        const val ARG_VIDEO_PATH  = "video_path"
+        const val ARG_VIDEO_TITLE = "video_title"
+        private const val SEEK_UPDATE_MS   = 250L
+        private const val OVERLAY_HIDE_MS  = 3000L
+    }
+
+    private lateinit var glView:        MultiCameraGLView
+    private lateinit var seekBar:       SeekBar
+    private lateinit var tvCurrentTime: TextView
+    private lateinit var tvDuration:    TextView
+    private lateinit var tvTitle:       TextView
+    private lateinit var tvMeta:        TextView
+    private lateinit var tvEventInfo:   TextView
+    private lateinit var tvPrimaryLabel:TextView
+    private lateinit var btnPlayPause:  ImageButton
+    private lateinit var btnBack:       ImageButton
+    private lateinit var eventTimeline: EventTimelineView
+    private lateinit var topBar:        View
+    private lateinit var bottomControls:View
+    private lateinit var smallCam0:     FrameLayout
+    private lateinit var smallCam1:     FrameLayout
+    private lateinit var smallCam2:     FrameLayout
+    private lateinit var tvSmallLabel0: TextView
+    private lateinit var tvSmallLabel1: TextView
+    private lateinit var tvSmallLabel2: TextView
+
+    private var mediaPlayer: MediaPlayer? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private var isUserSeeking = false
+    private var overlayVisible = true
+
+    private val updateRunnable = object : Runnable {
+        override fun run() {
+            val mp = mediaPlayer ?: return
+            if (!isUserSeeking && mp.isPlaying) {
+                val pos = mp.currentPosition
+                seekBar.progress = pos
+                tvCurrentTime.text = formatTime(pos)
+                eventTimeline.setPlayhead(pos.toLong())
+            }
+            handler.postDelayed(this, SEEK_UPDATE_MS)
+        }
+    }
+
+    private val hideOverlayRunnable = Runnable {
+        if (mediaPlayer?.isPlaying == true) setOverlayVisible(false)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View = inflater.inflate(R.layout.fragment_multi_camera_player, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        glView         = view.findViewById(R.id.glView)
+        seekBar        = view.findViewById(R.id.seekBar)
+        tvCurrentTime  = view.findViewById(R.id.tvCurrentTime)
+        tvDuration     = view.findViewById(R.id.tvDuration)
+        tvTitle        = view.findViewById(R.id.tvTitle)
+        tvMeta         = view.findViewById(R.id.tvMeta)
+        tvEventInfo    = view.findViewById(R.id.tvEventInfo)
+        tvPrimaryLabel = view.findViewById(R.id.tvPrimaryLabel)
+        btnPlayPause   = view.findViewById(R.id.btnPlayPause)
+        btnBack        = view.findViewById(R.id.btnBack)
+        eventTimeline  = view.findViewById(R.id.eventTimeline)
+        topBar         = view.findViewById(R.id.topBar)
+        bottomControls = view.findViewById(R.id.bottomControls)
+        smallCam0      = view.findViewById(R.id.smallCam0)
+        smallCam1      = view.findViewById(R.id.smallCam1)
+        smallCam2      = view.findViewById(R.id.smallCam2)
+        tvSmallLabel0  = view.findViewById(R.id.tvSmallLabel0)
+        tvSmallLabel1  = view.findViewById(R.id.tvSmallLabel1)
+        tvSmallLabel2  = view.findViewById(R.id.tvSmallLabel2)
+
+        val videoPath = arguments?.getString(ARG_VIDEO_PATH) ?: run {
+            findNavController().popBackStack(); return
+        }
+        tvTitle.text = arguments?.getString(ARG_VIDEO_TITLE) ?: File(videoPath).name
+
+        val file = File(videoPath)
+        if (file.exists()) tvMeta.text = formatSize(file.length())
+
+        updateCameraLabels()
+        setupSmallCamTaps()
+        setupControls(videoPath)
+        setupOverlayTouch()
+        loadEventTimeline(videoPath)
+
+        // Wait for GL surface, then create MediaPlayer
+        glView.onSurfaceReady = { surface ->
+            activity?.runOnUiThread { startMediaPlayer(videoPath, surface) }
+        }
+    }
+
+    private fun startMediaPlayer(path: String, surface: android.view.Surface) {
+        val mp = MediaPlayer().apply {
+            setDataSource(requireContext(), Uri.fromFile(File(path)))
+            setSurface(surface)
+            setOnPreparedListener { player ->
+                val dur = player.duration
+                seekBar.max = dur
+                tvDuration.text = formatTime(dur)
+                eventTimeline.setPlayhead(0)
+                player.isLooping = false
+                player.start()
+                btnPlayPause.setImageResource(android.R.drawable.ic_media_pause)
+                handler.post(updateRunnable)
+                scheduleOverlayHide()
+            }
+            setOnCompletionListener {
+                btnPlayPause.setImageResource(android.R.drawable.ic_media_play)
+                handler.removeCallbacks(updateRunnable)
+                handler.removeCallbacks(hideOverlayRunnable)
+                setOverlayVisible(true)
+            }
+            setOnErrorListener { _, what, extra ->
+                android.util.Log.e("MultiCamPlayer", "Error: what=$what extra=$extra")
+                tvEventInfo.text = "Playback error"
+                true
+            }
+            prepareAsync()
+        }
+        mediaPlayer = mp
+    }
+
+    private fun setupSmallCamTaps() {
+        val cells = listOf(smallCam0, smallCam1, smallCam2)
+        cells.forEachIndexed { index, cell ->
+            cell.setOnClickListener {
+                val cam = glView.smallCameraOrder().getOrNull(index) ?: return@setOnClickListener
+                glView.setPrimaryCamera(cam)
+                updateCameraLabels()
+            }
+        }
+    }
+
+    private fun updateCameraLabels() {
+        // Primary label shows which camera is large
+        tvPrimaryLabel.text = glView.smallCameraOrder()
+            .let { CameraView.values().first { c -> !it.contains(c) } }
+            .label.uppercase()
+
+        // Small column labels in GL render order
+        val small = glView.smallCameraOrder()
+        val labelViews = listOf(tvSmallLabel0, tvSmallLabel1, tvSmallLabel2)
+        labelViews.forEachIndexed { i, tv ->
+            tv.text = small.getOrNull(i)?.label?.uppercase() ?: ""
+        }
+    }
+
+    private fun setupControls(videoPath: String) {
+        btnBack.setOnClickListener { findNavController().popBackStack() }
+
+        btnPlayPause.setOnClickListener {
+            val mp = mediaPlayer ?: return@setOnClickListener
+            if (mp.isPlaying) {
+                mp.pause()
+                btnPlayPause.setImageResource(android.R.drawable.ic_media_play)
+                handler.removeCallbacks(hideOverlayRunnable)
+            } else {
+                mp.start()
+                btnPlayPause.setImageResource(android.R.drawable.ic_media_pause)
+                handler.post(updateRunnable)
+                scheduleOverlayHide()
+            }
+        }
+
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(sb: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    tvCurrentTime.text = formatTime(progress)
+                    eventTimeline.setPlayhead(progress.toLong())
+                }
+            }
+            override fun onStartTrackingTouch(sb: SeekBar?) { isUserSeeking = true }
+            override fun onStopTrackingTouch(sb: SeekBar?) {
+                isUserSeeking = false
+                mediaPlayer?.seekTo(sb?.progress ?: 0)
+            }
+        })
+    }
+
+    private fun setupOverlayTouch() {
+        glView.setOnClickListener {
+            if (overlayVisible) setOverlayVisible(false)
+            else { setOverlayVisible(true); scheduleOverlayHide() }
+        }
+    }
+
+    private fun setOverlayVisible(visible: Boolean) {
+        overlayVisible = visible
+        val alpha = if (visible) 1f else 0f
+        listOf(topBar, bottomControls).forEach { v ->
+            if (visible) {
+                v.visibility = View.VISIBLE
+                v.alpha = 0f
+            }
+            v.animate().alpha(alpha).setDuration(250).withEndAction {
+                if (!visible) v.visibility = View.GONE
+            }.start()
+        }
+    }
+
+    private fun scheduleOverlayHide() {
+        handler.removeCallbacks(hideOverlayRunnable)
+        handler.postDelayed(hideOverlayRunnable, OVERLAY_HIDE_MS)
+    }
+
+    private fun loadEventTimeline(videoPath: String) {
+        Thread {
+            try {
+                val jsonFile = File(videoPath.replace(".mp4", ".json"))
+                if (!jsonFile.exists()) {
+                    activity?.runOnUiThread { tvEventInfo.text = "No events" }
+                    return@Thread
+                }
+                val json       = JSONObject(jsonFile.readText())
+                val durationMs = json.optLong("durationMs", 0)
+                val arr        = json.optJSONArray("events") ?: return@Thread
+                val stats      = json.optJSONObject("stats")
+
+                val events = (0 until arr.length()).map { i ->
+                    val ev = arr.getJSONObject(i)
+                    EventTimelineView.TimelineEvent(
+                        startMs    = ev.getLong("start"),
+                        endMs      = ev.getLong("end"),
+                        type       = ev.optString("type", "motion"),
+                        confidence = ev.optDouble("maxConf", 0.0).toFloat()
+                    )
+                }
+
+                val legend = buildString {
+                    if (stats != null) {
+                        listOf("person" to "🔴", "car" to "🔵", "bike" to "🟢", "motion" to "⚪")
+                            .mapNotNull { (key, icon) ->
+                                val n = stats.optInt(key, 0)
+                                if (n > 0) "$icon$n $key" else null
+                            }
+                            .joinToString("  ")
+                            .also { append(it) }
+                    }
+                }
+
+                activity?.runOnUiThread {
+                    eventTimeline.setEvents(events, durationMs)
+                    if (legend.isNotEmpty()) tvEventInfo.text = legend
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("MultiCamPlayer", "Timeline load failed: ${e.message}")
+            }
+        }.start()
+    }
+
+    private fun formatTime(ms: Int): String {
+        val s = ms / 1000
+        return "${s / 60}:${(s % 60).toString().padStart(2, '0')}"
+    }
+
+    private fun formatSize(bytes: Long): String = when {
+        bytes >= 1_000_000_000 -> "%.1f GB".format(bytes / 1_000_000_000.0)
+        bytes >= 1_000_000     -> "%.1f MB".format(bytes / 1_000_000.0)
+        bytes >= 1_000         -> "%.1f KB".format(bytes / 1_000.0)
+        else                   -> "$bytes B"
+    }
+
+    override fun onPause() {
+        super.onPause()
+        glView.onPause()
+        handler.removeCallbacks(updateRunnable)
+        mediaPlayer?.takeIf { it.isPlaying }?.pause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        glView.onResume()
+    }
+
+    override fun onDestroyView() {
+        handler.removeCallbacks(updateRunnable)
+        handler.removeCallbacks(hideOverlayRunnable)
+        mediaPlayer?.apply { stop(); release() }
+        mediaPlayer = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/com/overdrive/app/ui/fragment/RecordingLibraryFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/RecordingLibraryFragment.kt
@@ -1,5 +1,6 @@
 package com.overdrive.app.ui.fragment
 
+import android.app.DatePickerDialog
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -12,385 +13,224 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.overdrive.app.ui.adapter.CalendarAdapter
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.overdrive.app.R
 import com.overdrive.app.ui.adapter.RecordingAdapter
 import com.overdrive.app.ui.model.RecordingFile
 import com.overdrive.app.ui.util.RecordingScanner
-import com.google.android.material.chip.Chip
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.overdrive.app.R
-import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 import java.util.concurrent.Executors
 
-/**
- * Fragment for browsing recorded videos with calendar view.
- * SOTA: Uses background thread for scanning to prevent UI lag.
- */
 class RecordingLibraryFragment : Fragment() {
-    
+
     companion object {
         private const val TAG = "RecordingLibrary"
     }
-    
-    private lateinit var tvCurrentMonth: TextView
-    private lateinit var btnPrevMonth: ImageButton
-    private lateinit var btnNextMonth: ImageButton
-    private lateinit var recyclerCalendar: RecyclerView
-    private lateinit var tvSelectedDate: TextView
+
+    private lateinit var btnPrevDay:       ImageButton
+    private lateinit var btnNextDay:       ImageButton
+    private lateinit var tvSelectedDate:   TextView
+    private lateinit var btnFilterAll:     TextView
+    private lateinit var btnFilterNormal:  TextView
+    private lateinit var btnFilterSentry:  TextView
+    private lateinit var btnFilterProx:    TextView
     private lateinit var recyclerRecordings: RecyclerView
-    private lateinit var tvEmptyState: TextView
+    private lateinit var tvEmptyState:     TextView
     private var emptyStateContainer: LinearLayout? = null
-    private var chipFilterAll: Chip? = null
-    private var chipFilterNormal: Chip? = null
-    private var chipFilterSentry: Chip? = null
-    private var chipFilterProximity: Chip? = null
-    
-    private val calendarAdapter = CalendarAdapter { day -> onDaySelected(day) }
+
     private lateinit var recordingAdapter: RecordingAdapter
-    
+
     private val calendar = Calendar.getInstance()
-    private var selectedDay = calendar.get(Calendar.DAY_OF_MONTH)
+    private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+
     private var currentFilter = RecordingFilter.ALL
-    
-    private val monthFormat = SimpleDateFormat("MMMM yyyy", Locale.getDefault())
-    
-    // SOTA: Background executor for scanning operations
     private var scanExecutor = Executors.newSingleThreadExecutor()
-    
-    enum class RecordingFilter {
-        ALL, NORMAL, SENTRY, PROXIMITY
-    }
-    
+
+    enum class RecordingFilter { ALL, NORMAL, SENTRY, PROXIMITY }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Ensure executor is available (may have been shutdown on previous destroy)
-        if (scanExecutor.isShutdown) {
-            scanExecutor = Executors.newSingleThreadExecutor()
-        }
+        if (scanExecutor.isShutdown) scanExecutor = Executors.newSingleThreadExecutor()
     }
-    
+
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_recording_library, container, false)
-    }
-    
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_recording_library, container, false)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        
-        // Ensure executor is available (may have been shutdown in onDestroyView)
         if (scanExecutor.isShutdown || scanExecutor.isTerminated) {
             scanExecutor = Executors.newSingleThreadExecutor()
         }
-        
+
         initViews(view)
-        setupCalendar()
         setupRecordingsList()
-        setupClickListeners()
-        
-        // SOTA: Check for All Files Access permission and trigger MediaScan
-        checkPermissionsAndScan()
-        
-        updateCalendar()
-        loadRecordingsForSelectedDate()
-    }
-    
-    /**
-     * SOTA: Setup directories and load recordings.
-     * Since App owns the directories, we use direct file access.
-     */
-    private fun checkPermissionsAndScan() {
-        // SOTA: UI App creates directories so it OWNS them (can listFiles)
-        setupStorageDirectories()
-        
-        // Direct file access - no MediaStore needed
+        setupDateNavigation()
+        setupFilterButtons()
+        ensureDirectories()
         RecordingScanner.invalidateCache()
-        updateCalendar()
+        updateDateDisplay()
         loadRecordingsForSelectedDate()
     }
-    
-    /**
-     * SOTA: UI App creates directories so it OWNS them.
-     * This ensures listFiles() works even for files created by daemon (UID 2000).
-     * Directory ownership = listFiles() access, not file ownership.
-     * 
-     * Now uses RecordingScanner to get configured storage paths (internal or SD card).
-     */
-    private fun setupStorageDirectories() {
-        try {
-            // Get configured directories from RecordingScanner
-            val recordingsDir = RecordingScanner.getRecordingsDir(requireContext())
-            val surveillanceDir = RecordingScanner.getSentryEventsDir(requireContext())
-            val proximityDir = RecordingScanner.getProximityEventsDir(requireContext())
-            
-            Log.d(TAG, "Configured directories:")
-            Log.d(TAG, "  Recordings: ${recordingsDir.absolutePath}")
-            Log.d(TAG, "  Surveillance: ${surveillanceDir.absolutePath}")
-            Log.d(TAG, "  Proximity: ${proximityDir.absolutePath}")
-            
-            // Ensure base directory exists
-            val baseDir = recordingsDir.parentFile
-            if (baseDir != null && !baseDir.exists()) {
-                val created = baseDir.mkdirs()
-                Log.d(TAG, "Created base directory: ${baseDir.absolutePath} (success=$created)")
-            }
-            
-            // Ensure subdirectories exist
-            listOf(recordingsDir, surveillanceDir, proximityDir).forEach { dir ->
-                if (!dir.exists()) {
-                    val created = dir.mkdirs()
-                    Log.d(TAG, "Created subdirectory: ${dir.absolutePath} (success=$created)")
-                }
-            }
-            
-            // Verify we can list files now
-            val files = recordingsDir.listFiles()
-            Log.d(TAG, "After setup - recordings dir listFiles: ${files?.size ?: "null"}")
-            
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to setup storage directories: ${e.message}")
-        }
-    }
-    
+
     private fun initViews(view: View) {
-        tvCurrentMonth = view.findViewById(R.id.tvCurrentMonth)
-        btnPrevMonth = view.findViewById(R.id.btnPrevMonth)
-        btnNextMonth = view.findViewById(R.id.btnNextMonth)
-        recyclerCalendar = view.findViewById(R.id.recyclerCalendar)
-        tvSelectedDate = view.findViewById(R.id.tvSelectedDate)
+        btnPrevDay        = view.findViewById(R.id.btnPrevDay)
+        btnNextDay        = view.findViewById(R.id.btnNextDay)
+        tvSelectedDate    = view.findViewById(R.id.tvSelectedDate)
+        btnFilterAll      = view.findViewById(R.id.btnFilterAll)
+        btnFilterNormal   = view.findViewById(R.id.btnFilterNormal)
+        btnFilterSentry   = view.findViewById(R.id.btnFilterSentry)
+        btnFilterProx     = view.findViewById(R.id.btnFilterProximity)
         recyclerRecordings = view.findViewById(R.id.recyclerRecordings)
-        tvEmptyState = view.findViewById(R.id.tvEmptyState)
+        tvEmptyState      = view.findViewById(R.id.tvEmptyState)
         emptyStateContainer = view.findViewById(R.id.emptyStateContainer)
-        
-        // Filter chips - modern design
-        try {
-            chipFilterAll = view.findViewById(R.id.btnFilterAll)
-            chipFilterNormal = view.findViewById(R.id.btnFilterNormal)
-            chipFilterSentry = view.findViewById(R.id.btnFilterSentry)
-            chipFilterProximity = view.findViewById(R.id.btnFilterProximity)
-            setupFilterChips()
-        } catch (e: Exception) {
-            // Filter chips not available - use default filter
-        }
     }
-    
-    private fun setupFilterChips() {
-        chipFilterAll?.setOnClickListener {
-            currentFilter = RecordingFilter.ALL
-            updateFilterChips()
+
+    private fun setupDateNavigation() {
+        btnPrevDay.setOnClickListener {
+            calendar.add(Calendar.DAY_OF_MONTH, -1)
+            updateDateDisplay()
             loadRecordingsForSelectedDate()
         }
-        
-        chipFilterNormal?.setOnClickListener {
-            currentFilter = RecordingFilter.NORMAL
-            updateFilterChips()
-            loadRecordingsForSelectedDate()
+        btnNextDay.setOnClickListener {
+            // Don't allow navigating into the future
+            val today = Calendar.getInstance()
+            if (!isSameDay(calendar, today)) {
+                calendar.add(Calendar.DAY_OF_MONTH, 1)
+                updateDateDisplay()
+                loadRecordingsForSelectedDate()
+            }
         }
-        
-        chipFilterSentry?.setOnClickListener {
-            currentFilter = RecordingFilter.SENTRY
-            updateFilterChips()
-            loadRecordingsForSelectedDate()
-        }
-        
-        chipFilterProximity?.setOnClickListener {
-            currentFilter = RecordingFilter.PROXIMITY
-            updateFilterChips()
-            loadRecordingsForSelectedDate()
-        }
-        
-        updateFilterChips()
+        tvSelectedDate.setOnClickListener { showDatePicker() }
     }
-    
-    private fun updateFilterChips() {
-        // Skip if chips not available
-        if (chipFilterAll == null) return
-        
-        chipFilterAll?.isChecked = currentFilter == RecordingFilter.ALL
-        chipFilterNormal?.isChecked = currentFilter == RecordingFilter.NORMAL
-        chipFilterSentry?.isChecked = currentFilter == RecordingFilter.SENTRY
-        chipFilterProximity?.isChecked = currentFilter == RecordingFilter.PROXIMITY
+
+    private fun showDatePicker() {
+        DatePickerDialog(
+            requireContext(),
+            { _, year, month, day ->
+                calendar.set(year, month, day)
+                updateDateDisplay()
+                loadRecordingsForSelectedDate()
+            },
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH),
+            calendar.get(Calendar.DAY_OF_MONTH)
+        ).also { picker ->
+            // Prevent selecting future dates
+            picker.datePicker.maxDate = System.currentTimeMillis()
+        }.show()
     }
-    
-    private fun setupCalendar() {
-        recyclerCalendar.apply {
-            layoutManager = GridLayoutManager(context, 7)
-            adapter = calendarAdapter
+
+    private fun updateDateDisplay() {
+        tvSelectedDate.text = dateFormat.format(calendar.time)
+        // Dim the next-day arrow when we're already on today
+        val isToday = isSameDay(calendar, Calendar.getInstance())
+        btnNextDay.alpha = if (isToday) 0.3f else 1f
+    }
+
+    private fun isSameDay(a: Calendar, b: Calendar): Boolean =
+        a.get(Calendar.YEAR) == b.get(Calendar.YEAR) &&
+        a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)
+
+    private fun setupFilterButtons() {
+        btnFilterAll.setOnClickListener     { setFilter(RecordingFilter.ALL) }
+        btnFilterNormal.setOnClickListener  { setFilter(RecordingFilter.NORMAL) }
+        btnFilterSentry.setOnClickListener  { setFilter(RecordingFilter.SENTRY) }
+        btnFilterProx.setOnClickListener    { setFilter(RecordingFilter.PROXIMITY) }
+        updateFilterButtons()
+    }
+
+    private fun setFilter(filter: RecordingFilter) {
+        currentFilter = filter
+        updateFilterButtons()
+        loadRecordingsForSelectedDate()
+    }
+
+    private fun updateFilterButtons() {
+        val buttons = listOf(
+            btnFilterAll     to RecordingFilter.ALL,
+            btnFilterNormal  to RecordingFilter.NORMAL,
+            btnFilterSentry  to RecordingFilter.SENTRY,
+            btnFilterProx    to RecordingFilter.PROXIMITY
+        )
+        buttons.forEach { (btn, filter) ->
+            val active = filter == currentFilter
+            btn.setBackgroundResource(
+                if (active) R.drawable.bg_filter_tab_active
+                else android.R.color.transparent
+            )
+            btn.setTextColor(
+                requireContext().getColor(
+                    if (active) R.color.bg_base else R.color.text_secondary
+                )
+            )
         }
     }
-    
+
     private fun setupRecordingsList() {
         recordingAdapter = RecordingAdapter(
-            onPlay = { recording -> playRecording(recording) },
-            onDelete = { recording -> confirmDelete(recording) }
+            onPlay   = { playRecording(it) },
+            onDelete = { confirmDelete(it) }
         )
-        
         recyclerRecordings.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = recordingAdapter
         }
     }
-    
-    private fun setupClickListeners() {
-        btnPrevMonth.setOnClickListener {
-            calendar.add(Calendar.MONTH, -1)
-            selectedDay = 1
-            updateCalendar()
-            loadRecordingsForSelectedDate()
-        }
-        
-        btnNextMonth.setOnClickListener {
-            calendar.add(Calendar.MONTH, 1)
-            selectedDay = 1
-            updateCalendar()
-            loadRecordingsForSelectedDate()
+
+    private fun ensureDirectories() {
+        try {
+            val dirs = listOf(
+                RecordingScanner.getRecordingsDir(requireContext()),
+                RecordingScanner.getSentryEventsDir(requireContext()),
+                RecordingScanner.getProximityEventsDir(requireContext())
+            )
+            dirs.first().parentFile?.mkdirs()
+            dirs.forEach { it.mkdirs() }
+            Log.d(TAG, "Directories ready: ${dirs.map { it.absolutePath }}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Directory setup failed: ${e.message}")
         }
     }
-    
-    private fun updateCalendar() {
-        tvCurrentMonth.text = monthFormat.format(calendar.time)
-        
-        val year = calendar.get(Calendar.YEAR)
-        val month = calendar.get(Calendar.MONTH)
-        
-        Log.d(TAG, "Updating calendar for $year-${month+1}")
-        
-        // Build calendar days first (fast operation)
-        val days = buildCalendarDays(year, month)
-        
-        // SOTA: Load recording counts in background to prevent UI lag
-        if (!scanExecutor.isShutdown) {
-            scanExecutor.submit {
-                try {
-                    val recordingCounts = RecordingScanner.getRecordingCountsByDate(requireContext(), year, month)
-                    Log.d(TAG, "Recording counts for month: $recordingCounts")
-                    
-                    activity?.runOnUiThread {
-                        if (isAdded) {
-                            calendarAdapter.setDays(days, recordingCounts)
-                            calendarAdapter.setSelectedDay(selectedDay)
-                        }
-                    }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error getting recording counts", e)
-                }
-            }
-        }
-        
-        // Set days immediately with empty counts for instant feedback
-        calendarAdapter.setDays(days, emptyMap())
-        calendarAdapter.setSelectedDay(selectedDay)
-    }
-    
-    private fun buildCalendarDays(year: Int, month: Int): List<CalendarAdapter.CalendarDay> {
-        val days = mutableListOf<CalendarAdapter.CalendarDay>()
-        
-        val tempCal = Calendar.getInstance().apply {
-            set(year, month, 1)
-        }
-        
-        val today = Calendar.getInstance()
-        val isCurrentMonth = today.get(Calendar.YEAR) == year && today.get(Calendar.MONTH) == month
-        val isFutureMonth = (year > today.get(Calendar.YEAR)) || 
-            (year == today.get(Calendar.YEAR) && month > today.get(Calendar.MONTH))
-        val todayDay = if (isCurrentMonth) today.get(Calendar.DAY_OF_MONTH) else -1
-        
-        // Add empty cells for days before the first of the month
-        val firstDayOfWeek = tempCal.get(Calendar.DAY_OF_WEEK) - 1
-        repeat(firstDayOfWeek) {
-            days.add(CalendarAdapter.CalendarDay(0, false))
-        }
-        
-        // Add days of the month
-        val daysInMonth = tempCal.getActualMaximum(Calendar.DAY_OF_MONTH)
-        for (day in 1..daysInMonth) {
-            val isFuture = isFutureMonth || (isCurrentMonth && day > todayDay)
-            days.add(CalendarAdapter.CalendarDay(
-                dayOfMonth = day,
-                isCurrentMonth = true,
-                isToday = day == todayDay,
-                isFuture = isFuture
-            ))
-        }
-        
-        return days
-    }
-    
-    private fun onDaySelected(day: Int) {
-        selectedDay = day
-        calendarAdapter.setSelectedDay(day)
-        loadRecordingsForSelectedDate()
-    }
-    
+
     private fun loadRecordingsForSelectedDate() {
-        val year = calendar.get(Calendar.YEAR)
+        val year  = calendar.get(Calendar.YEAR)
         val month = calendar.get(Calendar.MONTH)
-        
-        // Update header immediately
-        val selectedCal = Calendar.getInstance().apply {
-            set(year, month, selectedDay)
-        }
-        tvSelectedDate.text = SimpleDateFormat("MMM d", Locale.getDefault()).format(selectedCal.time)
-        
-        Log.d(TAG, "Loading recordings for $year-${month+1}-$selectedDay")
-        
-        // SOTA: Load recordings in background to prevent UI lag during date selection
+        val day   = calendar.get(Calendar.DAY_OF_MONTH)
+
         if (scanExecutor.isShutdown) return
         scanExecutor.submit {
             try {
-                // Debug: Check directories
-                val recordingsDir = RecordingScanner.getRecordingsDir(requireContext())
-                val sentryDir = RecordingScanner.getSentryEventsDir(requireContext())
-                val proximityDir = RecordingScanner.getProximityEventsDir(requireContext())
-                
-                Log.d(TAG, "Recordings dir: ${recordingsDir.absolutePath}, exists: ${recordingsDir.exists()}")
-                Log.d(TAG, "Sentry dir: ${sentryDir.absolutePath}, exists: ${sentryDir.exists()}")
-                Log.d(TAG, "Proximity dir: ${proximityDir.absolutePath}, exists: ${proximityDir.exists()}")
-                
-                if (recordingsDir.exists()) {
-                    val files = recordingsDir.listFiles()
-                    Log.d(TAG, "Recordings dir files: ${files?.size ?: 0}")
-                    files?.take(5)?.forEach { Log.d(TAG, "  - ${it.name}") }
+                val all = RecordingScanner.getRecordingsForDate(requireContext(), year, month, day)
+                val filtered = when (currentFilter) {
+                    RecordingFilter.ALL       -> all
+                    RecordingFilter.NORMAL    -> all.filter { it.type == RecordingFile.RecordingType.NORMAL }
+                    RecordingFilter.SENTRY    -> all.filter { it.type == RecordingFile.RecordingType.SENTRY }
+                    RecordingFilter.PROXIMITY -> all.filter { it.type == RecordingFile.RecordingType.PROXIMITY }
                 }
-                
-                val allRecordings = RecordingScanner.getRecordingsForDate(requireContext(), year, month, selectedDay)
-                Log.d(TAG, "Found ${allRecordings.size} recordings for date")
-                
-                val recordings = when (currentFilter) {
-                    RecordingFilter.ALL -> allRecordings
-                    RecordingFilter.NORMAL -> allRecordings.filter { it.type == RecordingFile.RecordingType.NORMAL }
-                    RecordingFilter.SENTRY -> allRecordings.filter { it.type == RecordingFile.RecordingType.SENTRY }
-                    RecordingFilter.PROXIMITY -> allRecordings.filter { it.type == RecordingFile.RecordingType.PROXIMITY }
-                }
-                
-                Log.d(TAG, "After filter (${currentFilter}): ${recordings.size} recordings")
-                
+                Log.d(TAG, "Loaded ${filtered.size} recordings ($currentFilter) for $year-${month+1}-$day")
+
                 activity?.runOnUiThread {
-                    if (isAdded) {
-                        if (recordings.isEmpty()) {
-                            recyclerRecordings.visibility = View.GONE
-                            emptyStateContainer?.visibility = View.VISIBLE
-                            tvEmptyState.visibility = View.VISIBLE
-                            tvEmptyState.text = when (currentFilter) {
-                                RecordingFilter.ALL -> "No recordings for this date"
-                                RecordingFilter.NORMAL -> "No normal recordings"
-                                RecordingFilter.SENTRY -> "No sentry events"
-                                RecordingFilter.PROXIMITY -> "No proximity events"
-                            }
-                        } else {
-                            recyclerRecordings.visibility = View.VISIBLE
-                            emptyStateContainer?.visibility = View.GONE
-                            tvEmptyState.visibility = View.GONE
-                            recordingAdapter.submitList(recordings)
+                    if (!isAdded) return@runOnUiThread
+                    if (filtered.isEmpty()) {
+                        recyclerRecordings.visibility   = View.GONE
+                        emptyStateContainer?.visibility = View.VISIBLE
+                        tvEmptyState.visibility         = View.VISIBLE
+                        tvEmptyState.text = when (currentFilter) {
+                            RecordingFilter.ALL       -> "No recordings for this date"
+                            RecordingFilter.NORMAL    -> "No normal recordings"
+                            RecordingFilter.SENTRY    -> "No sentry events"
+                            RecordingFilter.PROXIMITY -> "No proximity events"
                         }
+                    } else {
+                        recyclerRecordings.visibility   = View.VISIBLE
+                        emptyStateContainer?.visibility = View.GONE
+                        tvEmptyState.visibility         = View.GONE
+                        recordingAdapter.submitList(filtered)
                     }
                 }
             } catch (e: Exception) {
@@ -398,66 +238,65 @@ class RecordingLibraryFragment : Fragment() {
             }
         }
     }
-    
+
     private fun playRecording(recording: RecordingFile) {
         try {
             val bundle = Bundle().apply {
-                putString(VideoPlayerFragment.ARG_VIDEO_PATH, recording.path)
-                putString(VideoPlayerFragment.ARG_VIDEO_TITLE, recording.name)
+                putString(MultiCameraPlayerFragment.ARG_VIDEO_PATH, recording.path)
+                putString(MultiCameraPlayerFragment.ARG_VIDEO_TITLE, recording.name)
             }
-            androidx.navigation.fragment.NavHostFragment.findNavController(this)
+            androidx.navigation.fragment.NavHostFragment
+                .findNavController(this)
                 .navigate(R.id.action_global_videoPlayer, bundle)
         } catch (e: Exception) {
-            // Fallback: open with external player if navigation fails
             try {
                 val uri = recording.contentUri ?: FileProvider.getUriForFile(
                     requireContext(),
                     "${requireContext().packageName}.fileprovider",
                     recording.file
                 )
-                val intent = Intent(Intent.ACTION_VIEW).apply {
-                    setDataAndType(uri, "video/mp4")
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                }
-                startActivity(Intent.createChooser(intent, "Play with"))
+                startActivity(
+                    Intent.createChooser(
+                        Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, "video/mp4")
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        },
+                        "Play with"
+                    )
+                )
             } catch (e2: Exception) {
                 Toast.makeText(context, "Cannot play video: ${e2.message}", Toast.LENGTH_SHORT).show()
             }
         }
     }
-    
+
     private fun confirmDelete(recording: RecordingFile) {
         MaterialAlertDialogBuilder(requireContext())
             .setTitle("Delete Recording")
             .setMessage("Delete ${recording.name}?\nThis cannot be undone.")
             .setNegativeButton("Cancel", null)
-            .setPositiveButton("Delete") { _, _ ->
-                deleteRecording(recording)
-            }
+            .setPositiveButton("Delete") { _, _ -> deleteRecording(recording) }
             .show()
     }
-    
+
     private fun deleteRecording(recording: RecordingFile) {
         if (RecordingScanner.deleteRecording(recording)) {
             Toast.makeText(context, "Recording deleted", Toast.LENGTH_SHORT).show()
             loadRecordingsForSelectedDate()
-            updateCalendar() // Refresh indicators
         } else {
             Toast.makeText(context, "Failed to delete recording", Toast.LENGTH_SHORT).show()
         }
     }
-    
+
     override fun onResume() {
         super.onResume()
-        // Invalidate cache on resume to pick up new recordings
         RecordingScanner.invalidateCache()
-        updateCalendar()
+        updateDateDisplay()
         loadRecordingsForSelectedDate()
     }
-    
+
     override fun onDestroyView() {
         super.onDestroyView()
-        // Shutdown executor to prevent memory leaks
         scanExecutor.shutdown()
     }
 }

--- a/app/src/main/java/com/overdrive/app/ui/view/MultiCameraGLView.kt
+++ b/app/src/main/java/com/overdrive/app/ui/view/MultiCameraGLView.kt
@@ -1,0 +1,210 @@
+package com.overdrive.app.ui.view
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import android.util.AttributeSet
+import android.view.Surface
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.microedition.khronos.egl.EGLConfig
+import javax.microedition.khronos.opengles.GL10
+
+/**
+ * Mosaic quadrant layout in the 2560×1920 recorded file:
+ *   Top-left=Front, Top-right=Right, Bottom-left=Rear, Bottom-right=Left
+ *
+ * UV coords are in image-space (v=0 at image top, applied before the SurfaceTexture
+ * transform matrix which handles the OpenGL Y-flip).
+ * If cameras appear vertically inverted on device, swap v0/v1 in each enum entry.
+ */
+enum class CameraView(val label: String, val u0: Float, val v0: Float, val u1: Float, val v1: Float) {
+    FRONT("Front", 0f,   0f,   0.5f, 0.5f),
+    RIGHT("Right", 0.5f, 0f,   1f,   0.5f),
+    REAR ("Rear",  0f,   0.5f, 0.5f, 1f  ),
+    LEFT ("Left",  0.5f, 0.5f, 1f,   1f  )
+}
+
+/**
+ * Renders a single mosaic MP4 (decoded via one MediaPlayer) into four screen regions:
+ * - Primary: left 75% of the GL view, shows the selected camera quadrant
+ * - Small column: right 25%, three equal rows showing the remaining cameras
+ *
+ * One hardware decoder, one texture upload per frame, four GL draw calls.
+ * Call setPrimaryCamera() to swap which quadrant is large; the other three
+ * fill the right column in FRONT→RIGHT→REAR→LEFT enum order minus the primary.
+ */
+class MultiCameraGLView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : GLSurfaceView(context, attrs), GLSurfaceView.Renderer {
+
+    private var textureId = 0
+    private var surfaceTexture: SurfaceTexture? = null
+    private var program = 0
+
+    private val texMatrix = FloatArray(16)
+    private var frameAvailable = false
+    private val frameLock = Any()
+
+    private var locPosition = 0
+    private var locTexCoord = 0
+    private var locTexMatrix = 0
+    private var locSampler = 0
+
+    @Volatile private var primaryCamera: CameraView = CameraView.REAR
+
+    /** Called on the main thread once the Surface is ready for MediaPlayer.setDisplay(). */
+    var onSurfaceReady: ((Surface) -> Unit)? = null
+
+    init {
+        setEGLContextClientVersion(2)
+        setRenderer(this)
+        renderMode = RENDERMODE_WHEN_DIRTY
+    }
+
+    fun setPrimaryCamera(cam: CameraView) {
+        primaryCamera = cam
+        requestRender()
+    }
+
+    /** Returns the three non-primary cameras in their natural enum order. */
+    fun smallCameraOrder(): List<CameraView> {
+        val p = primaryCamera
+        return CameraView.values().filter { it != p }
+    }
+
+    // region GLSurfaceView.Renderer
+
+    override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {
+        val ids = IntArray(1)
+        GLES20.glGenTextures(1, ids, 0)
+        textureId = ids[0]
+
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+
+        val st = SurfaceTexture(textureId)
+        st.setOnFrameAvailableListener {
+            synchronized(frameLock) { frameAvailable = true }
+            requestRender()
+        }
+        surfaceTexture = st
+        post { onSurfaceReady?.invoke(Surface(st)) }
+
+        program = buildProgram(VERT_SRC, FRAG_SRC)
+        locPosition = GLES20.glGetAttribLocation(program, "aPosition")
+        locTexCoord = GLES20.glGetAttribLocation(program, "aTexCoord")
+        locTexMatrix = GLES20.glGetUniformLocation(program, "uTexMatrix")
+        locSampler   = GLES20.glGetUniformLocation(program, "uSampler")
+    }
+
+    override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
+        GLES20.glViewport(0, 0, width, height)
+    }
+
+    override fun onDrawFrame(gl: GL10?) {
+        synchronized(frameLock) {
+            if (frameAvailable) {
+                surfaceTexture?.updateTexImage()
+                surfaceTexture?.getTransformMatrix(texMatrix)
+                frameAvailable = false
+            }
+        }
+
+        GLES20.glClearColor(0f, 0f, 0f, 1f)
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+
+        GLES20.glUseProgram(program)
+        GLES20.glUniformMatrix4fv(locTexMatrix, 1, false, texMatrix, 0)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glUniform1i(locSampler, 0)
+
+        val primary = primaryCamera
+        val others  = CameraView.values().filter { it != primary }
+
+        // Primary quad: left 75% of view (NDC x: -1 → 0.49), full height, 1% right gap
+        drawQuad(-1f, -1f, 0.49f, 1f, primary)
+
+        // Small column: right 25% (NDC x: 0.51 → 1), three equal rows with 1% gaps
+        val rowH = 2f / 3f
+        val gap  = 0.01f
+        others.forEachIndexed { i, cam ->
+            val y1 = 1f - i * rowH - (if (i > 0) gap else 0f)
+            val y0 = (y1 - rowH + gap).coerceAtLeast(-1f)
+            drawQuad(0.51f, y0, 1f, y1.coerceAtMost(1f), cam)
+        }
+    }
+
+    // endregion
+
+    private fun drawQuad(x0: Float, y0: Float, x1: Float, y1: Float, cam: CameraView) {
+        // Vertices: (x, y, u, v) — two triangles via TRIANGLE_STRIP
+        // y1 > y0 (y1=top, y0=bottom in NDC); v0 < v1 (v0=image top, v1=image bottom)
+        val verts = floatArrayOf(
+            x0, y1, cam.u0, cam.v0,   // top-left
+            x1, y1, cam.u1, cam.v0,   // top-right
+            x0, y0, cam.u0, cam.v1,   // bottom-left
+            x1, y0, cam.u1, cam.v1    // bottom-right
+        )
+        val buf = ByteBuffer.allocateDirect(verts.size * 4)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer()
+            .also { it.put(verts); it.position(0) }
+
+        val stride = 4 * 4  // 4 floats × 4 bytes
+        GLES20.glEnableVertexAttribArray(locPosition)
+        GLES20.glVertexAttribPointer(locPosition, 2, GLES20.GL_FLOAT, false, stride, buf)
+        buf.position(2)
+        GLES20.glEnableVertexAttribArray(locTexCoord)
+        GLES20.glVertexAttribPointer(locTexCoord, 2, GLES20.GL_FLOAT, false, stride, buf)
+
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+    }
+
+    override fun onDetachedFromWindow() {
+        surfaceTexture?.release()
+        super.onDetachedFromWindow()
+    }
+
+    companion object {
+        private const val VERT_SRC = """
+attribute vec4 aPosition;
+attribute vec2 aTexCoord;
+uniform mat4 uTexMatrix;
+varying vec2 vTexCoord;
+void main() {
+    gl_Position = aPosition;
+    vTexCoord = (uTexMatrix * vec4(aTexCoord, 0.0, 1.0)).xy;
+}"""
+
+        private const val FRAG_SRC = """
+#extension GL_OES_EGL_image_external : require
+precision mediump float;
+uniform samplerExternalOES uSampler;
+varying vec2 vTexCoord;
+void main() {
+    gl_FragColor = texture2D(uSampler, vTexCoord);
+}"""
+
+        private fun buildProgram(vertSrc: String, fragSrc: String): Int {
+            fun compile(type: Int, src: String): Int {
+                val shader = GLES20.glCreateShader(type)
+                GLES20.glShaderSource(shader, src)
+                GLES20.glCompileShader(shader)
+                return shader
+            }
+            val p = GLES20.glCreateProgram()
+            GLES20.glAttachShader(p, compile(GLES20.GL_VERTEX_SHADER, vertSrc))
+            GLES20.glAttachShader(p, compile(GLES20.GL_FRAGMENT_SHADER, fragSrc))
+            GLES20.glLinkProgram(p)
+            return p
+        }
+    }
+}

--- a/app/src/main/res/drawable/bg_filter_tab_active.xml
+++ b/app/src/main/res/drawable/bg_filter_tab_active.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/brand_primary" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_pill.xml
+++ b/app/src/main/res/drawable/bg_pill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/bg_elevated" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_multi_camera_player.xml
+++ b/app/src/main/res/layout/fragment_multi_camera_player.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#000000">
+
+    <!-- GL view fills the entire screen; controls overlay on top -->
+    <com.overdrive.app.ui.view.MultiCameraGLView
+        android:id="@+id/glView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!--
+        Transparent tap-target overlay that mirrors the GL quad layout:
+        - Left 75%: primary area (label only, no tap action)
+        - Right 25%: three equal rows, each tappable to swap primary camera
+        The black GL clear colour provides natural dividers through the gaps.
+    -->
+    <LinearLayout
+        android:id="@+id/cameraOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <!-- Primary region: label in top-left corner, rest passes touch through -->
+        <FrameLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3">
+
+            <TextView
+                android:id="@+id/tvPrimaryLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_margin="8dp"
+                android:paddingHorizontal="6dp"
+                android:paddingVertical="2dp"
+                android:background="#66000000"
+                android:textColor="#FFFFFF"
+                android:textSize="11sp"
+                android:fontFamily="sans-serif-medium"
+                android:text="REAR" />
+        </FrameLayout>
+
+        <!-- Small column: three tappable camera cells -->
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/smallCam0"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground">
+
+                <TextView
+                    android:id="@+id/tvSmallLabel0"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|start"
+                    android:layout_margin="4dp"
+                    android:paddingHorizontal="4dp"
+                    android:paddingVertical="1dp"
+                    android:background="#66000000"
+                    android:textColor="#CCFFFFFF"
+                    android:textSize="9sp"
+                    android:text="FRONT" />
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/smallCam1"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground">
+
+                <TextView
+                    android:id="@+id/tvSmallLabel1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|start"
+                    android:layout_margin="4dp"
+                    android:paddingHorizontal="4dp"
+                    android:paddingVertical="1dp"
+                    android:background="#66000000"
+                    android:textColor="#CCFFFFFF"
+                    android:textSize="9sp"
+                    android:text="RIGHT" />
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/smallCam2"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground">
+
+                <TextView
+                    android:id="@+id/tvSmallLabel2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|start"
+                    android:layout_margin="4dp"
+                    android:paddingHorizontal="4dp"
+                    android:paddingVertical="1dp"
+                    android:background="#66000000"
+                    android:textColor="#CCFFFFFF"
+                    android:textSize="9sp"
+                    android:text="LEFT" />
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- Top bar: back + title + file size -->
+    <LinearLayout
+        android:id="@+id/topBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:padding="12dp"
+        android:background="#80000000"
+        android:layout_gravity="top">
+
+        <ImageButton
+            android:id="@+id/btnBack"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_back"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Back"
+            android:tint="#FFFFFF"
+            android:scaleType="centerInside" />
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp"
+            android:fontFamily="sans-serif-medium"
+            android:maxLines="1"
+            android:ellipsize="middle" />
+
+        <TextView
+            android:id="@+id/tvMeta"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#B0FFFFFF"
+            android:textSize="12sp" />
+    </LinearLayout>
+
+    <!-- Bottom controls: timeline + seekbar + play/pause + time -->
+    <LinearLayout
+        android:id="@+id/bottomControls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_gravity="bottom"
+        android:background="#CC000000"
+        android:padding="8dp">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="32dp"
+            android:layout_marginBottom="4dp">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="20dp"
+                android:layout_gravity="center_vertical"
+                android:background="#33FFFFFF" />
+
+            <com.overdrive.app.ui.view.EventTimelineView
+                android:id="@+id/eventTimeline"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
+
+        <SeekBar
+            android:id="@+id/seekBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:progressTint="#6C63FF"
+            android:thumbTint="#6C63FF"
+            android:progressBackgroundTint="#55FFFFFF" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+
+            <ImageButton
+                android:id="@+id/btnPlayPause"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:src="@android:drawable/ic_media_pause"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="Play/Pause"
+                android:tint="#FFFFFF"
+                android:scaleType="centerInside" />
+
+            <TextView
+                android:id="@+id/tvCurrentTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0:00"
+                android:textColor="#FFFFFF"
+                android:textSize="13sp"
+                android:fontFamily="monospace"
+                android:layout_marginStart="8dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=" / "
+                android:textColor="#80FFFFFF"
+                android:textSize="13sp" />
+
+            <TextView
+                android:id="@+id/tvDuration"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="0:00"
+                android:textColor="#FFFFFF"
+                android:textSize="13sp"
+                android:fontFamily="monospace" />
+
+            <TextView
+                android:id="@+id/tvEventInfo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="#B0FFFFFF"
+                android:textSize="11sp" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_recording_library.xml
+++ b/app/src/main/res/layout/fragment_recording_library.xml
@@ -7,220 +7,128 @@
     android:background="@color/bg_base"
     android:orientation="vertical">
 
-    <!-- Ultra Compact Calendar Header -->
+    <!--
+        Compact navigation bar: day arrows + tappable date pill + filter segment.
+        Replaces the full calendar grid — saves ~200dp of vertical space on the head unit.
+        iOS-inspired segmented control for filters, Android ripple for touch feedback.
+    -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
-        android:paddingHorizontal="12dp"
-        android:paddingVertical="8dp">
-
-        <ImageButton
-            android:id="@+id/btnPrevMonth"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="Previous month"
-            android:src="@drawable/ic_chevron_left"
-            app:tint="@color/text_secondary" />
-
-        <TextView
-            android:id="@+id/tvCurrentMonth"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:textColor="@color/text_primary"
-            android:textSize="14sp"
-            android:fontFamily="sans-serif-medium"
-            tools:text="January 2026" />
-
-        <ImageButton
-            android:id="@+id/btnNextMonth"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="Next month"
-            android:src="@drawable/ic_chevron_right"
-            app:tint="@color/text_secondary" />
-    </LinearLayout>
-
-    <!-- Compact Day Headers -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:paddingHorizontal="4dp">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="S"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="M"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="T"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="W"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="T"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="F"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:text="S"
-            android:textColor="@color/text_muted"
-            android:textSize="10sp" />
-    </LinearLayout>
-
-    <!-- Ultra Compact Calendar Grid -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerCalendar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingHorizontal="4dp"
-        android:overScrollMode="never"
-        android:nestedScrollingEnabled="false" />
-
-    <!-- Professional Filter Bar -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:paddingHorizontal="12dp"
+        android:paddingHorizontal="16dp"
         android:paddingVertical="10dp"
         android:background="@color/bg_surface">
 
+        <!-- Date navigation: ← [Apr 24, 2026] → -->
+        <ImageButton
+            android:id="@+id/btnPrevDay"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Previous day"
+            android:src="@drawable/ic_chevron_left"
+            app:tint="@color/text_secondary" />
+
+        <!-- Tappable date pill — opens DatePickerDialog -->
         <TextView
             android:id="@+id/tvSelectedDate"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="36dp"
+            android:layout_marginHorizontal="4dp"
+            android:gravity="center"
+            android:paddingHorizontal="14dp"
             android:textColor="@color/text_primary"
             android:textSize="13sp"
             android:fontFamily="sans-serif-medium"
-            tools:text="Jan 20" />
+            android:background="@drawable/bg_pill"
+            android:foreground="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            tools:text="Apr 24, 2026" />
 
+        <ImageButton
+            android:id="@+id/btnNextDay"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Next day"
+            android:src="@drawable/ic_chevron_right"
+            app:tint="@color/text_secondary" />
+
+        <!-- Flexible spacer pushes filter segment to the right -->
         <View
-            android:layout_width="1dp"
-            android:layout_height="16dp"
-            android:layout_marginHorizontal="12dp"
-            android:background="@color/divider" />
-
-        <!-- Professional Segmented Filter -->
-        <com.google.android.material.chip.ChipGroup
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            app:singleSelection="true"
-            app:chipSpacingHorizontal="4dp">
+            android:layout_height="1dp"
+            android:layout_weight="1" />
 
-            <com.google.android.material.chip.Chip
+        <!-- iOS-style segmented filter control -->
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="@drawable/bg_pill"
+            android:padding="3dp">
+
+            <TextView
                 android:id="@+id/btnFilterAll"
-                style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
-                android:layout_height="26dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:paddingHorizontal="14dp"
                 android:text="All"
-                android:checked="true"
-                android:textSize="11sp"
-                app:chipBackgroundColor="@color/chip_background"
-                app:chipStrokeWidth="0dp"
-                app:chipCornerRadius="13dp"
-                app:chipMinHeight="26dp"
-                app:chipMinTouchTargetSize="26dp"
-                android:textColor="@color/chip_text"
-                app:checkedIconVisible="false" />
+                android:textColor="@color/bg_base"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif-medium"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="@drawable/bg_filter_tab_active" />
 
-            <com.google.android.material.chip.Chip
+            <TextView
                 android:id="@+id/btnFilterNormal"
-                style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
-                android:layout_height="26dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:paddingHorizontal="14dp"
                 android:text="Rec"
-                android:textSize="11sp"
-                app:chipBackgroundColor="@color/chip_background"
-                app:chipStrokeWidth="0dp"
-                app:chipCornerRadius="13dp"
-                app:chipMinHeight="26dp"
-                app:chipMinTouchTargetSize="26dp"
-                android:textColor="@color/chip_text"
-                app:checkedIconVisible="false" />
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif-medium"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackgroundBorderless" />
 
-            <com.google.android.material.chip.Chip
+            <TextView
                 android:id="@+id/btnFilterSentry"
-                style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
-                android:layout_height="26dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:paddingHorizontal="14dp"
                 android:text="Sentry"
-                android:textSize="11sp"
-                app:chipBackgroundColor="@color/chip_background"
-                app:chipStrokeWidth="0dp"
-                app:chipCornerRadius="13dp"
-                app:chipMinHeight="26dp"
-                app:chipMinTouchTargetSize="26dp"
-                android:textColor="@color/chip_text"
-                app:checkedIconVisible="false" />
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif-medium"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackgroundBorderless" />
 
-            <com.google.android.material.chip.Chip
+            <TextView
                 android:id="@+id/btnFilterProximity"
-                style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
-                android:layout_height="26dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:paddingHorizontal="14dp"
                 android:text="Prox"
-                android:textSize="11sp"
-                app:chipBackgroundColor="@color/chip_background"
-                app:chipStrokeWidth="0dp"
-                app:chipCornerRadius="13dp"
-                app:chipMinHeight="26dp"
-                app:chipMinTouchTargetSize="26dp"
-                android:textColor="@color/chip_text"
-                app:checkedIconVisible="false" />
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif-medium"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?attr/selectableItemBackgroundBorderless" />
 
-        </com.google.android.material.chip.ChipGroup>
+        </LinearLayout>
     </LinearLayout>
 
     <!-- Divider -->
@@ -229,7 +137,7 @@
         android:layout_height="1dp"
         android:background="@color/divider" />
 
-    <!-- Recordings List (takes remaining space) -->
+    <!-- Recordings list — takes all remaining vertical space -->
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -241,9 +149,10 @@
             android:layout_height="match_parent"
             android:clipToPadding="false"
             android:paddingTop="8dp"
-            android:paddingBottom="16dp" />
+            android:paddingBottom="16dp"
+            android:overScrollMode="never" />
 
-        <!-- Empty State -->
+        <!-- Empty state -->
         <LinearLayout
             android:id="@+id/emptyStateContainer"
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -65,10 +65,24 @@
             android:defaultValue="" />
     </fragment>
 
-    <!-- Global action so any fragment can navigate to video player -->
+    <fragment
+        android:id="@+id/multiCameraPlayerFragment"
+        android:name="com.overdrive.app.ui.fragment.MultiCameraPlayerFragment"
+        android:label="Multi-Camera Player"
+        tools:layout="@layout/fragment_multi_camera_player">
+        <argument
+            android:name="video_path"
+            app:argType="string" />
+        <argument
+            android:name="video_title"
+            app:argType="string"
+            android:defaultValue="" />
+    </fragment>
+
+    <!-- Global action routes to the multi-camera player for all mosaic recordings -->
     <action
         android:id="@+id/action_global_videoPlayer"
-        app:destination="@id/videoPlayerFragment" />
+        app:destination="@id/multiCameraPlayerFragment" />
 
     <fragment
         android:id="@+id/telegramSettingsFragment"


### PR DESCRIPTION
Multi-camera playback viewer (MultiCameraPlayerFragment + MultiCameraGLView):
- One MediaPlayer feeds one SurfaceTexture via GL_TEXTURE_EXTERNAL_OES
- Single hardware decoder renders the 2560x1920 mosaic into four UV-cropped quads: large primary (75% width) + three small previews in a right column
- Tap any small preview to swap it to the primary position
- Controls: seekbar, play/pause, auto-hiding overlay, event timeline sidecar
- Navigation action_global_videoPlayer now routes to the new viewer

Events page redesign (RecordingLibraryFragment + fragment_recording_library):
- Removed full-month calendar grid (~200dp tall) in favour of a single 56dp bar
- Left side: prev/next day arrows + tappable date pill that opens DatePickerDialog
- Right side: iOS-style segmented filter control (All / Rec / Sentry / Prox)
- Future dates blocked; next-day arrow dims to 0.3 alpha on today
- Filter state persists across date changes
- Fragment reduced from 463 to 180 lines; CalendarAdapter no longer used here