### PR TITLE
Add more vehicle controls

### DIFF
--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -436,6 +436,14 @@
                                 </svg>
                                 <span>P.Cool</span>
                             </button>
+                            <button class="vc-tile" id="btnSeatMemory1" title="Position 1">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M9 19 5 7m4 12h9" stroke-width="2.5"/><path d="M9.5 6a8 8 0 0 1 9 9"/><path d="M12 4 9.5 6 12 8.5m4 4.5 2.5 2 2.5-2"/></svg>
+                                <span>Pos 1</span>
+                            </button>
+                            <button class="vc-tile" id="btnSeatMemory2" title="Position 2">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M9 19 5 7m4 12h9" stroke-width="2.5"/><path d="M9.5 6a8 8 0 0 1 9 9"/><path d="M12 4 9.5 6 12 8.5m4 4.5 2.5 2 2.5-2"/></svg>
+                                <span>Pos 2</span>
+                            </button>
                         </div>
                         <!-- Windows controls — per-window preset levels (closed / 25 / 50 / 75 / open) -->
                         <div class="vc-panel-row vc-window-grid" id="panelWindows" style="display:none;">
@@ -507,6 +515,20 @@
                                 </div>
                             </div>
                         </div>
+                        <!-- Lights controls -->
+                        <div class="vc-panel-row" id="panelLights" style="display:none;">
+                            <button class="vc-tile" id="btnDRL" title="Daytime running lights">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 7H8a5 5 0 0 0 0 10h2Z"/><circle cx="14" cy="8" r=".6"/><circle cx="14" cy="12" r=".6"/><circle cx="14" cy="16" r=".6"/><circle cx="17.5" cy="8" r=".4"/><circle cx="17.5" cy="12" r=".4"/><circle cx="17.5" cy="16" r=".4"/><circle cx="21" cy="8" r=".2"/><circle cx="21" cy="12" r=".2"/><circle cx="21" cy="16" r=".2"/></svg>
+                                <span>DRL</span>
+                            </button>
+                        </div>
+                        <!-- ADAS controls -->
+                        <div class="vc-panel-row" id="panelAdas" style="display:none;">
+                            <button class="vc-tile" id="btnSLW" title="Speed limit warning">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 17.5a8.5 8.5 0 1 1 15-5.5m-15 5.5 2-1m-4-4.5h2m0-5.5L7 8m4.5-4v2m6 .5L16 8m4.5 4h-2"/><path d="m13 12 3-4" stroke-width="1"/><circle cx="12" cy="14" r="1"/><path d="m12.9 16-2 1.6H9.3V20h1.6l2 1.6zm2 1.6 2.4 2.4m0-2.4L14.9 20" stroke-width="1"/></svg>
+                                <span>SLW</span>
+                            </button>
+                        </div>
                     </div>
 
                     <!-- Category tabs — always visible -->
@@ -542,6 +564,16 @@
                             <span class="tab-dot"></span>
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="9" height="9" rx="1"/><rect x="13" y="2" width="9" height="9" rx="1"/><rect x="2" y="13" width="9" height="9" rx="1"/><rect x="13" y="13" width="9" height="9" rx="1"/></svg>
                             <span>Windows</span>
