### PR TITLE
Add seat heat/cool listeners

### DIFF
--- a/app/src/main/assets/web/shared/styles.css
+++ b/app/src/main/assets/web/shared/styles.css
@@ -206,6 +206,11 @@ input, select { font-family: inherit; }
     top: 0;
     background: var(--bg-surface);
     z-index: 1;
+    /* Pad past the iOS notch / Android cutout so the text isn't
+       visually clipped or cut off by the system status bar. The
+       viewport-fit=cover meta tag on each page makes safe-area-inset-top
+       non-zero on devices with a notch. */
+    padding-top: calc(12px + env(safe-area-inset-top, 0px));
 }
 
 
@@ -470,6 +475,25 @@ input, select { font-family: inherit; }
     flex-direction: column;
 }
 
+/* === PWA FIX === */
+/* Android PWA makes the height too big with both lvh and dvh.
+   Rotating the page to landscape and portrait fixes it until
+   it is loaded again if not set to svh. */
+@media (display-mode: standalone) {
+    body, .app-layout, .main-content {
+        min-height: 100svh;
+    }
+}
+
+/* IOS PWA makes the height too small with svh */
+@supports (-webkit-touch-callout: none) {
+    @media (display-mode: standalone) {
+        body, .app-layout, .main-content {
+            min-height: 100lvh;
+        }
+    }
+}
+
 /* === PAGE HEADER === */
 .page-header {
     height: var(--header-height);
@@ -515,6 +539,7 @@ input, select { font-family: inherit; }
     padding: 32px;
     padding-bottom: calc(32px + 80px); /* Account for fixed footer */
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 /* === CARDS === */
@@ -655,7 +680,7 @@ input, select { font-family: inherit; }
 }
 
 .btn-toggle {
-    padding: 8px 16px;
+    padding: 8px 12px;
     font-size: 13px;
     font-weight: 500;
     color: var(--text-secondary);

--- a/app/src/main/assets/web/shared/vehicle-control.css
+++ b/app/src/main/assets/web/shared/vehicle-control.css
@@ -60,8 +60,18 @@
    the rest of the design system in shared/styles.css. Theme switching
    only fires when [data-theme="light"] is explicitly set (the Android
    WebViewFragment does this on every page-load). */
-.main-content { padding: 0 !important; overflow: hidden !important; height: 100vh !important; height: 100dvh !important; min-height: 0 !important; position: relative; }
-.vc-container { position: relative; width: 100%; height: 100%; background: var(--vc-canvas-bg); overflow: hidden; }
+.vc-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background: var(--vc-canvas-bg);
+    overflow: hidden;
+    /* Margin past the iOS notch / Android cutout so the hamburger isn't
+       visually clipped or cut off by the system status bar. The
+       viewport-fit=cover meta tag on each page makes safe-area-inset-top
+       non-zero on devices with a notch. */
+    margin-top: calc(12px + env(safe-area-inset-top, 0px));
+}
 
 /* 3D fills the entire area — car renders behind the translucent bar */
 .vc-viewport { position: absolute; top: 0; left: 0; right: 0; bottom: 0; }
@@ -413,7 +423,7 @@
     .vc-tyre-callout[data-corner="fl"],
     .vc-tyre-callout[data-corner="rl"] { right: 8px; }
     .vc-tyre-callout[data-corner="fl"],
