### PR TITLE
Fix broken listeners

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -347,6 +347,13 @@ public class CameraDaemon {
         ipcServer = new SurveillanceIpcServer(19877);
         accMonitor = new AccMonitor();
 
+        // Init app context. This will break the app if run in a thread
+        if (sharedAppContext == null) {
+            try {
+                sharedAppContext = createAppContext();
+            } catch (Throwable ignored) {}
+        }
+
         // Notifications subsystem — registry, push subscriptions, sinks.
         // Lives in this process because HttpServer (where the API routes bind)
         // runs here, and every v1 emit source (surveillance, proximity, tyre)
@@ -2894,15 +2901,10 @@ public class CameraDaemon {
 
         com.overdrive.app.notifications.CategoryRegistry registry = null;
 
-        // The registry JSON ships in the APK assets. Prefer the cached
-        // sharedAppContext if already populated; fall back to creating one
-        // (createAppContext() may block up to 10s on cold daemon start).
+        // The registry JSON ships in the APK assets. Use the cached
+        // sharedAppContext if already populated; Do not create one
+        // as it breaks in a thread
         android.content.Context appContext = getAppContext();
-        if (appContext == null) {
-            try {
-                appContext = createAppContext();
-            } catch (Throwable ignored) {}
-        }
         if (appContext != null) {
             try {
                 registry = com.overdrive.app.notifications.CategoryRegistry.loadFromAssets(appContext);


### PR DESCRIPTION
## What does this PR do?
Fixes the broken listeners when push notifications are initialised.
This may have broken more than just the listeners.

## Why is this change needed?
Allows BYD listeners to start working again.

## How to test
Try clicking the SLW or DRL button in the vehicle controls before this PR if you have Zrok enabled. The action will happen but the button will reset on next state refresh. After this PR, the behaviour is fixed. This only happens when Zrok is enabled as notifications are only initialised when they are.