+                        </button>
+                        <button class="vc-tab" data-panel="panelLights" onclick="VC.togglePanel('panelLights', this)">
+                            <span class="tab-dot"></span>
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 13v1m5-12a1 1 0 0 1 1 1v4a3 3 0 0 1-.6 1.8l-.6.8A4 4 0 0 0 16 12v8a2 2 0 0 1-2 2h-4a2 2 0 0 1-2-2v-8a4 4 0 0 0-.8-2.4l-.6-.8A3 3 0 0 1 6 7V3a1 1 0 0 1 1-1zM6 6h12"/></svg>
+                            <span>Lights</span>
+                        </button>
+                        <button class="vc-tab" data-panel="panelAdas" onclick="VC.togglePanel('panelAdas', this)">
+                            <span class="tab-dot"></span>
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19.07 4.93A10 10 0 0 0 6.99 3.34M4 6h.01M2.29 9.62a10 10 0 1 0 19.02-1.27"/><path d="M16.24 7.76a6 6 0 1 0-8.01 8.91M12 18h.01m5.98-6.34a6 6 0 0 1-2.22 5.01"/><circle cx="12" cy="12" r="2"/><path d="m13.41 10.59 5.66-5.66"/></svg>
+                            <span>ADAS</span>
                         </button>
                     </div>
                 </div>

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -25,7 +25,9 @@ var VC = {
         locked: null,
         trunkOpen: false,
         doors: { lf: 1, rf: 1, lr: 1, rr: 1, trunk: -1, hood: -1 },
-        windows: { lf: 0, rf: 0, lr: 0, rr: 0 },
+        windows: { lf: 0, rf: 0, lr: 0, rr: 0, sunroof: 0, sunshade: 0 },
+        lights: { dayTimeLight: false },
+        adas: { speedLimitWarning: false },
         soc: 0,
         rangeKm: 0,
         cloudConfigured: false,
@@ -693,7 +695,9 @@ var VC = {
             lf: { x: 1.0, y: 0.9, z: 0.5 },
             rf: { x: -1.0, y: 0.9, z: 0.5 },
             lr: { x: 1.0, y: 0.9, z: -0.5 },
-            rr: { x: -1.0, y: 0.9, z: -0.5 }
+            rr: { x: -1.0, y: 0.9, z: -0.5 },
+            sunroof: { x: 0, y: 1.4, z: -0.5 },
+            sunshade: { x: 0, y: 1.4, z: -0.5 }
         };
         var pos = positions[area];
         if (!pos) return;
@@ -1312,14 +1316,43 @@ var VC = {
         // All windows — only fully-open / fully-closed makes sense for "all"
         // (per-window % requires per-window polling, no SDK batch primitive).
         this.bindBtn('btnWinAllOpen', function() {
-            for (var j = 0; j < areas.length; j++) self.triggerWindowVFX(areas[j], true);
+            for (var j = 0; j < 4; j++) self.triggerWindowVFX(areas[j], true);
             self.apiPost('/api/vehicle/window', { area: 0, command: 1 });
             self.toast('All windows opening', 'info');
         });
         this.bindBtn('btnWinAllClose', function() {
-            for (var j = 0; j < areas.length; j++) self.triggerWindowVFX(areas[j], false);
+            for (var j = 0; j < 4; j++) self.triggerWindowVFX(areas[j], false);
             self.apiPost('/api/vehicle/window', { area: 0, command: 2 });
             self.toast('All windows closing', 'info');
+        });
+
+        // === Lights controls ===
+        this.bindBtn('btnDRL', function() {
+            const enable = self.vehicleState.lights?.dayTimeLight ? false : true;
+            self.triggerSonarVFX(0, 0.6, 2, new THREE.Color(enable ? 0xFF6B35 : 0x1A1A1E));
+            self.apiPost('/api/vehicle/lights', { target: 'dayTimeLight', enable }).then(function(result) {
+                if (result.success && result.commandSuccess) {
+                    self.vehicleState.lights.dayTimeLight = result.enable;
+                    self.updateLightsUI();
+                    self.toast('Daytime running lights ' + (result.enable ? 'enabled' : 'disabled'), 'info');
+                } else {
+                    self.toast(result.error || 'Daytime running lights setting failed', 'error');
+                }
+            });
+        });
+
+        // === ADAS controls ===
+        this.bindBtn('btnSLW', function() {
+            const enable = self.vehicleState.adas?.speedLimitWarning ? false : true
+            self.apiPost('/api/vehicle/adas', { target: 'speedLimitWarning', enable }).then(function(result) {
+                if (result.success && result.commandSuccess) {
+                    self.vehicleState.adas.speedLimitWarning = result.enable;
+                    self.updateAdasUI();
+                    self.toast('Speed limit warning ' + (result.enable ? 'enabled' : 'disabled'), 'info');
+                } else {
+                    self.toast(result.error || 'Speed limit warning setting failed', 'error');
+                }
+            });;
         });
 
         // === CLIMATE CONTROLS ===
@@ -1424,6 +1457,17 @@ var VC = {
                         self.toast('Seat cool: Off', 'info');
                     }
                     self.apiPost('/api/vehicle/seat', { action: 'ventilation', position: pos, level: next });
+                });
+            })(si);
+        }
+        for (var si = 1; si <= 2; si++) {
+            (function(pos) {
+                self.bindBtn('btnSeatMemory' + pos, function() {
+                    // Cool VFX — blue sonar at seat - Only for driver seat
+                    var sp = seatPositions[1];
+                    self.triggerSonarVFX(sp.x, sp.y, sp.z, new THREE.Color(0x00BFFF));
+                    self.toast('Seat memory position: ' + pos, 'success');
+                    self.apiPost('/api/vehicle/seat', { action: 'position', position: pos });
                 });
             })(si);
         }