-    .vc-tyre-callout[data-corner="fr"] { bottom: 100px; top: auto; }
+    .vc-tyre-callout[data-corner="fr"] { bottom: 120px; top: auto; }
 }
 @media (max-width: 480px) {
     .vc-tyre-callout { min-width: 72px; padding: 4px 7px 5px; border-radius: 8px; }
@@ -615,9 +625,11 @@
 /* Disable highlight stays readable: outline grey, not greyed-out invisible. */
 .vc-tile:disabled, .vc-tile[disabled] { color: var(--vc-text-muted); border-color: var(--vc-border-faint); background: var(--vc-tile-bg-disabled); cursor: not-allowed; }
 .vc-tile.heat:hover { border-color: rgba(239,68,68,.3); color: #EF4444; }
-.vc-tile.heat.on { border-color: #EF4444; background: rgba(239,68,68,.12); color: #EF4444; box-shadow: 0 0 12px rgba(239,68,68,.2); }
+.vc-tile.heat.on1 { border-color: #EF4444AA; background: rgba(239,68,68,.12); color: #EF4444AA; box-shadow: 0 0 12px rgba(239,68,68,.2); }
+.vc-tile.heat.on2 { border-color: #EF4444; background: rgba(239,68,68,.12); color: #EF4444; box-shadow: 0 0 12px rgba(239,68,68,.2); }
 .vc-tile.cool:hover { border-color: rgba(56,189,248,.3); color: #38BDF8; }
-.vc-tile.cool.on { border-color: #38BDF8; background: rgba(56,189,248,.12); color: #38BDF8; box-shadow: 0 0 12px rgba(56,189,248,.2); }
+.vc-tile.cool.on1 { border-color: #38BDF8AA; background: rgba(56,189,248,.12); color: #38BDF8AA; box-shadow: 0 0 12px rgba(56,189,248,.2); }
+.vc-tile.cool.on2 { border-color: #38BDF8; background: rgba(56,189,248,.12); color: #38BDF8; box-shadow: 0 0 12px rgba(56,189,248,.2); }
 .vc-tile.pending { opacity: .4; pointer-events: none; }
 
 /* Small +/- button */

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -34,8 +34,8 @@ var VC = {
         acOn: false,
         acTemp: 22,
         acFan: 3,
-        seatHeat: { 1: 0, 2: 0 },  // 0=off, 1=low, 2=high
-        seatCool: { 1: 0, 2: 0 }
+        seatHeat: [0, 0],  // 0=off, 1=low, 2=high
+        seatCool: [0, 0]
     },
 
     pollInterval: null,
@@ -1465,11 +1465,11 @@ var VC = {
         for (var si = 1; si <= 2; si++) {
             (function(pos) {
                 self.bindBtn('btnSeatHeat' + pos, function() {
-                    var cur = self.vehicleState.seatHeat[pos] || 0;
+                    var cur = self.vehicleState.seatHeat[pos - 1] || 0;
                     var next = (cur + 1) % 3;
-                    self.vehicleState.seatHeat[pos] = next;
-                    self.vehicleState.seatCool[pos] = 0;
-                    self.updateSeatUI(pos);
+                    self.vehicleState.seatHeat[pos - 1] = next;
+                    self.vehicleState.seatCool[pos - 1] = 0;
+                    self.updateSeatUI();
                     self.updateSeatGlows();
                     // Heat VFX — warm sonar at seat, intensity scales with level
                     var sp = seatPositions[pos];
@@ -1486,11 +1486,11 @@ var VC = {
                     self.apiPost('/api/vehicle/seat', { action: 'heating', position: pos, level: next });
                 });
                 self.bindBtn('btnSeatCool' + pos, function() {
-                    var cur = self.vehicleState.seatCool[pos] || 0;
+                    var cur = self.vehicleState.seatCool[pos - 1] || 0;
                     var next = (cur + 1) % 3;
-                    self.vehicleState.seatCool[pos] = next;
-                    self.vehicleState.seatHeat[pos] = 0;
-                    self.updateSeatUI(pos);
+                    self.vehicleState.seatCool[pos - 1] = next;
+                    self.vehicleState.seatHeat[pos - 1] = 0;
+                    self.updateSeatUI();
                     self.updateSeatGlows();
                     // Cool VFX — blue sonar at seat
                     var sp = seatPositions[pos];
@@ -1632,6 +1632,9 @@ var VC = {
             if (data.lights) self.vehicleState.lights = data.lights;
             if (data.adas) self.vehicleState.adas = data.adas;
 
+            if (data.seats?.heat) self.vehicleState.seatHeat = data.seats.heat;
+            if (data.seats?.cool) self.vehicleState.seatCool = data.seats.cool;
+
             // Update UI
             self.updateHUD();
             self.updateWindowBars();
@@ -1639,6 +1642,7 @@ var VC = {
             self.updateTrunkIndicator();
             self.updateWindowGlows();
             self.updateClimateUI();
+            self.updateSeatUI();
             self.updateSeatGlows();
             self.updateTabIndicators();
             self.updateLightsUI();
@@ -2000,14 +2004,22 @@ var VC = {
         }
     },
 
-    updateSeatUI: function(pos) {
-        var heatBtn = document.getElementById('btnSeatHeat' + pos);
-        var coolBtn = document.getElementById('btnSeatCool' + pos);
-        var heatLvl = this.vehicleState.seatHeat[pos] || 0;
-        var coolLvl = this.vehicleState.seatCool[pos] || 0;
+    updateSeatUI: function() {
+        for (var pos = 0; pos < 2; pos++) {
+            var heatBtn = document.getElementById('btnSeatHeat' + (pos + 1));
+            var coolBtn = document.getElementById('btnSeatCool' + (pos + 1));
+            var heatLvl = this.vehicleState.seatHeat[pos] || 0;
+            var coolLvl = this.vehicleState.seatCool[pos] || 0;
 
-        if (heatBtn) { if (heatLvl > 0) heatBtn.classList.add('on'); else heatBtn.classList.remove('on'); }
-        if (coolBtn) { if (coolLvl > 0) coolBtn.classList.add('on'); else coolBtn.classList.remove('on'); }
+            if (heatBtn) {
+                heatBtn.classList.remove('on1', 'on2');
+                if (heatLvl > 0) heatBtn.classList.add('on' + heatLvl);
+            }
+            if (coolBtn) {
+                coolBtn.classList.remove('on1', 'on2');
+                if (coolLvl > 0) coolBtn.classList.add('on' + coolLvl);
+            }
+        }
     },
 
     updateLightsUI: function() {
@@ -2034,8 +2046,8 @@ var VC = {
         };
 
         for (var pos = 1; pos <= 2; pos++) {
-            var heatLvl = this.vehicleState.seatHeat[pos] || 0;
-            var coolLvl = this.vehicleState.seatCool[pos] || 0;
+            var heatLvl = this.vehicleState.seatHeat[pos - 1] || 0;
+            var coolLvl = this.vehicleState.seatCool[pos - 1] || 0;
             var key = 'seat_' + pos;
 
             if (heatLvl > 0 || coolLvl > 0) {

--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -610,6 +610,7 @@ public class BydDataCollector {
         collectAc(b);
         collectLight(b);
         collectAdas(b);
+        collectSettings(b);
         collectPower(b);
         collectSafetyBelt(b);
         collectTyre(b);
@@ -1515,6 +1516,23 @@ public class BydDataCollector {
             }
         } catch (Exception e) {
             logger.debug("collectAdas error: " + e.getMessage());
+        }
+    }
+
+    private void collectSettings(BydVehicleData.Builder b) {
+        if (settingDevice == null) return;
+        try {
+            int[] seatHeat = new int[2];
+            int[] seatCool = new int[2];
+            for (int i = 0; i < 2; i++) {
+                Object heat = BydDeviceHelper.callGetter(settingDevice, "getSeatHeatingState", i + 1);
+                seatHeat[i] = (heat instanceof Number) ? ((Number) heat).intValue() - 1 : -1;
+                Object cool = BydDeviceHelper.callGetter(settingDevice, "getSeatVentilatingState", i + 1);
+                seatCool[i] = (cool instanceof Number) ? ((Number) cool).intValue() - 1 : -1;
+            }
+            b.seatHeat(seatHeat).seatCool(seatCool);
+        } catch (Exception e) {
+            logger.debug("collectSettings error: " + e.getMessage());
         }
     }
 
@@ -2851,6 +2869,10 @@ public class BydDataCollector {
             logger.info("  Adas listener registered");
             count++;
         }
+        if (BydDeviceHelper.registerListener(settingDevice, this::onSettingsCallback)) {
+            logger.info("  Settings listener registered");
+            count++;
+        }
         if (BydDeviceHelper.registerListener(radarDevice, this::onGenericCallback)) {
             logger.info("  Radar listener registered");
             count++;
@@ -3235,6 +3257,37 @@ public class BydDataCollector {
                     if (current != null) {
                         snapshot.set(current.toBuilder().speedLimitWarning(iVal == 2).build());
                     }
+                }
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void onSettingsCallback(String method, Object[] args) {
+        if ("onDataEventChanged".equals(method) && args != null && args.length >= 2) {
+            try {
+                int eventId = ((Number) args[0]).intValue();
+                Object eventValue = args[1];
+                int iVal = BydDeviceHelper.getIntValue(eventValue);
+
+                List<Integer> seatEventTypes = List.of(
+                        BydFeatureIds.SET_DRIVER_SEAT_HEATING_STATE,
+                        BydFeatureIds.SET_DRIVER_SEAT_VENTILATING_STATE,
+                        BydFeatureIds.SET_PASSENGER_SEAT_HEATING_STATE,
+                        BydFeatureIds.SET_PASSENGER_SEAT_VENTILATING_STATE
+                );
+
+                int seatEventType = seatEventTypes.indexOf(eventId);
+                if (seatEventType >= 0 && iVal > 0 && iVal < 4) {
+                    BydVehicleData.Builder current = snapshot.get().toBuilder();
+                    int[] seatHeat = current.seatHeat == null ? new int[2] : current.seatHeat;
+                    int[] seatCool = current.seatCool == null ? new int[2] : current.seatCool;
+                    switch (seatEventType) {
+                        case 0: seatHeat[0] = iVal - 1; break;
+                        case 1: seatCool[0] = iVal - 1; break;
+                        case 2: seatHeat[1] = iVal - 1; break;
+                        case 3: seatCool[1] = iVal - 1; break;
+                    }
+                    snapshot.set(current.seatCool(seatHeat).seatCool(seatCool).build());
                 }
             } catch (Exception ignored) {}
         }

--- a/app/src/main/java/com/overdrive/app/byd/BydFeatureIds.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydFeatureIds.java
@@ -82,6 +82,10 @@ public final class BydFeatureIds {
     public static final int SETTING_DRAG_MODE_CURRENT_STATE = resolveOrFallback("Setting.SETTING_DRAG_MODE_CURRENT_STATE", 875560989);
     public static final int SETTING_TARGET_DRIVING_MODE = resolveOrFallback("Setting.SETTING_TARGET_DRIVING_MODE", 1272971280);
     public static final int SETTING_TARGET_DRIVING_MODE_ALT = resolveOrFallback("Setting.SETTING_TARGET_DRIVING_MODE_ALT", 255852712);
+    public static final int SET_DRIVER_SEAT_HEATING_STATE = resolveOrFallback("Setting.SET_DRIVER_SEAT_HEATING_STATE", 1335885835);
+    public static final int SET_DRIVER_SEAT_VENTILATING_STATE = resolveOrFallback("Setting.SET_DRIVER_SEAT_VENTILATING_STATE", 1335885832);
+    public static final int SET_PASSENGER_SEAT_HEATING_STATE = resolveOrFallback("Setting.SET_PASSENGER_SEAT_HEATING_STATE", 1335885843);
+    public static final int SET_PASSENGER_SEAT_VENTILATING_STATE = resolveOrFallback("Setting.SET_PASSENGER_SEAT_VENTILATING_STATE", 1335885840);
 
     // ==================== BODY ====================
     public static final int BODY_ATMOSPHERE_LIGHT_SWITCH = resolveOrFallback("Body.ATMOSPHERE_LIGHT_SWITCH_EXECUTE", 489701406);

--- a/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
@@ -109,6 +109,10 @@ public class BydVehicleData {
     // ==================== SEATBELTS ====================
     public final int[] seatbeltStatus;    // [1-5]
 
+    // ==================== SEATS ====================
+    public final int[] seatHeat;    // [1-2]
+    public final int[] seatCool;    // [1-2]
+
     // ==================== CLIMATE ====================
     public final int acStartState;
     public final int acCycleMode;
@@ -256,6 +260,8 @@ public class BydVehicleData {
         this.dayTimeLight = b.dayTimeLight;
         this.speedLimitWarning = b.speedLimitWarning;
         this.seatbeltStatus = b.seatbeltStatus;
+        this.seatHeat = b.seatHeat;
+        this.seatCool = b.seatCool;
         this.acStartState = b.acStartState;
         this.acCycleMode = b.acCycleMode;
         this.acWindMode = b.acWindMode;
@@ -479,6 +485,16 @@ public class BydVehicleData {
                 for (int s : seatbeltStatus) sb.put(s);
                 j.put("seatbeltStatus", sb);
             }
+            if (seatHeat != null) {
+                JSONArray sb = new JSONArray();
+                for (int s : seatHeat) sb.put(s);
+                j.put("seatHeat", sb);
+            }
+            if (seatCool != null) {
+                JSONArray sb = new JSONArray();
+                for (int s : seatCool) sb.put(s);
+                j.put("seatCool", sb);
+            }
 
             // Climate
             JSONObject clim = new JSONObject();
@@ -637,6 +653,7 @@ public class BydVehicleData {
         b.rightTurnState = rightTurnState; b.lowBeam = lowBeam; b.highBeam = highBeam;
         b.rearFog = rearFog; b.frontFog = frontFog; b.hazard = hazard;
         b.dayTimeLight = dayTimeLight; b.seatbeltStatus = seatbeltStatus;
+        b.seatHeat = seatHeat; b.seatCool = seatCool;
         b.speedLimitWarning = speedLimitWarning;
         b.acStartState = acStartState; b.acCycleMode = acCycleMode; b.acWindMode = acWindMode; b.acFanLevel = acFanLevel;
         b.tempUnit = tempUnit; b.slopeDegrees = slopeDegrees; b.powerLevel = powerLevel;
@@ -693,6 +710,7 @@ public class BydVehicleData {
         double chargingPowerKw = NaN, externalChargingPowerKw = NaN, hvPackVoltage = NaN;
         int gearMode = UNAVAILABLE;
         int[] tyrePressure, doorLockStatus, windowOpenPercent, seatbeltStatus, radarDistances;
+        int[] seatHeat, seatCool;
         int[] tyrePressureState, tyreAirLeakState, tyreSignalState, tyreTemperature;
         int tyreSystemState = UNAVAILABLE, tyreTemperatureState = UNAVAILABLE;
         int leftTurnState = UNAVAILABLE, rightTurnState = UNAVAILABLE;
@@ -805,6 +823,8 @@ public class BydVehicleData {
         public Builder dayTimeLight(boolean v) { dayTimeLight = v; return this; }
         public Builder speedLimitWarning(boolean v) { speedLimitWarning = v; return this; }
         public Builder seatbeltStatus(int[] v) { seatbeltStatus = v; return this; }
+        public Builder seatHeat(int[] v) { seatHeat = v; return this; }
+        public Builder seatCool(int[] v) { seatCool = v; return this; }
         public Builder acStartState(int v) { acStartState = v; return this; }
         public Builder acCycleMode(int v) { acCycleMode = v; return this; }
         public Builder acWindMode(int v) { acWindMode = v; return this; }

--- a/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
@@ -6,9 +6,9 @@ import com.overdrive.app.byd.cloud.BydCloudClient;
 import com.overdrive.app.byd.cloud.BydCloudConfig;
 import com.overdrive.app.logging.DaemonLogger;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
@@ -225,6 +225,20 @@ public class VehicleControlApiHandler {
         JSONObject adas = new JSONObject();
         adas.put("speedLimitWarning", data.speedLimitWarning);
         response.put("adas", adas);
+
+        // Seats
+        JSONObject seats = new JSONObject();
+        if (data.seatHeat != null && data.seatHeat.length > 0) {
+            JSONArray heat = new JSONArray();
+            for (int item : data.seatHeat) heat.put(item);
+            seats.put("heat", heat);
+        }
+        if (data.seatCool != null && data.seatCool.length > 0) {
+            JSONArray cool = new JSONArray();
+            for (int item : data.seatCool) cool.put(item);
+            seats.put("cool", cool);
+        }
+        response.put("seats", seats);
 
         // Climate — only report AC state if vehicle power is on (powerLevel >= 2)
         // Otherwise stale cached data shows AC on when car is actually off


### PR DESCRIPTION
## What does this PR do?
Adds seat heating/ventilation listeners. Also makes a visual difference between low and high heating/cooling.
Some visual issues which appear on a PWA but not on a normal browser were fixed too. Tested in IOS with Safari and Android with Chrome.

## Why is this change needed?
Make the controls see the current real value of these settings instead of guessing.

## How to test
Turn on seat heating/cooling from the car directly and check the vehicle control tab shows the correct data after the next refresh. Also test controlling it from the vehicle control tab.
