### PR TITLE
Fix vehicle controls being cut off on Android

### DIFF
--- a/app/src/main/assets/web/shared/vehicle-control.css
+++ b/app/src/main/assets/web/shared/vehicle-control.css
@@ -60,7 +60,7 @@
    the rest of the design system in shared/styles.css. Theme switching
    only fires when [data-theme="light"] is explicitly set (the Android
    WebViewFragment does this on every page-load). */
-.main-content { padding: 0 !important; overflow: hidden !important; height: 100vh !important; height: 100dvh !important; min-height: 0 !important; position: relative; }
+.main-content { padding: 0 !important; overflow: hidden !important; position: relative; }
 .vc-container {
     position: relative;
     width: 100%;


### PR DESCRIPTION
## What does this PR do?
Fix vehicle controls being cut off by removing the height override which has !important.

## Why is this change needed?
Chrome on Android has a bug causing the view to be too big. It requires the screen to be rotated to fix the height.

## How to test
See screenshots below

## Screenshots (if applicable) 
Before:
<img width="1080" height="2215" alt="ChromePWAVehicleControls" src="https://github.com/user-attachments/assets/99db2a87-6169-453e-9f98-a152cd737df8" />

After:
<img width="1080" height="2215" alt="ChromePWAVehicleControlsAfter" src="https://github.com/user-attachments/assets/5175f899-c1a0-4cf1-be04-2af644606ea3" />