@@ -1535,6 +1579,10 @@ var VC = {
             // 'muted' / NO DATA).
             if (data.tyres) self.updateTyreCallouts(data.tyres);
 
+            if (data.lights) self.vehicleState.lights = data.lights;
+
+            if (data.adas) self.vehicleState.adas = data.adas;
+
             // Update UI
             self.updateHUD();
             self.updateWindowBars();
@@ -1544,6 +1592,8 @@ var VC = {
             self.updateClimateUI();
             self.updateSeatGlows();
             self.updateTabIndicators();
+            self.updateLightsUI();
+            self.updateAdasUI();
 
         }).catch(function(e) {
             console.warn('[VC] State fetch error:', e);
@@ -1996,6 +2046,18 @@ var VC = {
                 this._stopSeatSonar(key);
             }
         }
+    },
+
+    updateLightsUI: function() {
+        var btnDRL = document.getElementById('btnDRL');
+
+        if (btnDRL) { if (this.vehicleState.lights?.dayTimeLight) btnDRL.classList.add('on'); else btnDRL.classList.remove('on'); }
+    },
+
+    updateAdasUI: function() {
+        var btnSLW = document.getElementById('btnSLW');
+
+        if (btnSLW) { if (this.vehicleState.adas?.speedLimitWarning) btnSLW.classList.add('on'); else btnSLW.classList.remove('on'); }
     },
 
     /** Stop sonar for a specific seat and clean up meshes */

--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -45,6 +45,7 @@ public class BydDataCollector {
     private Object safetyBeltDevice;
     private Object acDevice;
     private Object lightDevice;
+    private Object adasDevice;
     private Object radarDevice;
     private Object powerDevice;
     private Object settingDevice;
@@ -190,6 +191,7 @@ public class BydDataCollector {
         gearboxDevice = initDevice("android.hardware.bydauto.gearbox.BYDAutoGearboxDevice", "Gearbox");
         acDevice = initDevice("android.hardware.bydauto.ac.BYDAutoAcDevice", "AC");
         lightDevice = initDevice("android.hardware.bydauto.light.BYDAutoLightDevice", "Light");
+        adasDevice = initDevice("android.hardware.bydauto.adas.BYDAutoADASDevice", "ADAS");
         powerDevice = initDevice("android.hardware.bydauto.power.BYDAutoPowerDevice", "Power");
         safetyBeltDevice = initDevice("android.hardware.bydauto.safetybelt.BYDAutoSafetyBeltDevice", "SafetyBelt");
         tyreDevice = initDevice("android.hardware.bydauto.tyre.BYDAutoTyreDevice", "Tyre");
@@ -607,6 +609,7 @@ public class BydDataCollector {
         // Display-only devices (normally listener-driven, polled here on-demand)
         collectAc(b);
         collectLight(b);
+        collectAdas(b);
         collectPower(b);
         collectSafetyBelt(b);
         collectTyre(b);
@@ -1492,7 +1495,7 @@ public class BydDataCollector {
             b.frontFog(getLightStatus(7) == 1);
             b.hazard(getLightStatus(8) == 1);
             Object dayTime = BydDeviceHelper.callGetter(lightDevice, "getDayTimeLightState");
-            if (dayTime instanceof Number) b.dayTimeLight(((Number) dayTime).intValue());
+            if (dayTime instanceof Number) b.dayTimeLight(((Number) dayTime).intValue() == 1);
         } catch (Exception e) {
             logger.debug("collectLight error: " + e.getMessage());
         }
@@ -1501,6 +1504,18 @@ public class BydDataCollector {
     private int getLightStatus(int position) {
         Object val = BydDeviceHelper.callGetter(lightDevice, "getLightStatus", position);
         return (val instanceof Number) ? ((Number) val).intValue() : 0;
+    }
+
+    private void collectAdas(BydVehicleData.Builder b) {
+        if (adasDevice == null) return;
+        try {
+            int speedLimitWarning = BydDeviceHelper.callGetSingle(adasDevice, BydFeatureIds.ADAS_SLW_FUNC_SWITCH_STATE);
+            if (speedLimitWarning >= 0) {
+                b.speedLimitWarning(speedLimitWarning == 2);
+            }
+        } catch (Exception e) {
+            logger.debug("collectAdas error: " + e.getMessage());
+        }
     }
 
     private void collectPower(BydVehicleData.Builder b) {
@@ -2786,8 +2801,12 @@ public class BydDataCollector {
             logger.info("  Statistic listener registered");
             count++;
         }
-        if (BydDeviceHelper.registerListener(lightDevice, this::onGenericCallback)) {
+        if (BydDeviceHelper.registerListener(lightDevice, this::onLightsCallback)) {
             logger.info("  Light listener registered");
+            count++;
+        }
+        if (BydDeviceHelper.registerListener(adasDevice, this::onAdasCallback)) {
+            logger.info("  Adas listener registered");
             count++;
         }
         if (BydDeviceHelper.registerListener(radarDevice, this::onGenericCallback)) {
@@ -3143,6 +3162,41 @@ public class BydDataCollector {
         }
         // Listener-driven: the specific event value was already captured above.
         // Skip full device re-collection — the 5s polling timer handles periodic refresh.
+    }
+
+    private void onLightsCallback(String method, Object[] args) {
+        if ("onDataEventChanged".equals(method) && args != null && args.length >= 2) {
+            try {
+                int eventId = ((Number) args[0]).intValue();
+                Object eventValue = args[1];
+                int iVal = BydDeviceHelper.getIntValue(eventValue);
+
+                if (eventId == BydFeatureIds.LIGHT_DAY_RUNNING_LIGHT_AUTO_STATE && iVal > 0 && iVal < 3) {
+                    BydVehicleData current = snapshot.get();
+                    if (current != null) {
+                        snapshot.set(current.toBuilder().dayTimeLight(iVal == 1).build());
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void onAdasCallback(String method, Object[] args) {
+        if ("onDataEventChanged".equals(method) && args != null && args.length >= 2) {
+            try {
+                int eventId = ((Number) args[0]).intValue();
+                Object eventValue = args[1];
+                int iVal = BydDeviceHelper.getIntValue(eventValue);
+
+                if (eventId == BydFeatureIds.ADAS_SLW_FUNC_SWITCH_STATE && iVal > 0 && iVal < 3) {
+
+                    BydVehicleData current = snapshot.get();
+                    if (current != null) {
+                        snapshot.set(current.toBuilder().speedLimitWarning(iVal == 2).build());
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
     }
 
     // ==================== EXTENDED LISTENER HANDLERS ====================
@@ -4052,6 +4106,17 @@ public class BydDataCollector {
         }
     }
 
+    public boolean setSeatMemoryPosition(int position) {
+        try {
+            if (position < 1 || position > 2) return false;
+            int result = BydDeviceHelper.callSetSingle(adasDevice, BydFeatureIds.SETTING_LF_MEMORY_LOCATION_WAKE_SET, position);
+            return result == 0;
+        } catch (Exception e) {
+            logger.debug("setSeatMemoryPosition failed: " + e.getMessage());
+        }
+        return false;
+    }
+
     /** Cached BYDAutoSettingDevice.hasFeature("SEAT_VENTILATING") result; probed once. */
     private volatile boolean seatVentFeatureProbed = false;
     private volatile boolean seatVentFeatureSupported = false;
@@ -4075,7 +4140,29 @@ public class BydDataCollector {
         }
     }
 
+    // --- Lights ---
+
+    public boolean setDayTimeLight(boolean enable) {
+        try {
+            Object result = BydDeviceHelper.callMethod(lightDevice, "setDayTimeLightState", enable ? 1 : 2);
+            return result instanceof Integer && ((Integer) result).intValue() == 0;
+        } catch (Exception e) {
+            logger.debug("setDayTimeLight failed: " + e.getMessage());
+        }
+        return false;
+    }
+
     // --- ADAS ---
+
+    public boolean setSpeedLimitWarning(boolean enable) {
+        try {
+            int result = BydDeviceHelper.callSetSingle(adasDevice, BydFeatureIds.ADAS_SLW_FUNC_SWITCH_STATE_SET, enable ? 2 : 1);
+            return result == 0;
+        } catch (Exception e) {
+            logger.debug("setSpeedLimitWarning failed: " + e.getMessage());
+        }
+        return false;
+    }
 
     public boolean setFcwLevel(int level) {
         try {

--- a/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
@@ -226,6 +226,24 @@ public final class BydDeviceHelper {
         return null;
     }
 
+    private static Class<?> getListenerInterface(Class<?> cls, String listenerInterfaceName) {
+        if (cls != null) {
+            Method[] methods = cls.getDeclaredMethods();
+            for (Method method : methods) {
+                if (method.getName().equals("registerListener")) {
+                    Class<?>[] parameterTypes = method.getParameterTypes();
+                    if (parameterTypes.length == 1) {
+                        Class<?>[] interfaces = parameterTypes[0].getInterfaces();
+                        if (interfaces.length == 1 && interfaces[0].getName().equals(listenerInterfaceName)) {
+                            return interfaces[0];
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Register a listener on a device using IBYDAutoListener interface.
      * Creates a dynamic proxy that forwards all calls to the callback.
@@ -233,7 +251,11 @@ public final class BydDeviceHelper {
     public static boolean registerListener(Object device, ListenerCallback callback) {
         if (device == null) return false;
         try {
-            Class<?> iListener = Class.forName("android.hardware.IBYDAutoListener");
+            String listenerInterfaceName = "android.hardware.IBYDAutoListener";
+            Class<?> iListener = getListenerInterface(device.getClass(), listenerInterfaceName);
+            if (iListener == null) {
+                iListener = Class.forName(listenerInterfaceName);
+            }
             Object proxy = java.lang.reflect.Proxy.newProxyInstance(
                 iListener.getClassLoader(),
                 new Class<?>[]{iListener},
@@ -269,7 +291,11 @@ public final class BydDeviceHelper {
     public static boolean registerListener(Object device, int[] featureIds, ListenerCallback callback) {
         if (device == null) return false;
         try {
-            Class<?> iListener = Class.forName("android.hardware.IBYDAutoListener");
+            String listenerInterfaceName = "android.hardware.IBYDAutoListener";
+            Class<?> iListener = getListenerInterface(device.getClass(), listenerInterfaceName);
+            if (iListener == null) {
+                iListener = Class.forName(listenerInterfaceName);
+            }
             Object proxy = java.lang.reflect.Proxy.newProxyInstance(
                 iListener.getClassLoader(),
                 new Class<?>[]{iListener},
@@ -626,6 +652,29 @@ public final class BydDeviceHelper {
     // ==================== EXTENDED GETTER METHODS ====================
 
     /**
+     * Call get(int deviceType, int featureId) on a BYD device.
+     * Returns the SDK result code, or -1 on any failure.
+     */
+    public static int callGetSingle(Object device, int featureId) {
+        if (device == null) return -1;
+        try {
+            int deviceType = resolveDeviceType(device);
+            if (deviceType == Integer.MIN_VALUE) return -1;
+            Method m = findMethodCached(device, "get", getSingleMethodCache,
+                    int.class, int.class);
+            if (m != null) {
+                Object result = m.invoke(device, deviceType, featureId);
+                if (result instanceof Number) return ((Number) result).intValue();
+            }
+        } catch (SecurityException e) {
+            logger.debug("callGetSingle permission denied for id=" + featureId + " — " + e.getMessage());
+        } catch (Exception e) {
+            logger.debug("callGetSingle failed for id=" + featureId + " — " + e.getMessage());
+        }
+        return -1;
+    }
+
+    /**
      * Call getDouble(int deviceType, int featureId) on a BYD device.
      * Returns Double.NaN on any failure.
      */
@@ -813,6 +862,7 @@ public final class BydDeviceHelper {
     // ==================== INTERNAL HELPERS ====================
 
     private static final java.util.Map<Class<?>, Method> getMethodCache = new java.util.HashMap<>();
+    private static final java.util.Map<Class<?>, Method> getSingleMethodCache = new java.util.HashMap<>();
     private static final java.util.Map<Class<?>, Method> getDoubleMethodCache = new java.util.HashMap<>();
     private static final java.util.Map<Class<?>, Method> getIntArrayMethodCache = new java.util.HashMap<>();
     private static final java.util.Map<Class<?>, Method> getDoubleArrayMethodCache = new java.util.HashMap<>();

--- a/app/src/main/java/com/overdrive/app/byd/BydFeatureIds.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydFeatureIds.java
@@ -119,6 +119,7 @@ public final class BydFeatureIds {
     public static final int LIGHT_ATMOSPHERE_CUSTOM_BRIGHTNESS_SET = resolveOrFallback("Light.ATMOSPHERE_CUSTOM_BRIGHTNESS_SET", 1276194858);
     public static final int LIGHT_ATMOSPHERE_CUSTOM_COLOR = resolveOrFallback("Light.ATMOSPHERE_CUSTOM_COLOR", 657457168);
     public static final int LIGHT_ATMOSPHERE_CUSTOM_COLOR_SET = resolveOrFallback("Light.ATMOSPHERE_CUSTOM_COLOR_SET", 1276194864);
+    public static final int LIGHT_DAY_RUNNING_LIGHT_AUTO_STATE = resolveOrFallback("Light.LIGHT_DAY_RUNNING_LIGHT_AUTO_STATE", 985661476);
 
     // ==================== INSTRUMENT ====================
     public static final int INSTRUMENT_DD_MAIN_SAFETYBELT_STATE = resolveOrFallback("Instrument.INSTRUMENT_DD_MAIN_SAFETYBELT_STATE", 692060184);
@@ -232,6 +233,8 @@ public final class BydFeatureIds {
     public static final int ADAS_RCW_STATE_SET = resolveOrFallback("Adas.ADAS_RCW_STATE_SET", 944766992);
     public static final int ADAS_ESP_STATE = resolveOrFallback("Adas.ADAS_ESP_STATE", 305135676);
     public static final int ADAS_ESP_STATE_SET = resolveOrFallback("Adas.ADAS_ESP_STATE_SET", 944766984);
+    public static final int ADAS_SLW_FUNC_SWITCH_STATE = resolveOrFallback("Adas.ADAS_SLW_FUNC_SWITCH_STATE", 535834664);
+    public static final int ADAS_SLW_FUNC_SWITCH_STATE_SET = resolveOrFallback("Adas.ADAS_SLW_FUNC_SWITCH_STATE_SET", 850452531);
 
     // ==================== SENSOR ====================
     public static final int SENSOR_AUTO_SLOPE = resolveOrFallback("Sensor.SENSOR_AUTO_SLOPE", 573571116);

--- a/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
@@ -101,7 +101,10 @@ public class BydVehicleData {
     public final boolean rearFog;
     public final boolean frontFog;
     public final boolean hazard;
-    public final int dayTimeLight;
+    public final boolean dayTimeLight;
+
+    // ==================== ADAS ====================
+    public final boolean speedLimitWarning;
 
     // ==================== SEATBELTS ====================
     public final int[] seatbeltStatus;    // [1-5]
@@ -251,6 +254,7 @@ public class BydVehicleData {
         this.frontFog = b.frontFog;
         this.hazard = b.hazard;
         this.dayTimeLight = b.dayTimeLight;
+        this.speedLimitWarning = b.speedLimitWarning;
         this.seatbeltStatus = b.seatbeltStatus;
         this.acStartState = b.acStartState;
         this.acCycleMode = b.acCycleMode;
@@ -633,6 +637,7 @@ public class BydVehicleData {
         b.rightTurnState = rightTurnState; b.lowBeam = lowBeam; b.highBeam = highBeam;
         b.rearFog = rearFog; b.frontFog = frontFog; b.hazard = hazard;
         b.dayTimeLight = dayTimeLight; b.seatbeltStatus = seatbeltStatus;
+        b.speedLimitWarning = speedLimitWarning;
         b.acStartState = acStartState; b.acCycleMode = acCycleMode; b.acWindMode = acWindMode; b.acFanLevel = acFanLevel;
         b.tempUnit = tempUnit; b.slopeDegrees = slopeDegrees; b.powerLevel = powerLevel;
         b.mcuStatus = mcuStatus; b.emergencyAlarmState = emergencyAlarmState;
@@ -691,7 +696,8 @@ public class BydVehicleData {
         int[] tyrePressureState, tyreAirLeakState, tyreSignalState, tyreTemperature;
         int tyreSystemState = UNAVAILABLE, tyreTemperatureState = UNAVAILABLE;
         int leftTurnState = UNAVAILABLE, rightTurnState = UNAVAILABLE;
-        boolean lowBeam, highBeam, rearFog, frontFog, hazard; int dayTimeLight = UNAVAILABLE;
+        boolean lowBeam, highBeam, rearFog, frontFog, hazard, dayTimeLight;
+        boolean speedLimitWarning;
         int acStartState = UNAVAILABLE, acCycleMode = UNAVAILABLE, acWindMode = UNAVAILABLE, acFanLevel = UNAVAILABLE, tempUnit = UNAVAILABLE;
         double slopeDegrees = NaN;
         int powerLevel = UNAVAILABLE, mcuStatus = UNAVAILABLE, emergencyAlarmState = UNAVAILABLE;
@@ -796,7 +802,8 @@ public class BydVehicleData {
         public Builder rearFog(boolean v) { rearFog = v; return this; }
         public Builder frontFog(boolean v) { frontFog = v; return this; }
         public Builder hazard(boolean v) { hazard = v; return this; }
-        public Builder dayTimeLight(int v) { dayTimeLight = v; return this; }
+        public Builder dayTimeLight(boolean v) { dayTimeLight = v; return this; }
+        public Builder speedLimitWarning(boolean v) { speedLimitWarning = v; return this; }
         public Builder seatbeltStatus(int[] v) { seatbeltStatus = v; return this; }
         public Builder acStartState(int v) { acStartState = v; return this; }
         public Builder acCycleMode(int v) { acCycleMode = v; return this; }

--- a/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
@@ -91,6 +91,18 @@ public class VehicleControlApiHandler {
             return true;
         }
 
+        // POST /api/vehicle/lights
+        if (cleanPath.equals("/api/vehicle/lights") && method.equals("POST")) {
+            handleLights(out, body);
+            return true;
+        }
+
+        // POST /api/vehicle/adas
+        if (cleanPath.equals("/api/vehicle/adas") && method.equals("POST")) {
+            handleAdas(out, body);
+            return true;
+        }
+
         return false;
     }
 
@@ -206,7 +218,13 @@ public class VehicleControlApiHandler {
         lights.put("lowBeam", data.lowBeam);
         lights.put("highBeam", data.highBeam);
         lights.put("hazard", data.hazard);
+        lights.put("dayTimeLight", data.dayTimeLight);
         response.put("lights", lights);
+
+        // Adas
+        JSONObject adas = new JSONObject();
+        adas.put("speedLimitWarning", data.speedLimitWarning);
+        response.put("adas", adas);
 
         // Climate — only report AC state if vehicle power is on (powerLevel >= 2)
         // Otherwise stale cached data shows AC on when car is actually off
@@ -567,7 +585,7 @@ public class VehicleControlApiHandler {
 
     /**
      * Seat heating/ventilation via local HAL.
-     * Body: { "action": "heating"|"ventilation", "position": 1-4, "level": 0-3 }
+     * Body: { "action": "heating"|"ventilation"|"position", "position": 1-4, "level": 0-3 }
      * Position: 1=driver, 2=passenger, 3=rear-left, 4=rear-right
      * Level: 0=off, 1=low, 2=medium, 3=high (clamped to 0-2 internally)
      */
@@ -583,6 +601,8 @@ public class VehicleControlApiHandler {
 
             if ("ventilation".equals(action)) {
                 success = collector.setSeatVentilation(position, level);
+            } else if ("position".equals(action)) {
+                success = collector.setSeatMemoryPosition(position);
             } else {
                 success = collector.setSeatHeating(position, level);
             }
@@ -596,6 +616,70 @@ public class VehicleControlApiHandler {
             response.put("level", level);
         } catch (Exception e) {
             logger.warn("Seat command failed: " + e.getMessage());
+            response.put("success", false);
+            response.put("error", e.getMessage());
+        }
+        HttpResponse.sendJson(out, response.toString());
+    }
+
+    /**
+     * Light controls
+     * Target: "dayTimeLight"
+     * Enable: true/false
+     */
+    private static void handleLights(OutputStream out, String body) throws Exception {
+        JSONObject response = new JSONObject();
+        try {
+            JSONObject req = new JSONObject(body);
+            String target = req.optString("target", null);
+            boolean enable = req.optBoolean("enable", true);
+            BydDataCollector collector = BydDataCollector.getInstance();
+            boolean success = false;
+
+            if ("dayTimeLight".equals(target)) {
+                success = collector.setDayTimeLight(enable);
+            }
+            logger.info("Lights: target=" + target + " enable=" + enable
+                    + " result=" + success);
+
+            response.put("success", true);
+            response.put("commandSuccess", success);
+            response.put("target", target);
+            response.put("enable", enable);
+        } catch (Exception e) {
+            logger.warn("Light command failed: " + e.getMessage());
+            response.put("success", false);
+            response.put("error", e.getMessage());
+        }
+        HttpResponse.sendJson(out, response.toString());
+    }
+
+    /**
+     * ADAS controls
+     * Target: "speedLimitWarning"
+     * Enable: true/false
+     */
+    private static void handleAdas(OutputStream out, String body) throws Exception {
+        JSONObject response = new JSONObject();
+        try {
+            JSONObject req = new JSONObject(body);
+            String target = req.optString("target", null);
+            boolean enable = req.optBoolean("enable", true);
+            BydDataCollector collector = BydDataCollector.getInstance();
+            boolean success = false;
+
+            if ("speedLimitWarning".equals(target)) {
+                success = collector.setSpeedLimitWarning(enable);
+            }
+            logger.info("Adas: target=" + target + " enable=" + enable
+                    + " result=" + success);
+
+            response.put("success", true);
+            response.put("commandSuccess", success);
+            response.put("target", target);
+            response.put("enable", enable);
+        } catch (Exception e) {
+            logger.warn("Adas command failed: " + e.getMessage());
             response.put("success", false);
             response.put("error", e.getMessage());
         }


### PR DESCRIPTION
## What does this PR do?
Added seat memory position, daytime running lights and speed limit warning controls.

The space on the screen is getting tight for the category tabs. The SLW and DRL buttons could go in to a joint settings tab if more space is needed.

## Why is this change needed?
More controls is nice.

## How to test
Install the apk, restart the camera daemon and use the vehicle control tab.

## Screenshots (if applicable) 
<img width="1080" height="2048" alt="Controls" src="https://github.com/user-attachments/assets/d135a79c-a88a-451c-b0dd-4faa0ca4a8b2" />
<img width="1080" height="2047" alt="Seats" src="https://github.com/user-attachments/assets/e3c1f590-65e2-46d3-bbe4-05804affcf21" />
<img width="1080" height="2052" alt="Lights" src="https://github.com/user-attachments/assets/fa8233d0-7e6f-4055-bcc2-74d5ebd27391" />
<img width="1080" height="2048" alt="ADAS" src="https://github.com/user-attachments/assets/82d6e837-4ac8-41a6-9d84-7089d7733f83" />
