### PR TITLE
Add camera mapping UI and panoramic slice calibration

### DIFF
--- a/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
@@ -1,0 +1,192 @@
+package com.overdrive.app.camera;
+
+import com.overdrive.app.config.UnifiedConfigManager;
+import com.overdrive.app.logging.DaemonLogger;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Resolves persisted + inferred camera settings into a concrete runtime config.
+ */
+public final class CameraConfigResolver {
+    private static final DaemonLogger logger = DaemonLogger.getInstance("CameraConfigResolver");
+
+    private CameraConfigResolver() {
+    }
+
+    public static ResolvedCameraConfig resolve() {
+        return resolve(readVehicleModel());
+    }
+
+    public static ResolvedCameraConfig resolve(String vehicleModel) {
+        JSONObject camera = getCameraSection();
+        String selectedProfileId = camera.optString("cameraProfile", CameraProfiles.PROFILE_AUTO);
+        boolean autoProfile = selectedProfileId.isEmpty() || CameraProfiles.PROFILE_AUTO.equalsIgnoreCase(selectedProfileId);
+        CameraProfile profile = autoProfile
+                ? CameraProfiles.infer(vehicleModel)
+                : CameraProfiles.get(selectedProfileId);
+
+        int panoCameraId = optNonNegative(camera, "probedCameraId", profile.getPanoCameraId());
+        int panoSurfaceMode = optNonNegative(camera, "probedSurfaceMode", profile.getPanoSurfaceMode());
+        int panoWidth = optNonNegative(camera, "probedWidth", profile.getPanoWidth());
+        int panoHeight = optNonNegative(camera, "probedHeight", profile.getPanoHeight());
+        boolean manual = camera.optBoolean("manualOverride", false);
+        boolean validated = camera.optBoolean("probedAndValidated", false);
+        boolean fallback = camera.optBoolean("fallbackFromProbe", false);
+
+        EnumMap<CameraRole, CameraSourceRef> roleMappings = profile.getDefaultRoleMappings();
+        JSONObject mappingsJson = camera.optJSONObject("roleMappings");
+        if (mappingsJson != null) {
+            for (CameraRole role : CameraRole.values()) {
+                JSONObject item = mappingsJson.optJSONObject(role.getKey());
+                CameraSourceRef sourceRef = CameraSourceRef.fromJson(item);
+                if (sourceRef != null) {
+                    roleMappings.put(role, sourceRef);
+                }
+            }
+        }
+
+        return new ResolvedCameraConfig(
+                profile,
+                autoProfile ? CameraProfiles.PROFILE_AUTO : profile.getId(),
+                autoProfile,
+                panoCameraId,
+                panoWidth,
+                panoHeight,
+                panoSurfaceMode,
+                manual,
+                validated,
+                fallback,
+                roleMappings);
+    }
+
+    public static JSONObject getCameraSection() {
+        return UnifiedConfigManager.loadConfig().optJSONObject("camera") != null
+                ? UnifiedConfigManager.loadConfig().optJSONObject("camera")
+                : new JSONObject();
+    }
+
+    public static JSONArray buildPreviewCandidates(ResolvedCameraConfig resolved) {
+        JSONArray out = new JSONArray();
+        for (int cameraId = 0; cameraId <= 5; cameraId++) {
+            JSONObject item = CameraSourceRef.direct(cameraId).toJson();
+            putSafely(item, "previewWidth", resolved.getProfile().getDirectPreviewWidth());
+            putSafely(item, "previewHeight", resolved.getProfile().getDirectPreviewHeight());
+            out.put(item);
+        }
+        for (CameraVirtualView view : CameraVirtualView.values()) {
+            JSONObject item = CameraSourceRef.panoramic(view).toJson();
+            putSafely(item, "previewWidth", resolved.getPanoWidth() / 4);
+            putSafely(item, "previewHeight", resolved.getPanoHeight());
+            out.put(item);
+        }
+        return out;
+    }
+
+    public static JSONArray roleOptionsJson() {
+        JSONArray out = new JSONArray();
+        for (CameraRole role : CameraRole.values()) {
+            out.put(role.toJson());
+        }
+        return out;
+    }
+
+    public static boolean saveCameraProfile(String profileId) {
+        JSONObject update = new JSONObject();
+        if (profileId == null || profileId.isEmpty() || CameraProfiles.PROFILE_AUTO.equalsIgnoreCase(profileId)) {
+            putSafely(update, "cameraProfile", CameraProfiles.PROFILE_AUTO);
+        } else if (CameraProfiles.isKnownProfile(profileId)) {
+            putSafely(update, "cameraProfile", profileId);
+            CameraProfile profile = CameraProfiles.get(profileId);
+            if (!getCameraSection().has("probedWidth")) putSafely(update, "probedWidth", profile.getPanoWidth());
+            if (!getCameraSection().has("probedHeight")) putSafely(update, "probedHeight", profile.getPanoHeight());
+        } else {
+            logger.warn("Ignoring unknown camera profile: " + profileId);
+            return false;
+        }
+        return UnifiedConfigManager.updateSection("camera", update);
+    }
+
+    public static boolean saveRoleMapping(CameraRole role, CameraSourceRef sourceRef) {
+        if (role == null || sourceRef == null) return false;
+        JSONObject camera = getCameraSection();
+        JSONObject mappings = camera.optJSONObject("roleMappings");
+        if (mappings == null) mappings = new JSONObject();
+        putSafely(mappings, role.getKey(), sourceRef.toJson());
+
+        JSONObject update = new JSONObject();
+        putSafely(update, "roleMappings", mappings);
+        return UnifiedConfigManager.updateSection("camera", update);
+    }
+
+    public static boolean clearRoleMapping(CameraRole role) {
+        if (role == null) return false;
+        JSONObject camera = getCameraSection();
+        JSONObject mappings = camera.optJSONObject("roleMappings");
+        if (mappings == null || !mappings.has(role.getKey())) return true;
+        mappings.remove(role.getKey());
+
+        JSONObject update = new JSONObject();
+        putSafely(update, "roleMappings", mappings);
+        return UnifiedConfigManager.updateSection("camera", update);
+    }
+
+    public static boolean persistPanoramicProbe(int cameraId, int surfaceMode, int width, int height,
+                                                boolean validated, boolean fallback) {
+        JSONObject update = new JSONObject();
+        putSafely(update, "probedCameraId", cameraId);
+        putSafely(update, "probedSurfaceMode", surfaceMode);
+        putSafely(update, "probedWidth", width);
+        putSafely(update, "probedHeight", height);
+        putSafely(update, "probedAndValidated", validated);
+        putSafely(update, "fallbackFromProbe", fallback);
+        return UnifiedConfigManager.updateSection("camera", update);
+    }
+
+    public static JSONObject resolvedSummaryJson(ResolvedCameraConfig resolved) {
+        JSONObject out = new JSONObject();
+        putSafely(out, "cameraProfile", resolved.getSelectedProfileId());
+        putSafely(out, "resolvedCameraProfile", resolved.getProfile().getId());
+        putSafely(out, "resolvedCameraProfileLabel", resolved.getProfile().getDisplayName());
+        putSafely(out, "panoCameraId", resolved.getPanoCameraId());
+        putSafely(out, "panoSurfaceMode", resolved.getPanoSurfaceMode());
+        putSafely(out, "panoWidth", resolved.getPanoWidth());
+        putSafely(out, "panoHeight", resolved.getPanoHeight());
+        putSafely(out, "cameraManualOverride", resolved.isManualPanoOverride());
+        putSafely(out, "cameraValidated", resolved.isValidated());
+        putSafely(out, "cameraFallbackFromProbe", resolved.isFallbackFromProbe());
+        putSafely(out, "cameraProfiles", CameraProfiles.toJsonArray());
+        putSafely(out, "cameraRoleOptions", roleOptionsJson());
+        putSafely(out, "cameraRoleMappings", resolved.roleMappingsToJson());
+        putSafely(out, "cameraPreviewCandidates", buildPreviewCandidates(resolved));
+        return out;
+    }
+
+    private static int optNonNegative(JSONObject obj, String key, int defaultValue) {
+        int value = obj.optInt(key, defaultValue);
+        return value >= 0 ? value : defaultValue;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+
+    private static String readVehicleModel() {
+        try {
+            return (String) Class.forName("android.os.SystemProperties")
+                    .getMethod("get", String.class, String.class)
+                    .invoke(null, "ro.product.model", "unknown");
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
@@ -79,8 +79,8 @@ public final class CameraConfigResolver {
             putSafely(item, "previewHeight", resolved.getProfile().getDirectPreviewHeight());
             out.put(item);
         }
-        for (CameraVirtualView view : CameraVirtualView.values()) {
-            JSONObject item = CameraSourceRef.panoramic(view).toJson();
+        for (PanoramicSlice slice : PanoramicSlice.values()) {
+            JSONObject item = CameraSourceRef.panoramicSlice(slice).toJson();
             putSafely(item, "previewWidth", resolved.getPanoWidth() / 4);
             putSafely(item, "previewHeight", resolved.getPanoHeight());
             out.put(item);
@@ -163,6 +163,7 @@ public final class CameraConfigResolver {
         putSafely(out, "cameraProfiles", CameraProfiles.toJsonArray());
         putSafely(out, "cameraRoleOptions", roleOptionsJson());
         putSafely(out, "cameraRoleMappings", resolved.roleMappingsToJson());
+        putSafely(out, "cameraPanoramicSlices", resolved.panoramicSlicesToJson());
         putSafely(out, "cameraPreviewCandidates", buildPreviewCandidates(resolved));
         return out;
     }

--- a/app/src/main/java/com/overdrive/app/camera/CameraPreviewHelper.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraPreviewHelper.java
@@ -1,5 +1,7 @@
 package com.overdrive.app.camera;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.ImageFormat;
 import android.graphics.Rect;
 import android.graphics.YuvImage;
@@ -46,6 +48,41 @@ public final class CameraPreviewHelper {
                 return jpeg;
             }
         }
+        return null;
+    }
+
+    public static byte[] captureDirectPreviewJpegExact(int cameraId, int width, int height,
+                                                       int fps, int timeoutMs) {
+        if (width <= 0 || height <= 0) return null;
+        return captureWithSize(cameraId, width, height, fps, timeoutMs);
+    }
+
+    public static byte[] capturePanoramicSliceJpeg(int cameraId, int panoWidth, int panoHeight,
+                                                   PanoramicSlice slice) {
+        if (slice == null || panoWidth <= 0 || panoHeight <= 0) return null;
+
+        int[][] candidates = new int[][] {
+            {panoWidth, panoHeight},
+            {Math.max(1, panoWidth / 2), Math.max(1, panoHeight / 2)},
+            {Math.max(1, panoWidth / 4), Math.max(1, panoHeight / 4)}
+        };
+
+        for (int[] candidate : candidates) {
+            byte[] fullJpeg = captureDirectPreviewJpegExact(
+                cameraId,
+                candidate[0],
+                candidate[1],
+                10,
+                DEFAULT_TIMEOUT_MS
+            );
+            if (fullJpeg == null || fullJpeg.length == 0) continue;
+
+            byte[] cropped = cropJpegToSlice(fullJpeg, slice, 82);
+            if (cropped != null && cropped.length > 0) {
+                return cropped;
+            }
+        }
+
         return null;
     }
 
@@ -128,6 +165,33 @@ public final class CameraPreviewHelper {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         yuvImage.compressToJpeg(new Rect(0, 0, image.getWidth(), image.getHeight()), quality, out);
         return out.toByteArray();
+    }
+
+    private static byte[] cropJpegToSlice(byte[] jpegBytes, PanoramicSlice slice, int quality) {
+        Bitmap bitmap = null;
+        Bitmap cropped = null;
+        try {
+            bitmap = BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.length);
+            if (bitmap == null) return null;
+
+            int sliceWidth = Math.max(1, bitmap.getWidth() / 4);
+            int startX = Math.min(bitmap.getWidth() - sliceWidth, Math.max(0, slice.getIndex() * sliceWidth));
+            cropped = Bitmap.createBitmap(bitmap, startX, 0, sliceWidth, bitmap.getHeight());
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            cropped.compress(Bitmap.CompressFormat.JPEG, quality, out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            logger.debug("Panoramic slice crop failed: " + e.getMessage());
+            return null;
+        } finally {
+            if (cropped != null) {
+                try { cropped.recycle(); } catch (Exception ignored) {}
+            }
+            if (bitmap != null) {
+                try { bitmap.recycle(); } catch (Exception ignored) {}
+            }
+        }
     }
 
     private static byte[] yuv420888ToNv21(Image image) {

--- a/app/src/main/java/com/overdrive/app/camera/CameraPreviewHelper.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraPreviewHelper.java
@@ -1,0 +1,168 @@
+package com.overdrive.app.camera;
+
+import android.graphics.ImageFormat;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.Handler;
+import android.os.HandlerThread;
+
+import com.overdrive.app.logging.DaemonLogger;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Best-effort preview capture for direct camera IDs.
+ */
+public final class CameraPreviewHelper {
+    private static final DaemonLogger logger = DaemonLogger.getInstance("CameraPreviewHelper");
+    private static final int DEFAULT_TIMEOUT_MS = 1500;
+
+    private CameraPreviewHelper() {
+    }
+
+    public static byte[] captureDirectPreviewJpeg(int cameraId, int preferredWidth, int preferredHeight) {
+        return captureDirectPreviewJpeg(cameraId, preferredWidth, preferredHeight, 10, DEFAULT_TIMEOUT_MS);
+    }
+
+    public static byte[] captureDirectPreviewJpeg(int cameraId, int preferredWidth, int preferredHeight,
+                                                  int fps, int timeoutMs) {
+        int[][] candidates = new int[][] {
+            {preferredWidth, preferredHeight},
+            {1280, 960},
+            {1280, 720},
+            {960, 720},
+            {720, 480}
+        };
+        for (int[] candidate : candidates) {
+            if (candidate[0] <= 0 || candidate[1] <= 0) continue;
+            byte[] jpeg = captureWithSize(cameraId, candidate[0], candidate[1], fps, timeoutMs);
+            if (jpeg != null && jpeg.length > 0) {
+                return jpeg;
+            }
+        }
+        return null;
+    }
+
+    private static byte[] captureWithSize(int cameraId, int width, int height, int fps, int timeoutMs) {
+        HandlerThread thread = null;
+        ImageReader reader = null;
+        BinderCameraBackend backend = new BinderCameraBackend();
+        AtomicReference<Image> imageRef = new AtomicReference<>();
+
+        try {
+            thread = new HandlerThread("DirectPreview-" + cameraId + "-" + width + "x" + height);
+            thread.start();
+            Handler handler = new Handler(thread.getLooper());
+            CountDownLatch latch = new CountDownLatch(1);
+
+            reader = ImageReader.newInstance(width, height, ImageFormat.YUV_420_888, 2);
+            reader.setOnImageAvailableListener(imageReader -> {
+                Image image = null;
+                try {
+                    image = imageReader.acquireLatestImage();
+                    if (image != null && imageRef.compareAndSet(null, image)) {
+                        latch.countDown();
+                        image = null;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Preview image callback failed: " + e.getMessage());
+                } finally {
+                    if (image != null) {
+                        try { image.close(); } catch (Exception ignored) {}
+                    }
+                }
+            }, handler);
+
+            if (!backend.startCamera(cameraId, reader.getSurface(), width, height, fps)) {
+                return null;
+            }
+
+            if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                logger.debug("Timed out waiting for preview frame cam=" + cameraId + " size=" + width + "x" + height);
+                return null;
+            }
+
+            Image image = imageRef.get();
+            if (image == null) {
+                return null;
+            }
+            try {
+                return yuv420888ToJpeg(image, 80);
+            } finally {
+                try { image.close(); } catch (Exception ignored) {}
+                imageRef.set(null);
+            }
+        } catch (Exception e) {
+            logger.debug("Direct preview capture failed cam=" + cameraId + " size=" + width + "x" + height + ": " + e.getMessage());
+            return null;
+        } finally {
+            try { backend.stopCamera(); } catch (Exception ignored) {}
+            try { backend.disconnect(); } catch (Exception ignored) {}
+            if (reader != null) {
+                try { reader.close(); } catch (Exception ignored) {}
+            }
+            Image leaked = imageRef.getAndSet(null);
+            if (leaked != null) {
+                try { leaked.close(); } catch (Exception ignored) {}
+            }
+            if (thread != null) {
+                try {
+                    thread.quitSafely();
+                    thread.join(250);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+    }
+
+    private static byte[] yuv420888ToJpeg(Image image, int quality) {
+        byte[] nv21 = yuv420888ToNv21(image);
+        YuvImage yuvImage = new YuvImage(nv21, ImageFormat.NV21, image.getWidth(), image.getHeight(), null);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        yuvImage.compressToJpeg(new Rect(0, 0, image.getWidth(), image.getHeight()), quality, out);
+        return out.toByteArray();
+    }
+
+    private static byte[] yuv420888ToNv21(Image image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        Image.Plane[] planes = image.getPlanes();
+        byte[] out = new byte[width * height * 3 / 2];
+        int dst = 0;
+
+        ByteBuffer yBuffer = planes[0].getBuffer();
+        int yRowStride = planes[0].getRowStride();
+        int yPixelStride = planes[0].getPixelStride();
+        for (int row = 0; row < height; row++) {
+            int rowOffset = row * yRowStride;
+            for (int col = 0; col < width; col++) {
+                out[dst++] = yBuffer.get(rowOffset + col * yPixelStride);
+            }
+        }
+
+        ByteBuffer uBuffer = planes[1].getBuffer();
+        ByteBuffer vBuffer = planes[2].getBuffer();
+        int uRowStride = planes[1].getRowStride();
+        int vRowStride = planes[2].getRowStride();
+        int uPixelStride = planes[1].getPixelStride();
+        int vPixelStride = planes[2].getPixelStride();
+        int chromaHeight = height / 2;
+        int chromaWidth = width / 2;
+        for (int row = 0; row < chromaHeight; row++) {
+            int uRowOffset = row * uRowStride;
+            int vRowOffset = row * vRowStride;
+            for (int col = 0; col < chromaWidth; col++) {
+                out[dst++] = vBuffer.get(vRowOffset + col * vPixelStride);
+                out[dst++] = uBuffer.get(uRowOffset + col * uPixelStride);
+            }
+        }
+        return out;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraProfile.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraProfile.java
@@ -89,6 +89,14 @@ public final class CameraProfile {
         return out;
     }
 
+    public JSONArray getPanoramicSlicesJson() {
+        JSONArray out = new JSONArray();
+        for (PanoramicSlice slice : PanoramicSlice.values()) {
+            out.put(slice.toJson());
+        }
+        return out;
+    }
+
     public JSONObject toJson() {
         JSONObject out = new JSONObject();
         putSafely(out, "id", id);
@@ -105,6 +113,7 @@ public final class CameraProfile {
             putSafely(mappings, entry.getKey().getKey(), entry.getValue().toJson());
         }
         putSafely(out, "defaultRoleMappings", mappings);
+        putSafely(out, "panoramicSlices", getPanoramicSlicesJson());
         putSafely(out, "virtualViews", getVirtualViewsJson());
         return out;
     }

--- a/app/src/main/java/com/overdrive/app/camera/CameraProfile.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraProfile.java
@@ -1,0 +1,119 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Vehicle/profile-specific panoramic defaults.
+ */
+public final class CameraProfile {
+    private final String id;
+    private final String displayName;
+    private final int panoCameraId;
+    private final int panoWidth;
+    private final int panoHeight;
+    private final int panoSurfaceMode;
+    private final int directPreviewWidth;
+    private final int directPreviewHeight;
+    private final EnumMap<CameraRole, CameraSourceRef> defaultRoleMappings;
+
+    public CameraProfile(
+            String id,
+            String displayName,
+            int panoCameraId,
+            int panoWidth,
+            int panoHeight,
+            int panoSurfaceMode,
+            int directPreviewWidth,
+            int directPreviewHeight,
+            Map<CameraRole, CameraSourceRef> defaultRoleMappings) {
+        this.id = id;
+        this.displayName = displayName;
+        this.panoCameraId = panoCameraId;
+        this.panoWidth = panoWidth;
+        this.panoHeight = panoHeight;
+        this.panoSurfaceMode = panoSurfaceMode;
+        this.directPreviewWidth = directPreviewWidth;
+        this.directPreviewHeight = directPreviewHeight;
+        this.defaultRoleMappings = new EnumMap<>(CameraRole.class);
+        if (defaultRoleMappings != null) {
+            this.defaultRoleMappings.putAll(defaultRoleMappings);
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getPanoCameraId() {
+        return panoCameraId;
+    }
+
+    public int getPanoWidth() {
+        return panoWidth;
+    }
+
+    public int getPanoHeight() {
+        return panoHeight;
+    }
+
+    public int getPanoSurfaceMode() {
+        return panoSurfaceMode;
+    }
+
+    public int getDirectPreviewWidth() {
+        return directPreviewWidth;
+    }
+
+    public int getDirectPreviewHeight() {
+        return directPreviewHeight;
+    }
+
+    public EnumMap<CameraRole, CameraSourceRef> getDefaultRoleMappings() {
+        return new EnumMap<>(defaultRoleMappings);
+    }
+
+    public JSONArray getVirtualViewsJson() {
+        JSONArray out = new JSONArray();
+        for (CameraVirtualView view : CameraVirtualView.values()) {
+            out.put(view.toJson());
+        }
+        return out;
+    }
+
+    public JSONObject toJson() {
+        JSONObject out = new JSONObject();
+        putSafely(out, "id", id);
+        putSafely(out, "label", displayName);
+        putSafely(out, "panoCameraId", panoCameraId);
+        putSafely(out, "panoWidth", panoWidth);
+        putSafely(out, "panoHeight", panoHeight);
+        putSafely(out, "panoSurfaceMode", panoSurfaceMode);
+        putSafely(out, "directPreviewWidth", directPreviewWidth);
+        putSafely(out, "directPreviewHeight", directPreviewHeight);
+
+        JSONObject mappings = new JSONObject();
+        for (Map.Entry<CameraRole, CameraSourceRef> entry : defaultRoleMappings.entrySet()) {
+            putSafely(mappings, entry.getKey().getKey(), entry.getValue().toJson());
+        }
+        putSafely(out, "defaultRoleMappings", mappings);
+        putSafely(out, "virtualViews", getVirtualViewsJson());
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
@@ -21,10 +21,10 @@ public final class CameraProfiles {
 
     static {
         EnumMap<CameraRole, CameraSourceRef> legacyMappings = new EnumMap<>(CameraRole.class);
-        legacyMappings.put(CameraRole.PANO_FRONT, CameraSourceRef.panoramic(CameraVirtualView.FRONT));
-        legacyMappings.put(CameraRole.PANO_RIGHT, CameraSourceRef.panoramic(CameraVirtualView.RIGHT));
-        legacyMappings.put(CameraRole.PANO_REAR, CameraSourceRef.panoramic(CameraVirtualView.REAR));
-        legacyMappings.put(CameraRole.PANO_LEFT, CameraSourceRef.panoramic(CameraVirtualView.LEFT));
+        legacyMappings.put(CameraRole.PANO_FRONT, CameraSourceRef.panoramicSlice(PanoramicSlice.SLICE_4));
+        legacyMappings.put(CameraRole.PANO_RIGHT, CameraSourceRef.panoramicSlice(PanoramicSlice.SLICE_3));
+        legacyMappings.put(CameraRole.PANO_REAR, CameraSourceRef.panoramicSlice(PanoramicSlice.SLICE_1));
+        legacyMappings.put(CameraRole.PANO_LEFT, CameraSourceRef.panoramicSlice(PanoramicSlice.SLICE_2));
 
         register(new CameraProfile(
                 PROFILE_LEGACY_SEAL_ATTO,

--- a/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
@@ -1,0 +1,103 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Registry of known camera profiles.
+ */
+public final class CameraProfiles {
+    public static final String PROFILE_AUTO = "auto";
+    public static final String PROFILE_LEGACY_SEAL_ATTO = "legacy_seal_atto";
+    public static final String PROFILE_TANG_2022 = "tang_2022";
+
+    private static final LinkedHashMap<String, CameraProfile> PROFILES = new LinkedHashMap<>();
+
+    static {
+        EnumMap<CameraRole, CameraSourceRef> legacyMappings = new EnumMap<>(CameraRole.class);
+        legacyMappings.put(CameraRole.PANO_FRONT, CameraSourceRef.panoramic(CameraVirtualView.FRONT));
+        legacyMappings.put(CameraRole.PANO_RIGHT, CameraSourceRef.panoramic(CameraVirtualView.RIGHT));
+        legacyMappings.put(CameraRole.PANO_REAR, CameraSourceRef.panoramic(CameraVirtualView.REAR));
+        legacyMappings.put(CameraRole.PANO_LEFT, CameraSourceRef.panoramic(CameraVirtualView.LEFT));
+
+        register(new CameraProfile(
+                PROFILE_LEGACY_SEAL_ATTO,
+                "Legacy panoramic (Seal / Atto)",
+                1,
+                5120,
+                960,
+                0,
+                1280,
+                960,
+                legacyMappings));
+
+        EnumMap<CameraRole, CameraSourceRef> tangMappings = new EnumMap<>(legacyMappings);
+        tangMappings.put(CameraRole.WINDSHIELD, CameraSourceRef.direct(0));
+        register(new CameraProfile(
+                PROFILE_TANG_2022,
+                "BYD Tang 2022",
+                2,
+                5120,
+                720,
+                0,
+                1280,
+                720,
+                tangMappings));
+    }
+
+    private CameraProfiles() {
+    }
+
+    private static void register(CameraProfile profile) {
+        PROFILES.put(profile.getId(), profile);
+    }
+
+    public static CameraProfile get(String id) {
+        CameraProfile profile = PROFILES.get(id);
+        return profile != null ? profile : getLegacyDefault();
+    }
+
+    public static CameraProfile getLegacyDefault() {
+        return PROFILES.get(PROFILE_LEGACY_SEAL_ATTO);
+    }
+
+    public static CameraProfile infer(String vehicleModel) {
+        if (vehicleModel != null) {
+            String normalized = vehicleModel.toLowerCase(Locale.US);
+            if (normalized.contains("tang")) {
+                return get(PROFILE_TANG_2022);
+            }
+        }
+        return getLegacyDefault();
+    }
+
+    public static boolean isKnownProfile(String id) {
+        return PROFILES.containsKey(id);
+    }
+
+    public static JSONArray toJsonArray() {
+        JSONArray out = new JSONArray();
+        JSONObject autoOption = new JSONObject();
+        putSafely(autoOption, "id", PROFILE_AUTO);
+        putSafely(autoOption, "label", "Auto detect");
+        out.put(autoOption);
+        for (Map.Entry<String, CameraProfile> entry : PROFILES.entrySet()) {
+            out.put(entry.getValue().toJson());
+        }
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraRole.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraRole.java
@@ -1,0 +1,57 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Logical camera role presented to the user.
+ */
+public enum CameraRole {
+    WINDSHIELD("windshield", "Windshield"),
+    CABIN("cabin", "Cabin"),
+    PANO_FRONT("panoFront", "360 Front"),
+    PANO_REAR("panoRear", "360 Rear"),
+    PANO_LEFT("panoLeft", "360 Left"),
+    PANO_RIGHT("panoRight", "360 Right");
+
+    private final String key;
+    private final String displayName;
+
+    CameraRole(String key, String displayName) {
+        this.key = key;
+        this.displayName = displayName;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public JSONObject toJson() {
+        JSONObject out = new JSONObject();
+        putSafely(out, "key", key);
+        putSafely(out, "label", displayName);
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+
+    public static CameraRole fromKey(String key) {
+        if (key == null) return null;
+        for (CameraRole role : values()) {
+            if (role.key.equalsIgnoreCase(key)) {
+                return role;
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraSourceKind.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraSourceKind.java
@@ -1,0 +1,29 @@
+package com.overdrive.app.camera;
+
+/**
+ * Backing source used for a camera role.
+ */
+public enum CameraSourceKind {
+    DIRECT("direct"),
+    PANORAMIC_VIRTUAL("panoramicVirtual");
+
+    private final String id;
+
+    CameraSourceKind(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static CameraSourceKind fromId(String id) {
+        if (id == null) return null;
+        for (CameraSourceKind value : values()) {
+            if (value.id.equalsIgnoreCase(id)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraSourceKind.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraSourceKind.java
@@ -5,6 +5,7 @@ package com.overdrive.app.camera;
  */
 public enum CameraSourceKind {
     DIRECT("direct"),
+    PANORAMIC_SLICE("panoramicSlice"),
     PANORAMIC_VIRTUAL("panoramicVirtual");
 
     private final String id;

--- a/app/src/main/java/com/overdrive/app/camera/CameraSourceRef.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraSourceRef.java
@@ -9,20 +9,20 @@ import org.json.JSONObject;
 public final class CameraSourceRef {
     private final CameraSourceKind kind;
     private final Integer cameraId;
-    private final CameraVirtualView virtualView;
+    private final PanoramicSlice panoramicSlice;
 
-    private CameraSourceRef(CameraSourceKind kind, Integer cameraId, CameraVirtualView virtualView) {
+    private CameraSourceRef(CameraSourceKind kind, Integer cameraId, PanoramicSlice panoramicSlice) {
         this.kind = kind;
         this.cameraId = cameraId;
-        this.virtualView = virtualView;
+        this.panoramicSlice = panoramicSlice;
     }
 
     public static CameraSourceRef direct(int cameraId) {
         return new CameraSourceRef(CameraSourceKind.DIRECT, cameraId, null);
     }
 
-    public static CameraSourceRef panoramic(CameraVirtualView virtualView) {
-        return new CameraSourceRef(CameraSourceKind.PANORAMIC_VIRTUAL, null, virtualView);
+    public static CameraSourceRef panoramicSlice(PanoramicSlice panoramicSlice) {
+        return new CameraSourceRef(CameraSourceKind.PANORAMIC_SLICE, null, panoramicSlice);
     }
 
     public CameraSourceKind getKind() {
@@ -33,22 +33,22 @@ public final class CameraSourceRef {
         return cameraId;
     }
 
-    public CameraVirtualView getVirtualView() {
-        return virtualView;
+    public PanoramicSlice getPanoramicSlice() {
+        return panoramicSlice;
     }
 
     public String getStableId() {
         if (kind == CameraSourceKind.DIRECT) {
             return "direct:" + cameraId;
         }
-        return "pano:" + (virtualView != null ? virtualView.getId() : "unknown");
+        return "panoSlice:" + (panoramicSlice != null ? panoramicSlice.getId() : "unknown");
     }
 
     public String getDisplayLabel() {
         if (kind == CameraSourceKind.DIRECT) {
             return "Direct camera " + cameraId;
         }
-        return virtualView != null ? virtualView.getDisplayName() : "Panoramic view";
+        return panoramicSlice != null ? panoramicSlice.getDisplayName() : "Merged panoramic slice";
     }
 
     public JSONObject toJson() {
@@ -57,8 +57,8 @@ public final class CameraSourceRef {
         if (cameraId != null) {
             putSafely(out, "cameraId", cameraId.intValue());
         }
-        if (virtualView != null) {
-            putSafely(out, "view", virtualView.getId());
+        if (panoramicSlice != null) {
+            putSafely(out, "slice", panoramicSlice.getId());
         }
         putSafely(out, "id", getStableId());
         putSafely(out, "label", getDisplayLabel());
@@ -79,10 +79,17 @@ public final class CameraSourceRef {
         if (kind == CameraSourceKind.DIRECT && obj.has("cameraId")) {
             return direct(obj.optInt("cameraId", -1));
         }
+        if (kind == CameraSourceKind.PANORAMIC_SLICE) {
+            PanoramicSlice slice = PanoramicSlice.fromId(obj.optString("slice", null));
+            if (slice != null) {
+                return panoramicSlice(slice);
+            }
+        }
         if (kind == CameraSourceKind.PANORAMIC_VIRTUAL) {
             CameraVirtualView view = CameraVirtualView.fromId(obj.optString("view", null));
-            if (view != null) {
-                return panoramic(view);
+            PanoramicSlice slice = PanoramicSlice.fromLegacyView(view);
+            if (slice != null) {
+                return panoramicSlice(slice);
             }
         }
         return null;

--- a/app/src/main/java/com/overdrive/app/camera/CameraSourceRef.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraSourceRef.java
@@ -1,0 +1,90 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Serializable pointer to a direct camera or a panoramic subview.
+ */
+public final class CameraSourceRef {
+    private final CameraSourceKind kind;
+    private final Integer cameraId;
+    private final CameraVirtualView virtualView;
+
+    private CameraSourceRef(CameraSourceKind kind, Integer cameraId, CameraVirtualView virtualView) {
+        this.kind = kind;
+        this.cameraId = cameraId;
+        this.virtualView = virtualView;
+    }
+
+    public static CameraSourceRef direct(int cameraId) {
+        return new CameraSourceRef(CameraSourceKind.DIRECT, cameraId, null);
+    }
+
+    public static CameraSourceRef panoramic(CameraVirtualView virtualView) {
+        return new CameraSourceRef(CameraSourceKind.PANORAMIC_VIRTUAL, null, virtualView);
+    }
+
+    public CameraSourceKind getKind() {
+        return kind;
+    }
+
+    public Integer getCameraId() {
+        return cameraId;
+    }
+
+    public CameraVirtualView getVirtualView() {
+        return virtualView;
+    }
+
+    public String getStableId() {
+        if (kind == CameraSourceKind.DIRECT) {
+            return "direct:" + cameraId;
+        }
+        return "pano:" + (virtualView != null ? virtualView.getId() : "unknown");
+    }
+
+    public String getDisplayLabel() {
+        if (kind == CameraSourceKind.DIRECT) {
+            return "Direct camera " + cameraId;
+        }
+        return virtualView != null ? virtualView.getDisplayName() : "Panoramic view";
+    }
+
+    public JSONObject toJson() {
+        JSONObject out = new JSONObject();
+        putSafely(out, "kind", kind.getId());
+        if (cameraId != null) {
+            putSafely(out, "cameraId", cameraId.intValue());
+        }
+        if (virtualView != null) {
+            putSafely(out, "view", virtualView.getId());
+        }
+        putSafely(out, "id", getStableId());
+        putSafely(out, "label", getDisplayLabel());
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+
+    public static CameraSourceRef fromJson(JSONObject obj) {
+        if (obj == null) return null;
+        CameraSourceKind kind = CameraSourceKind.fromId(obj.optString("kind", null));
+        if (kind == CameraSourceKind.DIRECT && obj.has("cameraId")) {
+            return direct(obj.optInt("cameraId", -1));
+        }
+        if (kind == CameraSourceKind.PANORAMIC_VIRTUAL) {
+            CameraVirtualView view = CameraVirtualView.fromId(obj.optString("view", null));
+            if (view != null) {
+                return panoramic(view);
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/CameraVirtualView.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraVirtualView.java
@@ -1,0 +1,68 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Named subview extracted from a panoramic strip.
+ */
+public enum CameraVirtualView {
+    FRONT("front", "360 Front", 1, 0.75f),
+    RIGHT("right", "360 Right", 2, 0.50f),
+    REAR("rear", "360 Rear", 3, 0.00f),
+    LEFT("left", "360 Left", 4, 0.25f);
+
+    private final String id;
+    private final String displayName;
+    private final int streamViewMode;
+    private final float stripOffsetX;
+
+    CameraVirtualView(String id, String displayName, int streamViewMode, float stripOffsetX) {
+        this.id = id;
+        this.displayName = displayName;
+        this.streamViewMode = streamViewMode;
+        this.stripOffsetX = stripOffsetX;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getStreamViewMode() {
+        return streamViewMode;
+    }
+
+    public float getStripOffsetX() {
+        return stripOffsetX;
+    }
+
+    public JSONObject toJson() {
+        JSONObject out = new JSONObject();
+        putSafely(out, "id", id);
+        putSafely(out, "label", displayName);
+        putSafely(out, "streamViewMode", streamViewMode);
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+
+    public static CameraVirtualView fromId(String id) {
+        if (id == null) return null;
+        for (CameraVirtualView value : values()) {
+            if (value.id.equalsIgnoreCase(id)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
@@ -1,5 +1,6 @@
 package com.overdrive.app.camera;
 
+import android.graphics.Bitmap;
 import android.graphics.ImageFormat;
 import android.hardware.HardwareBuffer;
 import android.media.Image;
@@ -429,7 +430,7 @@ public class PanoramicCameraGpu {
         }
         
         // Initialize foveated cropper for high-res AI crops
-        foveatedCropper = new FoveatedCropper();
+        foveatedCropper = new FoveatedCropper(width, height);
         foveatedCropper.init();
         
         logger.info( "OpenGL initialized (texture=" + cameraTextureId + ")");
@@ -933,7 +934,7 @@ public class PanoramicCameraGpu {
                         lastDataCameraId = currentId;
                         
                         // During auto-probe: accept the first camera with non-black panoramic data.
-                        // The 5120x960 resolution IS the panoramic strip identifier on BYD — no other
+                        // The wide panoramic strip geometry is the identifier on BYD — no other
                         // camera output uses this resolution with real image data. The luma-based
                         // strip check was producing false negatives in low-light/uniform scenes.
                         if (autoProbeCameras) {
@@ -1015,11 +1016,13 @@ public class PanoramicCameraGpu {
                             // Only write back if there's no manual override, or if the manual override
                             // matches what we're currently running (user's choice is already applied)
                             if (!hasManualOverride || savedId == currentId) {
-                                org.json.JSONObject camCfg = new org.json.JSONObject();
-                                camCfg.put("probedCameraId", currentId);
-                                camCfg.put("probedSurfaceMode", cameraSurfaceMode);
-                                camCfg.put("probedAndValidated", true);
-                                com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                                com.overdrive.app.camera.CameraConfigResolver.persistPanoramicProbe(
+                                    currentId,
+                                    cameraSurfaceMode,
+                                    width,
+                                    height,
+                                    true,
+                                    false);
                             } else {
                                 logger.info("Skipping config write — manual override exists (saved=" + savedId + ", running=" + currentId + ")");
                             }
@@ -1403,12 +1406,13 @@ public class PanoramicCameraGpu {
                 }
                 // Persist this as a fallback so next restart doesn't re-probe
                 try {
-                    org.json.JSONObject camCfg = new org.json.JSONObject();
-                    camCfg.put("probedCameraId", lastDataCameraId);
-                    camCfg.put("probedSurfaceMode", 0);
-                    camCfg.put("probedAndValidated", true);
-                    camCfg.put("fallbackFromProbe", true);
-                    com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                    com.overdrive.app.camera.CameraConfigResolver.persistPanoramicProbe(
+                        lastDataCameraId,
+                        0,
+                        width,
+                        height,
+                        true,
+                        true);
                     logger.info("Persisted fallback camera ID " + lastDataCameraId + " for next launch");
                 } catch (Exception ex) {
                     logger.warn("Failed to persist fallback camera config: " + ex.getMessage());
@@ -2237,9 +2241,100 @@ public class PanoramicCameraGpu {
      * @return JPEG byte array, or null if not available
      */
     public byte[] getLatestJpegFrame(int cameraId) {
-        // This would need to be implemented by storing the latest extracted frame
-        // For now, return null (MJPEG streaming handles this via callback)
-        return null;
+        if (!running || glHandler == null || downscaler == null || cameraTextureId == 0 || !probeComplete) {
+            return null;
+        }
+
+        final Object lock = new Object();
+        final byte[][] resultHolder = new byte[1][];
+
+        glHandler.post(() -> {
+            try {
+                byte[] mosaicRgb = downscaler.readPixelsDirect(cameraTextureId);
+                if (mosaicRgb == null) {
+                    return;
+                }
+
+                final int mosaicWidth = 640;
+                final int mosaicHeight = 480;
+                final int quadrantWidth = mosaicWidth / 2;
+                final int quadrantHeight = mosaicHeight / 2;
+
+                int cropX = 0;
+                int cropY = 0;
+                int outputWidth = mosaicWidth;
+                int outputHeight = mosaicHeight;
+
+                switch (cameraId) {
+                    case 1: // Front (top-left)
+                        cropX = 0;
+                        cropY = 0;
+                        outputWidth = quadrantWidth;
+                        outputHeight = quadrantHeight;
+                        break;
+                    case 2: // Right (top-right)
+                        cropX = quadrantWidth;
+                        cropY = 0;
+                        outputWidth = quadrantWidth;
+                        outputHeight = quadrantHeight;
+                        break;
+                    case 3: // Rear (bottom-left)
+                        cropX = 0;
+                        cropY = quadrantHeight;
+                        outputWidth = quadrantWidth;
+                        outputHeight = quadrantHeight;
+                        break;
+                    case 4: // Left (bottom-right)
+                        cropX = quadrantWidth;
+                        cropY = quadrantHeight;
+                        outputWidth = quadrantWidth;
+                        outputHeight = quadrantHeight;
+                        break;
+                    case 0: // Full mosaic preview
+                    default:
+                        break;
+                }
+
+                int[] pixels = new int[outputWidth * outputHeight];
+                int dst = 0;
+                for (int y = 0; y < outputHeight; y++) {
+                    int srcY = cropY + y;
+                    for (int x = 0; x < outputWidth; x++) {
+                        int srcX = cropX + x;
+                        int srcIdx = (srcY * mosaicWidth + srcX) * 3;
+                        if (srcIdx + 2 >= mosaicRgb.length) {
+                            pixels[dst++] = 0xFF000000;
+                            continue;
+                        }
+                        int r = mosaicRgb[srcIdx] & 0xFF;
+                        int g = mosaicRgb[srcIdx + 1] & 0xFF;
+                        int b = mosaicRgb[srcIdx + 2] & 0xFF;
+                        pixels[dst++] = 0xFF000000 | (r << 16) | (g << 8) | b;
+                    }
+                }
+
+                Bitmap bitmap = Bitmap.createBitmap(pixels, outputWidth, outputHeight, Bitmap.Config.ARGB_8888);
+                java.io.ByteArrayOutputStream jpegOut = new java.io.ByteArrayOutputStream();
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 82, jpegOut);
+                bitmap.recycle();
+                resultHolder[0] = jpegOut.toByteArray();
+            } catch (Exception e) {
+                logger.warn("getLatestJpegFrame failed: " + e.getMessage());
+            } finally {
+                synchronized (lock) {
+                    lock.notifyAll();
+                }
+            }
+        });
+
+        synchronized (lock) {
+            try {
+                lock.wait(600);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return resultHolder[0];
     }
     
     /**

--- a/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
@@ -221,6 +221,7 @@ public class PanoramicCameraGpu {
     private static final int AI_READBACK_FRAME_MODULO = 3;
 
     private int targetFps = 15;  // Desired frame rate for camera
+    private final float[] quadrantStripOffsetX;
     
     /**
      * Creates a GPU-based panoramic camera.
@@ -229,8 +230,15 @@ public class PanoramicCameraGpu {
      * @param height Camera height (typically 960)
      */
     public PanoramicCameraGpu(int width, int height) {
+        this(width, height, null);
+    }
+
+    public PanoramicCameraGpu(int width, int height, float[] quadrantStripOffsetX) {
         this.width = width;
         this.height = height;
+        this.quadrantStripOffsetX = quadrantStripOffsetX != null && quadrantStripOffsetX.length == 4
+            ? quadrantStripOffsetX.clone()
+            : null;
     }
     
     /**
@@ -430,7 +438,7 @@ public class PanoramicCameraGpu {
         }
         
         // Initialize foveated cropper for high-res AI crops
-        foveatedCropper = new FoveatedCropper(width, height);
+        foveatedCropper = new FoveatedCropper(width, height, quadrantStripOffsetX);
         foveatedCropper.init();
         
         logger.info( "OpenGL initialized (texture=" + cameraTextureId + ")");

--- a/app/src/main/java/com/overdrive/app/camera/PanoramicSlice.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoramicSlice.java
@@ -1,0 +1,83 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Raw quarter-slice from the merged panoramic strip.
+ *
+ * These are intentionally neutral physical slices, not logical directions.
+ * Logical front/right/rear/left is derived by mapping camera roles to slices.
+ */
+public enum PanoramicSlice {
+    SLICE_1("slice1", "Merged slice 1", 0, 0.00f),
+    SLICE_2("slice2", "Merged slice 2", 1, 0.25f),
+    SLICE_3("slice3", "Merged slice 3", 2, 0.50f),
+    SLICE_4("slice4", "Merged slice 4", 3, 0.75f);
+
+    private final String id;
+    private final String displayName;
+    private final int index;
+    private final float stripOffsetX;
+
+    PanoramicSlice(String id, String displayName, int index, float stripOffsetX) {
+        this.id = id;
+        this.displayName = displayName;
+        this.index = index;
+        this.stripOffsetX = stripOffsetX;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public float getStripOffsetX() {
+        return stripOffsetX;
+    }
+
+    public JSONObject toJson() {
+        JSONObject out = new JSONObject();
+        putSafely(out, "id", id);
+        putSafely(out, "label", displayName);
+        putSafely(out, "index", index + 1);
+        putSafely(out, "offsetX", stripOffsetX);
+        return out;
+    }
+
+    public static PanoramicSlice fromId(String id) {
+        if (id == null) return null;
+        for (PanoramicSlice value : values()) {
+            if (value.id.equalsIgnoreCase(id)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    public static PanoramicSlice fromLegacyView(CameraVirtualView view) {
+        if (view == null) return null;
+        switch (view) {
+            case REAR:  return SLICE_1;
+            case LEFT:  return SLICE_2;
+            case RIGHT: return SLICE_3;
+            case FRONT:
+            default:    return SLICE_4;
+        }
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/ResolvedCameraConfig.java
+++ b/app/src/main/java/com/overdrive/app/camera/ResolvedCameraConfig.java
@@ -1,0 +1,112 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Fully resolved runtime camera configuration.
+ */
+public final class ResolvedCameraConfig {
+    private final CameraProfile profile;
+    private final String selectedProfileId;
+    private final boolean autoProfile;
+    private final int panoCameraId;
+    private final int panoWidth;
+    private final int panoHeight;
+    private final int panoSurfaceMode;
+    private final boolean manualPanoOverride;
+    private final boolean validated;
+    private final boolean fallbackFromProbe;
+    private final EnumMap<CameraRole, CameraSourceRef> roleMappings;
+
+    public ResolvedCameraConfig(
+            CameraProfile profile,
+            String selectedProfileId,
+            boolean autoProfile,
+            int panoCameraId,
+            int panoWidth,
+            int panoHeight,
+            int panoSurfaceMode,
+            boolean manualPanoOverride,
+            boolean validated,
+            boolean fallbackFromProbe,
+            Map<CameraRole, CameraSourceRef> roleMappings) {
+        this.profile = profile;
+        this.selectedProfileId = selectedProfileId;
+        this.autoProfile = autoProfile;
+        this.panoCameraId = panoCameraId;
+        this.panoWidth = panoWidth;
+        this.panoHeight = panoHeight;
+        this.panoSurfaceMode = panoSurfaceMode;
+        this.manualPanoOverride = manualPanoOverride;
+        this.validated = validated;
+        this.fallbackFromProbe = fallbackFromProbe;
+        this.roleMappings = new EnumMap<>(CameraRole.class);
+        if (roleMappings != null) {
+            this.roleMappings.putAll(roleMappings);
+        }
+    }
+
+    public CameraProfile getProfile() {
+        return profile;
+    }
+
+    public String getSelectedProfileId() {
+        return selectedProfileId;
+    }
+
+    public boolean isAutoProfile() {
+        return autoProfile;
+    }
+
+    public int getPanoCameraId() {
+        return panoCameraId;
+    }
+
+    public int getPanoWidth() {
+        return panoWidth;
+    }
+
+    public int getPanoHeight() {
+        return panoHeight;
+    }
+
+    public int getPanoSurfaceMode() {
+        return panoSurfaceMode;
+    }
+
+    public boolean isManualPanoOverride() {
+        return manualPanoOverride;
+    }
+
+    public boolean isValidated() {
+        return validated;
+    }
+
+    public boolean isFallbackFromProbe() {
+        return fallbackFromProbe;
+    }
+
+    public EnumMap<CameraRole, CameraSourceRef> getRoleMappings() {
+        return new EnumMap<>(roleMappings);
+    }
+
+    public JSONObject roleMappingsToJson() {
+        JSONObject out = new JSONObject();
+        for (Map.Entry<CameraRole, CameraSourceRef> entry : roleMappings.entrySet()) {
+            putSafely(out, entry.getKey().getKey(), entry.getValue().toJson());
+        }
+        return out;
+    }
+
+    private static void putSafely(JSONObject object, String key, Object value) {
+        try {
+            object.put(key, value);
+        } catch (JSONException e) {
+            throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/ResolvedCameraConfig.java
+++ b/app/src/main/java/com/overdrive/app/camera/ResolvedCameraConfig.java
@@ -4,7 +4,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Fully resolved runtime camera configuration.
@@ -92,6 +94,82 @@ public final class ResolvedCameraConfig {
 
     public EnumMap<CameraRole, CameraSourceRef> getRoleMappings() {
         return new EnumMap<>(roleMappings);
+    }
+
+    private EnumMap<CameraRole, PanoramicSlice> buildResolvedPanoramicSlices() {
+        EnumMap<CameraRole, PanoramicSlice> resolved = new EnumMap<>(CameraRole.class);
+        EnumMap<CameraRole, PanoramicSlice> defaults = new EnumMap<>(CameraRole.class);
+        Set<PanoramicSlice> used = new HashSet<>();
+        CameraRole[] panoRoles = new CameraRole[] {
+                CameraRole.PANO_FRONT,
+                CameraRole.PANO_RIGHT,
+                CameraRole.PANO_REAR,
+                CameraRole.PANO_LEFT
+        };
+
+        for (CameraRole role : panoRoles) {
+            CameraSourceRef defaultSource = profile.getDefaultRoleMappings().get(role);
+            if (defaultSource != null && defaultSource.getPanoramicSlice() != null) {
+                defaults.put(role, defaultSource.getPanoramicSlice());
+            }
+        }
+
+        for (CameraRole role : panoRoles) {
+            CameraSourceRef mappedSource = roleMappings.get(role);
+            PanoramicSlice slice = mappedSource != null ? mappedSource.getPanoramicSlice() : null;
+            if (slice != null && !used.contains(slice)) {
+                resolved.put(role, slice);
+                used.add(slice);
+            }
+        }
+
+        for (CameraRole role : panoRoles) {
+            if (resolved.containsKey(role)) continue;
+
+            PanoramicSlice fallback = defaults.get(role);
+            if (fallback != null && !used.contains(fallback)) {
+                resolved.put(role, fallback);
+                used.add(fallback);
+                continue;
+            }
+
+            for (PanoramicSlice candidate : PanoramicSlice.values()) {
+                if (!used.contains(candidate)) {
+                    resolved.put(role, candidate);
+                    used.add(candidate);
+                    break;
+                }
+            }
+
+            if (!resolved.containsKey(role) && fallback != null) {
+                resolved.put(role, fallback);
+            }
+        }
+
+        return resolved;
+    }
+
+    public PanoramicSlice getSliceForRole(CameraRole role) {
+        return buildResolvedPanoramicSlices().get(role);
+    }
+
+    public float[] getQuadrantStripOffsetX() {
+        EnumMap<CameraRole, PanoramicSlice> slices = buildResolvedPanoramicSlices();
+        return new float[] {
+            slices.get(CameraRole.PANO_FRONT).getStripOffsetX(),
+            slices.get(CameraRole.PANO_RIGHT).getStripOffsetX(),
+            slices.get(CameraRole.PANO_REAR).getStripOffsetX(),
+            slices.get(CameraRole.PANO_LEFT).getStripOffsetX()
+        };
+    }
+
+    public JSONObject panoramicSlicesToJson() {
+        EnumMap<CameraRole, PanoramicSlice> slices = buildResolvedPanoramicSlices();
+        JSONObject out = new JSONObject();
+        for (Map.Entry<CameraRole, PanoramicSlice> entry : slices.entrySet()) {
+            putSafely(out, entry.getKey().getKey(), entry.getValue().toJson());
+        }
+        return out;
     }
 
     public JSONObject roleMappingsToJson() {

--- a/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
+++ b/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
@@ -76,6 +76,7 @@ object UnifiedConfigManager {
         unified.put("recording", JSONObject())
         unified.put("streaming", JSONObject())
         unified.put("telegram", JSONObject())
+        unified.put("camera", JSONObject())
         unified.put("proximityGuard", JSONObject())
         unified.put("telemetryOverlay", JSONObject())
         unified.put("tripAnalytics", JSONObject())
@@ -178,6 +179,9 @@ object UnifiedConfigManager {
         val surveillance = config.getJSONObject("surveillance")
         val recording = config.getJSONObject("recording")
         val streaming = config.getJSONObject("streaming")
+        val camera = config.optJSONObject("camera") ?: JSONObject().also {
+            config.put("camera", it)
+        }
         val proximityGuard = config.optJSONObject("proximityGuard") ?: JSONObject().also { 
             config.put("proximityGuard", it) 
         }
@@ -209,6 +213,15 @@ object UnifiedConfigManager {
         
         // Streaming defaults
         if (!streaming.has("quality")) streaming.put("quality", "MEDIUM")
+
+        // Camera defaults. `cameraProfile=auto` lets the runtime resolver infer
+        // Tang vs legacy panoramic defaults from the vehicle model, while still
+        // preserving old installs that only know about `probedCameraId`.
+        if (!camera.has("cameraProfile")) camera.put("cameraProfile", com.overdrive.app.camera.CameraProfiles.PROFILE_AUTO)
+        if (!camera.has("targetFps")) camera.put("targetFps", 15)
+        if (!camera.has("probedCameraId")) camera.put("probedCameraId", -1)
+        if (!camera.has("probedSurfaceMode")) camera.put("probedSurfaceMode", -1)
+        if (!camera.has("roleMappings")) camera.put("roleMappings", JSONObject())
         
         // Proximity Guard defaults
         if (!proximityGuard.has("enabled")) proximityGuard.put("enabled", false)
@@ -709,6 +722,7 @@ object UnifiedConfigManager {
         config.put("recording", JSONObject())
         config.put("streaming", JSONObject())
         config.put("telegram", JSONObject())
+        config.put("camera", JSONObject())
         config.put("proximityGuard", JSONObject())
         config.put("telemetryOverlay", JSONObject())
         config.put("tripAnalytics", JSONObject())

--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -55,11 +55,15 @@ public class CameraDaemon {
     public static String STREAM_DIR() { return PATH_CAMERA_STREAM_DIR(); }
     public static final String APP_STREAM_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files/stream";
     
-    // Recording config (full quality)
-    public static final int PANO_WIDTH = 5120;
-    public static final int PANO_HEIGHT = 960;
-    public static final int VIEW_WIDTH = 1280;
-    public static final int VIEW_HEIGHT = 960;
+    // Recording config defaults. Runtime panoramic geometry comes from
+    // CameraConfigResolver; these stay as legacy-profile fallbacks for code
+    // paths that still read the daemon constants directly.
+    public static final int PANO_WIDTH = com.overdrive.app.camera.CameraProfiles
+        .getLegacyDefault().getPanoWidth();
+    public static final int PANO_HEIGHT = com.overdrive.app.camera.CameraProfiles
+        .getLegacyDefault().getPanoHeight();
+    public static final int VIEW_WIDTH = PANO_WIDTH / 4;
+    public static final int VIEW_HEIGHT = PANO_HEIGHT;
     public static final int FRAME_RATE = 25;
     public static final int BITRATE = 4_000_000;
     public static final int KEYFRAME_INTERVAL = 2;
@@ -1211,6 +1215,8 @@ public class CameraDaemon {
     private static void initSurveillance() {
         try {
             log("Initializing GPU Surveillance Pipeline...");
+            com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+                com.overdrive.app.camera.CameraConfigResolver.resolve();
             
             // SOTA: Use StorageManager for surveillance output directory
             com.overdrive.app.storage.StorageManager storageManager =
@@ -1219,7 +1225,7 @@ public class CameraDaemon {
             
             // Create GPU pipeline
             gpuPipeline = new com.overdrive.app.surveillance.GpuSurveillancePipeline(
-                PANO_WIDTH, PANO_HEIGHT, eventDir);
+                resolvedCamera.getPanoWidth(), resolvedCamera.getPanoHeight(), eventDir);
             
             // Get AssetManager from the app's APK
             // Since we're running as app_process, load model from filesystem
@@ -1307,8 +1313,10 @@ public class CameraDaemon {
             
             gpuPipeline.init(assetManager, com.overdrive.app.daemon.DaemonBootstrap.getContext());
             
-            log("GPU Surveillance initialized: " + PANO_WIDTH + "x" + PANO_HEIGHT + 
-                " -> 2560x1920 (mosaic)");
+            log("GPU Surveillance initialized: profile=" + resolvedCamera.getProfile().getDisplayName()
+                + ", panoCam=" + resolvedCamera.getPanoCameraId()
+                + ", size=" + resolvedCamera.getPanoWidth() + "x" + resolvedCamera.getPanoHeight()
+                + " -> 2560x1920 (mosaic)");
             
             // Clean up orphaned .tmp files from previous crashed recordings
             try {

--- a/app/src/main/java/com/overdrive/app/daemon/camera/CameraConfiguration.kt
+++ b/app/src/main/java/com/overdrive/app/daemon/camera/CameraConfiguration.kt
@@ -1,5 +1,7 @@
 package com.overdrive.app.daemon.camera
 
+import com.overdrive.app.camera.CameraProfiles
+
 /**
  * Camera configuration constants.
  * 
@@ -17,10 +19,10 @@ object CameraConfiguration {
     const val DEFAULT_OUTPUT_DIR = "/sdcard/DCIM/BYDCam"
     
     // Recording config (full quality)
-    const val PANO_WIDTH = 5120
-    const val PANO_HEIGHT = 960
-    const val VIEW_WIDTH = 1280
-    const val VIEW_HEIGHT = 960
+    val PANO_WIDTH = CameraProfiles.getLegacyDefault().panoWidth
+    val PANO_HEIGHT = CameraProfiles.getLegacyDefault().panoHeight
+    val VIEW_WIDTH = PANO_WIDTH / 4
+    val VIEW_HEIGHT = PANO_HEIGHT
     const val FRAME_RATE = 25
     const val BITRATE = 4_000_000
     const val KEYFRAME_INTERVAL = 2

--- a/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
@@ -1016,6 +1016,19 @@ public class SurveillanceApiHandler {
             int height = safeParseInt(getQueryParam(path, "height"), resolvedCamera.getProfile().getDirectPreviewHeight());
             jpegBytes = com.overdrive.app.camera.CameraPreviewHelper
                 .captureDirectPreviewJpeg(cameraId, width, height);
+        } else if ("panoramicSlice".equalsIgnoreCase(kind)) {
+            com.overdrive.app.camera.PanoramicSlice slice = com.overdrive.app.camera.PanoramicSlice
+                .fromId(getQueryParam(path, "slice"));
+            if (slice == null) {
+                HttpResponse.sendJsonError(out, "Invalid panoramic slice");
+                return;
+            }
+            jpegBytes = com.overdrive.app.camera.CameraPreviewHelper.capturePanoramicSliceJpeg(
+                resolvedCamera.getPanoCameraId(),
+                resolvedCamera.getPanoWidth(),
+                resolvedCamera.getPanoHeight(),
+                slice
+            );
         } else {
             com.overdrive.app.camera.CameraVirtualView view = com.overdrive.app.camera.CameraVirtualView
                 .fromId(getQueryParam(path, "view"));

--- a/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
@@ -68,6 +68,10 @@ public class SurveillanceApiHandler {
             sendFilterLog(out);
             return true;
         }
+        if (cleanPath.equals("/api/surveillance/camera-preview")) {
+            sendCameraPreview(path, out);
+            return true;
+        }
         return false;
     }
     
@@ -318,6 +322,20 @@ public class SurveillanceApiHandler {
             config.put("telegramSendStartPing", false);
             config.put("shadowFilter", 2);
         }
+
+        try {
+            com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+                com.overdrive.app.camera.CameraConfigResolver.resolve();
+            JSONObject resolvedJson = com.overdrive.app.camera.CameraConfigResolver
+                .resolvedSummaryJson(resolvedCamera);
+            java.util.Iterator<String> keys = resolvedJson.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                config.put(key, resolvedJson.get(key));
+            }
+        } catch (Exception e) {
+            CameraDaemon.log("Failed to resolve camera profile summary: " + e.getMessage());
+        }
         
         response.put("config", config);
         HttpResponse.sendJson(out, response.toString());
@@ -338,6 +356,44 @@ public class SurveillanceApiHandler {
         
         try {
             JSONObject configJson = new JSONObject(body);
+            boolean cameraConfigChanged = false;
+
+            if (configJson.has("cameraProfile") || configJson.optBoolean("clearCameraProfile", false)) {
+                String requestedProfile = configJson.optBoolean("clearCameraProfile", false)
+                    ? com.overdrive.app.camera.CameraProfiles.PROFILE_AUTO
+                    : configJson.optString("cameraProfile", com.overdrive.app.camera.CameraProfiles.PROFILE_AUTO);
+                if (com.overdrive.app.camera.CameraConfigResolver.saveCameraProfile(requestedProfile)) {
+                    cameraConfigChanged = true;
+                    CameraDaemon.log("Camera profile saved: " + requestedProfile);
+                }
+            }
+
+            if (configJson.has("cameraRoleMapping")) {
+                JSONObject mappingJson = configJson.optJSONObject("cameraRoleMapping");
+                if (mappingJson != null) {
+                    com.overdrive.app.camera.CameraRole role = com.overdrive.app.camera.CameraRole
+                        .fromKey(mappingJson.optString("role", null));
+                    if (role != null) {
+                        if (mappingJson.optBoolean("clear", false)) {
+                            if (com.overdrive.app.camera.CameraConfigResolver.clearRoleMapping(role)) {
+                                cameraConfigChanged = true;
+                            }
+                        } else {
+                            com.overdrive.app.camera.CameraSourceRef source = com.overdrive.app.camera.CameraSourceRef
+                                .fromJson(mappingJson.optJSONObject("source"));
+                            if (source != null && com.overdrive.app.camera.CameraConfigResolver.saveRoleMapping(role, source)) {
+                                cameraConfigChanged = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if (configJson.optBoolean("clearCameraRoleMappings", false)) {
+                for (com.overdrive.app.camera.CameraRole role : com.overdrive.app.camera.CameraRole.values()) {
+                    com.overdrive.app.camera.CameraConfigResolver.clearRoleMapping(role);
+                }
+                cameraConfigChanged = true;
+            }
             
             SurveillanceEngineGpu sentry = null;
             if (gpuPipeline != null) {
@@ -826,9 +882,13 @@ public class SurveillanceApiHandler {
                 int camId = configJson.optInt("manualCameraId", -1);
                 if (camId >= 0 && camId <= 5) {
                     try {
+                        com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+                            com.overdrive.app.camera.CameraConfigResolver.resolve();
                         org.json.JSONObject camCfg = new org.json.JSONObject();
                         camCfg.put("probedCameraId", camId);
-                        camCfg.put("probedSurfaceMode", 0);
+                        camCfg.put("probedSurfaceMode", resolvedCamera.getPanoSurfaceMode());
+                        camCfg.put("probedWidth", resolvedCamera.getPanoWidth());
+                        camCfg.put("probedHeight", resolvedCamera.getPanoHeight());
                         camCfg.put("probedAndValidated", true);
                         camCfg.put("manualOverride", true);
                         com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
@@ -836,14 +896,18 @@ public class SurveillanceApiHandler {
                     } catch (Exception e) {
                         CameraDaemon.log("Failed to save manual camera ID: " + e.getMessage());
                     }
-                    configChanged = true;
+                    cameraConfigChanged = true;
                 }
             }
             if (configJson.has("clearManualCameraId") && configJson.optBoolean("clearManualCameraId", false)) {
                 try {
+                    com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+                        com.overdrive.app.camera.CameraConfigResolver.resolve();
                     org.json.JSONObject camCfg = new org.json.JSONObject();
                     camCfg.put("probedCameraId", -1);
                     camCfg.put("probedSurfaceMode", -1);
+                    camCfg.put("probedWidth", resolvedCamera.getPanoWidth());
+                    camCfg.put("probedHeight", resolvedCamera.getPanoHeight());
                     camCfg.put("probedAndValidated", false);
                     camCfg.put("manualOverride", false);
                     com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
@@ -851,7 +915,7 @@ public class SurveillanceApiHandler {
                 } catch (Exception e) {
                     CameraDaemon.log("Failed to clear manual camera ID: " + e.getMessage());
                 }
-                configChanged = true;
+                cameraConfigChanged = true;
             }
             
             if (configChanged) {
@@ -933,6 +997,86 @@ public class SurveillanceApiHandler {
         } catch (Exception e) {
             CameraDaemon.log("Error applying surveillance config: " + e.getMessage());
             HttpResponse.sendJsonError(out, e.getMessage());
+        }
+    }
+
+    private static void sendCameraPreview(String path, OutputStream out) throws Exception {
+        com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+            com.overdrive.app.camera.CameraConfigResolver.resolve();
+        String kind = getQueryParam(path, "kind");
+        byte[] jpegBytes = null;
+
+        if ("direct".equalsIgnoreCase(kind)) {
+            int cameraId = safeParseInt(getQueryParam(path, "cameraId"), -1);
+            if (cameraId < 0 || cameraId > 5) {
+                HttpResponse.sendJsonError(out, "Invalid direct camera ID");
+                return;
+            }
+            int width = safeParseInt(getQueryParam(path, "width"), resolvedCamera.getProfile().getDirectPreviewWidth());
+            int height = safeParseInt(getQueryParam(path, "height"), resolvedCamera.getProfile().getDirectPreviewHeight());
+            jpegBytes = com.overdrive.app.camera.CameraPreviewHelper
+                .captureDirectPreviewJpeg(cameraId, width, height);
+        } else {
+            com.overdrive.app.camera.CameraVirtualView view = com.overdrive.app.camera.CameraVirtualView
+                .fromId(getQueryParam(path, "view"));
+            if (view == null) {
+                HttpResponse.sendJsonError(out, "Invalid panoramic view");
+                return;
+            }
+            GpuSurveillancePipeline gpuPipeline = CameraDaemon.getGpuPipeline();
+            if (gpuPipeline == null) {
+                HttpResponse.sendJsonError(out, "GPU pipeline unavailable");
+                return;
+            }
+            try {
+                if (!gpuPipeline.isRunning()) {
+                    gpuPipeline.start(false);
+                    Thread.sleep(1200);
+                }
+            } catch (Exception e) {
+                CameraDaemon.log("Camera preview auto-start failed: " + e.getMessage());
+            }
+            if (gpuPipeline.getCamera() != null) {
+                jpegBytes = gpuPipeline.getCamera().getLatestJpegFrame(view.getStreamViewMode());
+            }
+        }
+
+        if (jpegBytes == null || jpegBytes.length == 0) {
+            HttpResponse.sendJsonError(out, "Preview unavailable");
+            return;
+        }
+
+        String header = "HTTP/1.1 200 OK\r\n" +
+                "Content-Type: image/jpeg\r\n" +
+                "Content-Length: " + jpegBytes.length + "\r\n" +
+                "Cache-Control: no-cache\r\n" +
+                "Access-Control-Allow-Origin: *\r\n" +
+                "\r\n";
+        out.write(header.getBytes());
+        out.write(jpegBytes);
+        out.flush();
+    }
+
+    private static String getQueryParam(String path, String key) {
+        if (path == null) return null;
+        int queryStart = path.indexOf('?');
+        if (queryStart < 0 || queryStart >= path.length() - 1) return null;
+        String[] pairs = path.substring(queryStart + 1).split("&");
+        for (String pair : pairs) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2 && key.equalsIgnoreCase(kv[0])) {
+                return java.net.URLDecoder.decode(kv[1], java.nio.charset.StandardCharsets.UTF_8);
+            }
+        }
+        return null;
+    }
+
+    private static int safeParseInt(String value, int defaultValue) {
+        if (value == null) return defaultValue;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
         }
     }
     

--- a/app/src/main/java/com/overdrive/app/streaming/GpuStreamScaler.java
+++ b/app/src/main/java/com/overdrive/app/streaming/GpuStreamScaler.java
@@ -10,6 +10,7 @@ import android.opengl.EGLSurface;
 import android.view.Surface;
 
 import java.nio.FloatBuffer;
+import java.util.Locale;
 
 /**
  * GpuStreamScaler - GPU-based downscaler for H.264 streaming.
@@ -51,6 +52,12 @@ public class GpuStreamScaler {
     // Configuration
     private final int outputWidth;
     private final int outputHeight;
+    private final float[] quadrantStripOffsetX;
+    private final String fragmentShader;
+
+    private static final float[] DEFAULT_QUADRANT_STRIP_OFFSET_X = {
+        0.75f, 0.50f, 0.00f, 0.25f
+    };
     
     // Fullscreen quad vertices
     private static final float[] VERTEX_COORDS = {
@@ -131,6 +138,15 @@ public class GpuStreamScaler {
     public GpuStreamScaler(int outputWidth, int outputHeight) {
         this.outputWidth = outputWidth;
         this.outputHeight = outputHeight;
+        this.quadrantStripOffsetX = DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
+    }
+
+    public GpuStreamScaler(int outputWidth, int outputHeight, float[] quadrantStripOffsetX) {
+        this.outputWidth = outputWidth;
+        this.outputHeight = outputHeight;
+        this.quadrantStripOffsetX = normalizeOffsets(quadrantStripOffsetX);
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
     }
     
     public int getWidth() { return outputWidth; }
@@ -155,7 +171,7 @@ public class GpuStreamScaler {
         encoderSurface = eglCore.createWindowSurface(encoderInputSurface);
         
         // Compile shaders
-        programId = GlUtil.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        programId = GlUtil.createProgram(VERTEX_SHADER, fragmentShader);
         if (programId == 0) {
             throw new RuntimeException("Failed to create shader program");
         }
@@ -269,5 +285,67 @@ public class GpuStreamScaler {
         }
         
         logger.info("GpuStreamScaler released");
+    }
+
+    private static float[] normalizeOffsets(float[] quadrantStripOffsetX) {
+        if (quadrantStripOffsetX == null || quadrantStripOffsetX.length != 4) {
+            return DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+        }
+        return quadrantStripOffsetX.clone();
+    }
+
+    private static String buildFragmentShader(float[] offsets) {
+        return String.format(Locale.US,
+            "#extension GL_OES_EGL_image_external : require\n" +
+            "precision mediump float;\n" +
+            "uniform samplerExternalOES uCameraTex;\n" +
+            "uniform int uViewMode;\n" +
+            "uniform float uApaMode;\n" +
+            "varying vec2 vTexCoord;\n" +
+            "void main() {\n" +
+            "    vec2 samplePos;\n" +
+            "    float frontOffset = %.5ff;\n" +
+            "    float rightOffset = %.5ff;\n" +
+            "    float rearOffset = %.5ff;\n" +
+            "    float leftOffset = %.5ff;\n" +
+            "    if (uViewMode == 5) {\n" +
+            "        samplePos = vTexCoord;\n" +
+            "    } else if (uApaMode > 1.5) {\n" +
+            "        if (uViewMode == 1) { samplePos = vec2(0.75 + vTexCoord.x * 0.25, vTexCoord.y); }\n" +
+            "        else if (uViewMode == 3) { samplePos = vec2(vTexCoord.x * 0.25, vTexCoord.y); }\n" +
+            "        else if (uViewMode == 2 || uViewMode == 4) { samplePos = vec2(0.25 + vTexCoord.x * 0.5, vTexCoord.y); }\n" +
+            "        else {\n" +
+            "            if (vTexCoord.x < 0.5) {\n" +
+            "                float lx = vTexCoord.x * 0.5;\n" +
+            "                float ly = mod(vTexCoord.y, 0.5) * 2.0;\n" +
+            "                if (vTexCoord.y < 0.5) { samplePos = vec2(lx + 0.75, ly); }\n" +
+            "                else { samplePos = vec2(lx, ly); }\n" +
+            "            } else {\n" +
+            "                samplePos = vec2(0.25 + (vTexCoord.x - 0.5) * 1.0 * 0.5, vTexCoord.y);\n" +
+            "            }\n" +
+            "        }\n" +
+            "    } else if (uApaMode > 0.5) {\n" +
+            "        samplePos = vTexCoord;\n" +
+            "    } else if (uViewMode == 0) {\n" +
+            "        vec2 gridPos = step(0.5, vTexCoord);\n" +
+            "        float stripOffsetX;\n" +
+            "        if (gridPos.x < 0.5) {\n" +
+            "            stripOffsetX = gridPos.y < 0.5 ? frontOffset : rearOffset;\n" +
+            "        } else {\n" +
+            "            stripOffsetX = gridPos.y < 0.5 ? rightOffset : leftOffset;\n" +
+            "        }\n" +
+            "        float localX = mod(vTexCoord.x, 0.5) * 0.5;\n" +
+            "        float localY = mod(vTexCoord.y, 0.5) * 2.0;\n" +
+            "        samplePos = vec2(localX + stripOffsetX, localY);\n" +
+            "    } else {\n" +
+            "        float startX = frontOffset;\n" +
+            "        if (uViewMode == 2) startX = rightOffset;\n" +
+            "        else if (uViewMode == 3) startX = rearOffset;\n" +
+            "        else if (uViewMode == 4) startX = leftOffset;\n" +
+            "        samplePos = vec2(startX + (vTexCoord.x * 0.25), vTexCoord.y);\n" +
+            "    }\n" +
+            "    gl_FragColor = texture2D(uCameraTex, samplePos);\n" +
+            "}\n",
+            offsets[0], offsets[1], offsets[2], offsets[3]);
     }
 }

--- a/app/src/main/java/com/overdrive/app/surveillance/FoveatedCropper.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/FoveatedCropper.java
@@ -64,12 +64,10 @@ public class FoveatedCropper {
     // Output crop size — matches YOLO input
     public static final int CROP_SIZE = 640;
 
-    // Source strip dimensions
-    private static final int STRIP_WIDTH = 5120;
-    private static final int STRIP_HEIGHT = 960;
-
-    // Each camera occupies 1/4 of the strip = 1280×960
-    private static final int CAM_WIDTH = 1280;
+    // Source strip dimensions (runtime-resolved per camera profile).
+    private final int stripWidth;
+    private final int stripHeight;
+    private final float[] quadrantStripOffsetX;
 
     // GL resources
     private int fbo = -1;
@@ -145,12 +143,28 @@ public class FoveatedCropper {
      *
      * QUADRANT_NAMES = ["front", "right", "rear", "left"]
      */
-    private static final float[] QUADRANT_STRIP_OFFSET_X = {
+    private static final float[] DEFAULT_QUADRANT_STRIP_OFFSET_X = {
         0.75f,  // Q0 (TL → Front)
         0.50f,  // Q1 (TR → Right)
         0.00f,  // Q2 (BL → Rear)
         0.25f   // Q3 (BR → Left)
     };
+
+    public FoveatedCropper() {
+        this(5120, 960, DEFAULT_QUADRANT_STRIP_OFFSET_X);
+    }
+
+    public FoveatedCropper(int stripWidth, int stripHeight) {
+        this(stripWidth, stripHeight, DEFAULT_QUADRANT_STRIP_OFFSET_X);
+    }
+
+    public FoveatedCropper(int stripWidth, int stripHeight, float[] quadrantStripOffsetX) {
+        this.stripWidth = Math.max(1, stripWidth);
+        this.stripHeight = Math.max(1, stripHeight);
+        this.quadrantStripOffsetX = quadrantStripOffsetX != null && quadrantStripOffsetX.length == 4
+            ? quadrantStripOffsetX.clone()
+            : DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+    }
 
     /**
      * Initialize the FBO and shader. Must be called on the GL thread.
@@ -236,12 +250,11 @@ public class FoveatedCropper {
 
         // Step 3: Compute the crop window in the full 5120×960 strip.
         // Each camera occupies 0.25 of the strip width.
-        float stripOffsetX = QUADRANT_STRIP_OFFSET_X[quadrant];
+        float stripOffsetX = quadrantStripOffsetX[quadrant];
 
-        // The crop window is 640×640 pixels from the 5120×960 strip.
-        // In normalized strip coords: width = 640/5120 = 0.125, height = 640/960 = 0.667
-        float cropWidthNorm = (float) CROP_SIZE / STRIP_WIDTH;   // 0.125
-        float cropHeightNorm = (float) CROP_SIZE / STRIP_HEIGHT; // 0.6667
+        // The crop window is 640×640 pixels from the full panoramic strip.
+        float cropWidthNorm = (float) CROP_SIZE / stripWidth;
+        float cropHeightNorm = (float) CROP_SIZE / stripHeight;
 
         // Center the crop on the centroid within this camera's strip region.
         // Camera region in strip: [stripOffsetX, stripOffsetX + 0.25] × [0, 1]

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuDownscaler.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuDownscaler.java
@@ -18,6 +18,7 @@ import com.overdrive.app.camera.GlUtil;
 
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
+import java.util.Locale;
 
 /**
  * AsyncGpuDownscaler - Zero-stutter GPU thumbnail generator.
@@ -69,6 +70,8 @@ public class GpuDownscaler {
     
     // Shared context from main thread
     private EGLContext sharedContext;
+    private final float[] quadrantStripOffsetX;
+    private final String fragmentShader;
     
     // Shader program
     private int programId;
@@ -109,23 +112,9 @@ public class GpuDownscaler {
         "    vTexCoord = aTexCoord;\n" +
         "}\n";
     
-    // Fragment shader - mosaic transformation (5120x960 strip → 2x2 grid)
-    // Grid layout: TL=Front, TR=Right, BL=Rear, BR=Left
-    // Strip layout: cam1(Rear)=0.00, cam2(Left)=0.25, cam3(Right)=0.50, cam4(Front)=0.75
-    private static final String FRAGMENT_SHADER =
-        "#extension GL_OES_EGL_image_external : require\n" +
-        "precision mediump float;\n" +
-        "uniform samplerExternalOES uCameraTex;\n" +
-        "varying vec2 vTexCoord;\n" +
-        "void main() {\n" +
-        "    vec2 gridPos = step(0.5, vTexCoord);\n" +
-        "    // TL=Front(0.75), TR=Right(0.50), BL=Rear(0.00), BR=Left(0.25)\n" +
-        "    float stripOffsetX = 0.75 - (gridPos.x * 0.25) - (gridPos.y * 0.75) + (gridPos.x * gridPos.y * 0.50);\n" +
-        "    float localX = mod(vTexCoord.x, 0.5) * 0.5;\n" +
-        "    float localY = mod(vTexCoord.y, 0.5) * 2.0;\n" +
-        "    vec2 samplePos = vec2(localX + stripOffsetX, localY);\n" +
-        "    gl_FragColor = texture2D(uCameraTex, samplePos);\n" +
-        "}\n";
+    private static final float[] DEFAULT_QUADRANT_STRIP_OFFSET_X = {
+        0.75f, 0.50f, 0.00f, 0.25f
+    };
 
     /**
      * Creates the async downscaler with shared EGL context.
@@ -133,7 +122,13 @@ public class GpuDownscaler {
      * @param mainThreadContext EGL context from main render thread (for texture sharing)
      */
     public GpuDownscaler(EGLContext mainThreadContext) {
+        this(mainThreadContext, null);
+    }
+
+    public GpuDownscaler(EGLContext mainThreadContext, float[] quadrantStripOffsetX) {
         this.sharedContext = mainThreadContext;
+        this.quadrantStripOffsetX = normalizeOffsets(quadrantStripOffsetX);
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
         
         // Start background thread
         renderThread = new HandlerThread("GpuDownscalerThread");
@@ -148,7 +143,15 @@ public class GpuDownscaler {
      * Default constructor - call init() later with context.
      */
     public GpuDownscaler() {
-        // Will be initialized via init()
+        this.sharedContext = null;
+        this.quadrantStripOffsetX = DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
+    }
+
+    public GpuDownscaler(float[] quadrantStripOffsetX) {
+        this.sharedContext = null;
+        this.quadrantStripOffsetX = normalizeOffsets(quadrantStripOffsetX);
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
     }
     
     /**
@@ -245,7 +248,7 @@ public class GpuDownscaler {
     }
     
     private void setupShaders() {
-        programId = GlUtil.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        programId = GlUtil.createProgram(VERTEX_SHADER, fragmentShader);
         if (programId == 0) {
             throw new RuntimeException("Failed to create shader program");
         }
@@ -527,7 +530,7 @@ public class GpuDownscaler {
     
     private void initDirectFbo() {
         try {
-            directProgram = GlUtil.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+            directProgram = GlUtil.createProgram(VERTEX_SHADER, fragmentShader);
             if (directProgram == 0) { logger.error("Direct FBO shader failed"); return; }
             directAPosition = GLES20.glGetAttribLocation(directProgram, "aPosition");
             directATexCoord = GLES20.glGetAttribLocation(directProgram, "aTexCoord");
@@ -678,5 +681,38 @@ public class GpuDownscaler {
         }
         
         logger.info("AsyncGpuDownscaler released");
+    }
+
+    private static float[] normalizeOffsets(float[] quadrantStripOffsetX) {
+        if (quadrantStripOffsetX == null || quadrantStripOffsetX.length != 4) {
+            return DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+        }
+        return quadrantStripOffsetX.clone();
+    }
+
+    private static String buildFragmentShader(float[] offsets) {
+        return String.format(Locale.US,
+            "#extension GL_OES_EGL_image_external : require\n" +
+            "precision mediump float;\n" +
+            "uniform samplerExternalOES uCameraTex;\n" +
+            "varying vec2 vTexCoord;\n" +
+            "void main() {\n" +
+            "    vec2 gridPos = step(0.5, vTexCoord);\n" +
+            "    float tlOffset = %.5ff;\n" +
+            "    float trOffset = %.5ff;\n" +
+            "    float blOffset = %.5ff;\n" +
+            "    float brOffset = %.5ff;\n" +
+            "    float stripOffsetX;\n" +
+            "    if (gridPos.x < 0.5) {\n" +
+            "        stripOffsetX = gridPos.y < 0.5 ? tlOffset : blOffset;\n" +
+            "    } else {\n" +
+            "        stripOffsetX = gridPos.y < 0.5 ? trOffset : brOffset;\n" +
+            "    }\n" +
+            "    float localX = mod(vTexCoord.x, 0.5) * 0.5;\n" +
+            "    float localY = mod(vTexCoord.y, 0.5) * 2.0;\n" +
+            "    vec2 samplePos = vec2(localX + stripOffsetX, localY);\n" +
+            "    gl_FragColor = texture2D(uCameraTex, samplePos);\n" +
+            "}\n",
+            offsets[0], offsets[1], offsets[2], offsets[3]);
     }
 }

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuMosaicRecorder.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuMosaicRecorder.java
@@ -14,6 +14,7 @@ import com.overdrive.app.telemetry.TelemetryDataCollector;
 import com.overdrive.app.telemetry.TelemetrySnapshot;
 
 import java.nio.FloatBuffer;
+import java.util.Locale;
 
 /**
  * GpuMosaicRecorder - GPU-based 2x2 grid compositor for zero-copy recording.
@@ -104,6 +105,8 @@ public class GpuMosaicRecorder {
     private int consecutiveSurfaceErrors = 0;
     private static final int SURFACE_ERROR_REINIT_THRESHOLD = 3;
     private volatile boolean needsReinit = false;
+    private final float[] quadrantStripOffsetX;
+    private final String fragmentShader;
     
     // Fullscreen quad vertices (NDC coordinates)
     private static final float[] VERTEX_COORDS = {
@@ -119,6 +122,10 @@ public class GpuMosaicRecorder {
         1.0f, 1.0f,  // Bottom-right (flipped to top-right)
         0.0f, 0.0f,  // Top-left (flipped to bottom-left)
         1.0f, 0.0f   // Top-right (flipped to bottom-right)
+    };
+
+    private static final float[] DEFAULT_QUADRANT_STRIP_OFFSET_X = {
+        0.75f, 0.50f, 0.00f, 0.25f
     };
     
     // Vertex shader - simple passthrough
@@ -193,6 +200,15 @@ public class GpuMosaicRecorder {
         "void main() {\n" +
         "    gl_FragColor = texture2D(uTexture, vTexCoord);\n" +
         "}\n";
+
+    public GpuMosaicRecorder() {
+        this(null);
+    }
+
+    public GpuMosaicRecorder(float[] quadrantStripOffsetX) {
+        this.quadrantStripOffsetX = normalizeOffsets(quadrantStripOffsetX);
+        this.fragmentShader = buildFragmentShader(this.quadrantStripOffsetX);
+    }
     
     /**
      * Initializes the GPU mosaic recorder.
@@ -264,7 +280,7 @@ public class GpuMosaicRecorder {
         encoderSurface = eglCore.createWindowSurface(encoderInputSurface);
         
         // Compile shaders and create program
-        programId = GlUtil.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        programId = GlUtil.createProgram(VERTEX_SHADER, fragmentShader);
         if (programId == 0) {
             throw new RuntimeException("Failed to create shader program");
         }
@@ -777,6 +793,58 @@ public class GpuMosaicRecorder {
     
     public void setApaMode(boolean apa) {
         setCameraLayout(apa ? 1 : 0);
+    }
+
+    private static float[] normalizeOffsets(float[] quadrantStripOffsetX) {
+        if (quadrantStripOffsetX == null || quadrantStripOffsetX.length != 4) {
+            return DEFAULT_QUADRANT_STRIP_OFFSET_X.clone();
+        }
+        return quadrantStripOffsetX.clone();
+    }
+
+    private static String buildFragmentShader(float[] offsets) {
+        return String.format(Locale.US,
+            "#extension GL_OES_EGL_image_external : require\n" +
+            "precision mediump float;\n" +
+            "uniform samplerExternalOES uCameraTex;\n" +
+            "uniform float uApaMode;\n" +
+            "varying vec2 vTexCoord;\n" +
+            "void main() {\n" +
+            "    vec2 samplePos;\n" +
+            "    if (uApaMode > 1.5) {\n" +
+            "        if (vTexCoord.x < 0.5) {\n" +
+            "            float localX = vTexCoord.x * 0.5;\n" +
+            "            float localY = mod(vTexCoord.y, 0.5) * 2.0;\n" +
+            "            if (vTexCoord.y < 0.5) {\n" +
+            "                samplePos = vec2(localX + 0.75, localY);\n" +
+            "            } else {\n" +
+            "                samplePos = vec2(localX, localY);\n" +
+            "            }\n" +
+            "        } else {\n" +
+            "            float localX = (vTexCoord.x - 0.5) * 1.0;\n" +
+            "            samplePos = vec2(0.25 + localX * 0.5, vTexCoord.y);\n" +
+            "        }\n" +
+            "    } else if (uApaMode > 0.5) {\n" +
+            "        samplePos = vTexCoord;\n" +
+            "    } else {\n" +
+            "        vec2 gridPos = step(0.5, vTexCoord);\n" +
+            "        float tlOffset = %.5ff;\n" +
+            "        float trOffset = %.5ff;\n" +
+            "        float blOffset = %.5ff;\n" +
+            "        float brOffset = %.5ff;\n" +
+            "        float stripOffsetX;\n" +
+            "        if (gridPos.x < 0.5) {\n" +
+            "            stripOffsetX = gridPos.y < 0.5 ? tlOffset : blOffset;\n" +
+            "        } else {\n" +
+            "            stripOffsetX = gridPos.y < 0.5 ? trOffset : brOffset;\n" +
+            "        }\n" +
+            "        float localX = mod(vTexCoord.x, 0.5) * 0.5;\n" +
+            "        float localY = mod(vTexCoord.y, 0.5) * 2.0;\n" +
+            "        samplePos = vec2(localX + stripOffsetX, localY);\n" +
+            "    }\n" +
+            "    gl_FragColor = texture2D(uCameraTex, samplePos);\n" +
+            "}\n",
+            offsets[0], offsets[1], offsets[2], offsets[3]);
     }
     
     // (TBC timestamp is computed inline in drawFrame)

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuPipelineFactory.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuPipelineFactory.java
@@ -13,12 +13,14 @@ import java.io.File;
 public class GpuPipelineFactory {
     private static final String TAG = "GpuPipelineFactory";
     private static final DaemonLogger logger = DaemonLogger.getInstance(TAG);
+    private static final com.overdrive.app.camera.CameraProfile LEGACY_PROFILE =
+        com.overdrive.app.camera.CameraProfiles.getLegacyDefault();
     
     /**
      * Creates a complete GPU surveillance pipeline with default settings.
      * 
      * Configuration:
-     * - Camera: 5120x960 @ 30 FPS
+    * - Camera: legacy-profile panoramic resolution @ 30 FPS
      * - Encoder: 2560x1920 @ 15 FPS, 6 Mbps
      * - AI: 320x240 @ 2 FPS (idle), 5 FPS (active)
      * - Thermal protection enabled
@@ -28,7 +30,10 @@ public class GpuPipelineFactory {
      * @return Configured GpuSurveillancePipeline
      */
     public static GpuSurveillancePipeline createDefault(File eventOutputDir) {
-        return new GpuSurveillancePipeline(5120, 960, eventOutputDir);
+        return new GpuSurveillancePipeline(
+            LEGACY_PROFILE.getPanoWidth(),
+            LEGACY_PROFILE.getPanoHeight(),
+            eventOutputDir);
     }
     
     /**
@@ -78,8 +83,8 @@ public class GpuPipelineFactory {
      * Builder for custom GPU pipeline configuration.
      */
     public static class PipelineBuilder {
-        private int cameraWidth = 5120;
-        private int cameraHeight = 960;
+        private int cameraWidth = LEGACY_PROFILE.getPanoWidth();
+        private int cameraHeight = LEGACY_PROFILE.getPanoHeight();
         private int encoderWidth = 2560;
         private int encoderHeight = 1920;
         private int fps = 15;

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
@@ -637,8 +637,12 @@ public class GpuSurveillancePipeline {
 
         encoder.init();
 
+        com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+            com.overdrive.app.camera.CameraConfigResolver.resolve(getVehicleModel());
+        float[] quadrantStripOffsetX = resolvedCamera.getQuadrantStripOffsetX();
+
         // 2. Create GPU mosaic recorder (shared)
-        recorder = new GpuMosaicRecorder();
+        recorder = new GpuMosaicRecorder(quadrantStripOffsetX);
         // Note: recorder.init() will be called after EGL context is created by camera
 
         // Wire up telemetry collector to new recorder if available
@@ -649,7 +653,7 @@ public class GpuSurveillancePipeline {
         recorder.setOverlayEnabled(overlayEnabledConfig);
 
         // 3. Create GPU downscaler
-        downscaler = new GpuDownscaler();
+        downscaler = new GpuDownscaler(quadrantStripOffsetX);
         // Note: downscaler.init() will be called after EGL context is created by camera
 
         // 4. Create surveillance engine (uses shared recorder)
@@ -674,8 +678,6 @@ public class GpuSurveillancePipeline {
             logger.warn("Failed to load saved config, using defaults: " + e.getMessage());
         }
 
-        com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
-            com.overdrive.app.camera.CameraConfigResolver.resolve(getVehicleModel());
         if (cameraWidth != resolvedCamera.getPanoWidth() || cameraHeight != resolvedCamera.getPanoHeight()) {
             logger.warn("Pipeline geometry " + cameraWidth + "x" + cameraHeight
                 + " differs from resolved camera profile "
@@ -684,7 +686,7 @@ public class GpuSurveillancePipeline {
         }
         
         // 5. Create camera (this creates EGL context)
-        camera = new PanoramicCameraGpu(cameraWidth, cameraHeight);
+        camera = new PanoramicCameraGpu(cameraWidth, cameraHeight, quadrantStripOffsetX);
         camera.setConsumers(recorder, downscaler, sentry);
         
         // Camera FPS config — must match the encoder FPS used above (loadTargetFps())
@@ -1274,7 +1276,14 @@ public class GpuSurveillancePipeline {
         
         // Create stream scaler
         logger.info("Creating stream scaler...");
-        streamScaler = new com.overdrive.app.streaming.GpuStreamScaler(streamWidth, streamHeight);
+        float[] quadrantStripOffsetX = com.overdrive.app.camera.CameraConfigResolver
+            .resolve(getVehicleModel())
+            .getQuadrantStripOffsetX();
+        streamScaler = new com.overdrive.app.streaming.GpuStreamScaler(
+            streamWidth,
+            streamHeight,
+            quadrantStripOffsetX
+        );
         
         // Always 4-camera mosaic for streaming
         streamScaler.setCameraLayout(0);

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
@@ -673,6 +673,15 @@ public class GpuSurveillancePipeline {
         } catch (Exception e) {
             logger.warn("Failed to load saved config, using defaults: " + e.getMessage());
         }
+
+        com.overdrive.app.camera.ResolvedCameraConfig resolvedCamera =
+            com.overdrive.app.camera.CameraConfigResolver.resolve(getVehicleModel());
+        if (cameraWidth != resolvedCamera.getPanoWidth() || cameraHeight != resolvedCamera.getPanoHeight()) {
+            logger.warn("Pipeline geometry " + cameraWidth + "x" + cameraHeight
+                + " differs from resolved camera profile "
+                + resolvedCamera.getPanoWidth() + "x" + resolvedCamera.getPanoHeight()
+                + " — restart the daemon to apply the new profile dimensions");
+        }
         
         // 5. Create camera (this creates EGL context)
         camera = new PanoramicCameraGpu(cameraWidth, cameraHeight);
@@ -682,83 +691,44 @@ public class GpuSurveillancePipeline {
         // so that camera frame delivery rate matches the encoder's KEY_FRAME_RATE.
         camera.setTargetFps(fps);
         logger.info("Camera targetFps=" + fps + " (from config)");
-        
-        // Camera config strategy:
-        // 1. Saved config from previous VALIDATED probe → use directly (highest trust)
-        // 2. BmmCameraInfo discovery → asks the system for the correct panoramic camera ID
-        // 3. Default camera ID 1 (correct for Seal, most common model)
-        // 4. Full auto-probe only when all above fail
-        String model = getVehicleModel();
-        logger.info("Vehicle model: " + model);
+        logger.info("Resolved camera profile: " + resolvedCamera.getProfile().getDisplayName()
+            + " (panoCam=" + resolvedCamera.getPanoCameraId()
+            + ", size=" + resolvedCamera.getPanoWidth() + "x" + resolvedCamera.getPanoHeight()
+            + ", surfaceMode=" + resolvedCamera.getPanoSurfaceMode() + ")");
 
-        boolean configured = false;
-        
-        // Step 1: Validated saved config (probedAndValidated=true OR manualOverride=true)
-        if (!configured) {
-            try {
-                org.json.JSONObject cameraConfig = com.overdrive.app.config.UnifiedConfigManager
-                    .loadConfig().optJSONObject("camera");
-                int savedId = cameraConfig != null ? cameraConfig.optInt("probedCameraId", -1) : -1;
-                int savedMode = cameraConfig != null ? cameraConfig.optInt("probedSurfaceMode", -1) : -1;
-                boolean validated = cameraConfig != null && cameraConfig.optBoolean("probedAndValidated", false);
-                boolean manual = cameraConfig != null && cameraConfig.optBoolean("manualOverride", false);
-                boolean fallback = cameraConfig != null && cameraConfig.optBoolean("fallbackFromProbe", false);
-                
-                if (savedId >= 0 && savedMode >= 0 && (validated || manual)) {
-                    logger.info("Using " + (manual ? "MANUAL" : fallback ? "fallback" : "validated") + 
-                        " camera config: id=" + savedId + ", surfaceMode=" + savedMode);
-                    camera.setCameraId(savedId);
-                    camera.setCameraSurfaceMode(savedMode);
-                    camera.setAutoProbeCameras(false);
-                    // Skip frame validation for ALL saved configs. The strip check uses
-                    // an 8x8 luma heuristic that produces false negatives when all 4 cameras
-                    // see similar scenes (parked in garage, night, uniform lighting).
-                    // A saved config was already validated — no need to re-check every startup.
-                    camera.setSkipFrameValidation(true);
-                    configured = true;
-                }
-            } catch (Exception e) {
-                logger.warn("Failed to load saved camera config: " + e.getMessage());
-            }
-        }
-        
-        // Step 2: BmmCameraInfo discovery — asks the system which camera ID is panoramic.
-        // This is how DiPlus resolves camera IDs across different vehicle models.
-        if (!configured) {
+        if (resolvedCamera.isValidated() || resolvedCamera.isManualPanoOverride()) {
+            logger.info("Using saved panoramic config: id=" + resolvedCamera.getPanoCameraId()
+                + ", surfaceMode=" + resolvedCamera.getPanoSurfaceMode()
+                + (resolvedCamera.isManualPanoOverride() ? " (manual)" : " (validated)"));
+            camera.setCameraId(resolvedCamera.getPanoCameraId());
+            camera.setCameraSurfaceMode(resolvedCamera.getPanoSurfaceMode());
+            camera.setAutoProbeCameras(false);
+            camera.setSkipFrameValidation(true);
+        } else {
             int discoveredId = com.overdrive.app.camera.AvmCameraHelper.discoverPanoCameraId();
             if (discoveredId >= 0) {
-                logger.info("Using BmmCameraInfo discovered camera ID: " + discoveredId);
+                logger.info("Using BmmCameraInfo panoramic hint: camera ID " + discoveredId);
                 camera.setCameraId(discoveredId);
-                camera.setCameraSurfaceMode(0);
-                camera.setAutoProbeCameras(false);
-                configured = true;
+            } else {
+                logger.info("Using profile default panoramic camera ID " + resolvedCamera.getPanoCameraId());
+                camera.setCameraId(resolvedCamera.getPanoCameraId());
             }
-        }
-        
-        // Step 3: Default camera ID 1 (correct for Seal, most common model).
-        // If wrong for other models, frame-50 recheck will detect and re-probe.
-        if (!configured) {
-            logger.info("Using default camera ID 1");
-            camera.setCameraId(1);
-            camera.setCameraSurfaceMode(0);
+            camera.setCameraSurfaceMode(resolvedCamera.getPanoSurfaceMode());
             camera.setAutoProbeCameras(false);
-            configured = true;
-        }
-        
-        // Step 4: Full auto-probe as last resort (shouldn't reach here)
-        if (!configured) {
-            logger.warn("All camera config strategies failed — enabling auto-probe");
-            camera.setAutoProbeCameras(true);
+            camera.setSkipFrameValidation(false);
         }
         
         // Register probe callback — only used when manual probe is triggered via API
         camera.setCameraProbeCallback((cameraId, surfaceMode) -> {
             logger.info("Probe found working camera: id=" + cameraId + ", surfaceMode=" + surfaceMode);
             try {
-                org.json.JSONObject camCfg = new org.json.JSONObject();
-                camCfg.put("probedCameraId", cameraId);
-                camCfg.put("probedSurfaceMode", surfaceMode);
-                com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                com.overdrive.app.camera.CameraConfigResolver.persistPanoramicProbe(
+                    cameraId,
+                    surfaceMode,
+                    cameraWidth,
+                    cameraHeight,
+                    true,
+                    false);
                 logger.info("Saved camera config for next launch");
             } catch (Exception ex) {
                 logger.warn("Failed to save camera config: " + ex.getMessage());
@@ -818,32 +788,17 @@ public class GpuSurveillancePipeline {
             // Re-read camera config before starting — user may have changed camera ID
             // via the app UI menu since the pipeline was initialized.
             try {
-                org.json.JSONObject cameraConfig = com.overdrive.app.config.UnifiedConfigManager
-                    .loadConfig().optJSONObject("camera");
-                if (cameraConfig != null) {
-                    int savedId = cameraConfig.optInt("probedCameraId", -1);
-                    int savedMode = cameraConfig.optInt("probedSurfaceMode", -1);
-                    boolean validated = cameraConfig.optBoolean("probedAndValidated", false);
-                    boolean manual = cameraConfig.optBoolean("manualOverride", false);
-                    
-                    if (savedId >= 0 && savedMode >= 0 && (validated || manual)) {
-                        int currentId = camera.getCameraId();
-                        if (currentId != savedId) {
-                            logger.info("Camera config changed since init: " + currentId + " → " + savedId +
-                                " (" + (manual ? "manual" : "validated") + ")");
-                            camera.setCameraId(savedId);
-                            camera.setCameraSurfaceMode(savedMode);
-                            camera.setAutoProbeCameras(false);
-                            camera.setSkipFrameValidation(true);
-                        }
-                    } else if (savedId < 0 && camera.getCameraId() != 1) {
-                        // User cleared manual override → revert to default
-                        logger.info("Camera config cleared — reverting to default ID 1");
-                        camera.setCameraId(1);
-                        camera.setCameraSurfaceMode(0);
-                        camera.setAutoProbeCameras(false);
-                        camera.setSkipFrameValidation(false);
-                    }
+                com.overdrive.app.camera.ResolvedCameraConfig refreshedCamera =
+                    com.overdrive.app.camera.CameraConfigResolver.resolve(getVehicleModel());
+                int targetCameraId = refreshedCamera.getPanoCameraId();
+                int targetSurfaceMode = refreshedCamera.getPanoSurfaceMode();
+                int currentId = camera.getCameraId();
+                if (currentId != targetCameraId) {
+                    logger.info("Camera config changed since init: " + currentId + " → " + targetCameraId);
+                    camera.setCameraId(targetCameraId);
+                    camera.setCameraSurfaceMode(targetSurfaceMode);
+                    camera.setAutoProbeCameras(false);
+                    camera.setSkipFrameValidation(refreshedCamera.isValidated() || refreshedCamera.isManualPanoOverride());
                 }
             } catch (Exception e) {
                 logger.debug("Camera config re-read failed: " + e.getMessage());

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -959,6 +959,7 @@ class MainActivity : AppCompatActivity() {
         val kind: String,
         val label: String,
         val cameraId: Int?,
+        val slice: String?,
         val view: String?,
         val width: Int,
         val height: Int
@@ -966,6 +967,7 @@ class MainActivity : AppCompatActivity() {
         fun toJson(): org.json.JSONObject = org.json.JSONObject().apply {
             put("kind", kind)
             cameraId?.let { put("cameraId", it) }
+            slice?.let { put("slice", it) }
             view?.let { put("view", it) }
         }
     }
@@ -1033,10 +1035,11 @@ class MainActivity : AppCompatActivity() {
                 val item = candidateArray.optJSONObject(i) ?: continue
                 candidates += CameraPreviewCandidate(
                     id = item.optString("id", "candidate-$i"),
-                    kind = item.optString("kind", "panoramicVirtual"),
+                    kind = item.optString("kind", "panoramicSlice"),
                     label = item.optString("label", item.optString("id", "Candidate")),
                     cameraId = if (item.has("cameraId")) item.optInt("cameraId") else null,
-                    view = item.optString("view", null),
+                    slice = if (item.has("slice")) item.optString("slice") else null,
+                    view = if (item.has("view")) item.optString("view") else null,
                     width = item.optInt("previewWidth", 1280),
                     height = item.optInt("previewHeight", 720)
                 )
@@ -1046,7 +1049,7 @@ class MainActivity : AppCompatActivity() {
             val mappingsJson = config.optJSONObject("cameraRoleMappings")
             roles.forEach { role ->
                 val source = mappingsJson?.optJSONObject(role.key)
-                val sourceId = source?.optString("id", null)
+                val sourceId = if (source != null && source.has("id")) source.optString("id") else null
                 if (!sourceId.isNullOrEmpty()) {
                     mappings[role.key] = sourceId
                 }
@@ -1298,6 +1301,8 @@ class MainActivity : AppCompatActivity() {
     private fun buildCameraPreviewPath(candidate: CameraPreviewCandidate): String {
         return if (candidate.kind.equals("direct", ignoreCase = true) && candidate.cameraId != null) {
             "/api/surveillance/camera-preview?kind=direct&cameraId=${candidate.cameraId}&width=${candidate.width}&height=${candidate.height}"
+        } else if (candidate.kind.equals("panoramicSlice", ignoreCase = true) && !candidate.slice.isNullOrEmpty()) {
+            "/api/surveillance/camera-preview?kind=panoramicSlice&slice=${candidate.slice}&width=${candidate.width}&height=${candidate.height}"
         } else {
             "/api/surveillance/camera-preview?kind=panoramic&view=${candidate.view ?: "front"}"
         }

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -953,110 +953,354 @@ class MainActivity : AppCompatActivity() {
      */
     private fun updateCameraProbeMenuItem() { /* intentionally empty */ }
 
+    private data class CameraRoleOption(val key: String, val label: String)
+    private data class CameraPreviewCandidate(
+        val id: String,
+        val kind: String,
+        val label: String,
+        val cameraId: Int?,
+        val view: String?,
+        val width: Int,
+        val height: Int
+    ) {
+        fun toJson(): org.json.JSONObject = org.json.JSONObject().apply {
+            put("kind", kind)
+            cameraId?.let { put("cameraId", it) }
+            view?.let { put("view", it) }
+        }
+    }
+
+    private data class CameraMappingState(
+        val summary: String,
+        val roles: List<CameraRoleOption>,
+        val candidates: List<CameraPreviewCandidate>,
+        val currentMappings: Map<String, String>
+    )
+
 
     /**
      * Handle "Reconfigure Camera" menu item click.
-     * Shows a styled dialog to manually select camera ID or use auto-detection.
+    * Shows a role-mapping dialog with live preview candidates.
      */
     private fun onReconfigureCameraClicked() {
-        var currentId = -1
-        var isManual = false
-        try {
-            val config = com.overdrive.app.config.UnifiedConfigManager.loadConfig()
-            val cameraConfig = config.optJSONObject("camera")
-            if (cameraConfig != null) {
-                currentId = cameraConfig.optInt("probedCameraId", -1)
-                isManual = cameraConfig.optBoolean("manualOverride", false)
+        Thread {
+            val state = fetchCameraMappingState()
+            runOnUiThread {
+                if (state == null) {
+                    Toast.makeText(this, getString(R.string.toast_failed_to_save_short), Toast.LENGTH_SHORT).show()
+                    return@runOnUiThread
+                }
+                showCameraMappingDialog(state)
             }
-        } catch (e: Exception) { /* ignore */ }
+        }.start()
+    }
 
-        val dialogView = layoutInflater.inflate(R.layout.dialog_camera_selection, null)
-        
-        // Set current status
-        val statusText = dialogView.findViewById<TextView>(R.id.tvCurrentCamera)
-        if (isManual && currentId >= 0) {
-            statusText.text = getString(R.string.camera_current_manual, currentId)
-        } else {
-            statusText.text = getString(R.string.camera_current_auto_label)
+    private fun fetchCameraMappingState(): CameraMappingState? {
+        return try {
+            val conn = com.overdrive.app.util.DaemonHttpClient.open(
+                "/api/surveillance/config", "GET", 3000, 4000)
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            conn.disconnect()
+            val config = org.json.JSONObject(body).optJSONObject("config") ?: return null
+
+            val panoCameraId = config.optInt("panoCameraId", config.optInt("cameraId", -1))
+            val panoWidth = config.optInt("panoWidth", -1)
+            val panoHeight = config.optInt("panoHeight", -1)
+            val summary = if (panoCameraId >= 0 && panoWidth > 0 && panoHeight > 0) {
+                getString(
+                    R.string.camera_mapping_summary_format,
+                    panoCameraId,
+                    panoWidth,
+                    panoHeight
+                )
+            } else {
+                getString(R.string.camera_mapping_summary_probing)
+            }
+
+            val roles = mutableListOf<CameraRoleOption>()
+            val roleArray = config.optJSONArray("cameraRoleOptions") ?: org.json.JSONArray()
+            for (i in 0 until roleArray.length()) {
+                val item = roleArray.optJSONObject(i) ?: continue
+                roles += CameraRoleOption(
+                    item.optString("key", ""),
+                    item.optString("label", item.optString("key", "Role"))
+                )
+            }
+
+            val candidates = mutableListOf<CameraPreviewCandidate>()
+            val candidateArray = config.optJSONArray("cameraPreviewCandidates") ?: org.json.JSONArray()
+            for (i in 0 until candidateArray.length()) {
+                val item = candidateArray.optJSONObject(i) ?: continue
+                candidates += CameraPreviewCandidate(
+                    id = item.optString("id", "candidate-$i"),
+                    kind = item.optString("kind", "panoramicVirtual"),
+                    label = item.optString("label", item.optString("id", "Candidate")),
+                    cameraId = if (item.has("cameraId")) item.optInt("cameraId") else null,
+                    view = item.optString("view", null),
+                    width = item.optInt("previewWidth", 1280),
+                    height = item.optInt("previewHeight", 720)
+                )
+            }
+
+            val mappings = mutableMapOf<String, String>()
+            val mappingsJson = config.optJSONObject("cameraRoleMappings")
+            roles.forEach { role ->
+                val source = mappingsJson?.optJSONObject(role.key)
+                val sourceId = source?.optString("id", null)
+                if (!sourceId.isNullOrEmpty()) {
+                    mappings[role.key] = sourceId
+                }
+            }
+
+            CameraMappingState(
+                summary = summary,
+                roles = roles,
+                candidates = candidates,
+                currentMappings = mappings
+            )
+        } catch (e: Exception) {
+            logsViewModel.error("Camera", "Failed to load camera mapping state: ${e.message}")
+            null
         }
-        
-        // Set radio button selection
-        val radioGroup = dialogView.findViewById<android.widget.RadioGroup>(R.id.rgCameraOptions)
-        val radioIds = arrayOf(
-            R.id.rbCameraAuto, R.id.rbCamera0, R.id.rbCamera1,
-            R.id.rbCamera2, R.id.rbCamera3, R.id.rbCamera4, R.id.rbCamera5
+    }
+
+    private fun showCameraMappingDialog(state: CameraMappingState) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_camera_mapping, null)
+        val summaryView = dialogView.findViewById<TextView>(R.id.tvCameraProfileSummary)
+        val roleSpinner = dialogView.findViewById<android.widget.Spinner>(R.id.spinnerCameraRole)
+        val currentMappingView = dialogView.findViewById<TextView>(R.id.tvCurrentRoleMapping)
+        val candidateLabelView = dialogView.findViewById<TextView>(R.id.tvCandidateLabel)
+        val previewImageView = dialogView.findViewById<ImageView>(R.id.ivCameraCandidatePreview)
+        val previewPlaceholderView = dialogView.findViewById<TextView>(R.id.tvCameraPreviewPlaceholder)
+        val prevButton = dialogView.findViewById<View>(R.id.btnPrevCandidate)
+        val nextButton = dialogView.findViewById<View>(R.id.btnNextCandidate)
+        val saveMappingButton = dialogView.findViewById<View>(R.id.btnSaveCameraRoleMapping)
+        val clearMappingButton = dialogView.findViewById<View>(R.id.btnClearCameraRoleMapping)
+
+        summaryView.text = state.summary
+
+        val roleAdapter = android.widget.ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            state.roles.map { it.label }
         )
-        val currentSelection = if (isManual && currentId >= 0) currentId + 1 else 0
-        radioGroup.check(radioIds[currentSelection])
-        
+        roleSpinner.adapter = roleAdapter
+
+        var currentRoleIndex = 0
+        var currentCandidateIndex = 0
+        val previewHandler = android.os.Handler(android.os.Looper.getMainLooper())
+        var dialogClosed = false
+        var activePreviewCandidateId: String? = null
+
+        fun mappedCandidateIndexForRole(roleKey: String): Int {
+            val mappedId = state.currentMappings[roleKey] ?: return 0
+            return state.candidates.indexOfFirst { it.id == mappedId }.let { if (it >= 0) it else 0 }
+        }
+
+        fun updateCurrentMappingText() {
+            val role = state.roles.getOrNull(currentRoleIndex)
+            val mappedId = role?.let { state.currentMappings[it.key] }
+            val mappedLabel = state.candidates.firstOrNull { it.id == mappedId }?.label
+            currentMappingView.text = if (mappedLabel.isNullOrEmpty()) {
+                getString(R.string.camera_mapping_current_none)
+            } else {
+                getString(R.string.camera_mapping_current_format, mappedLabel)
+            }
+        }
+
+        fun refreshPreview(scheduleNext: Boolean) {
+            if (dialogClosed || state.candidates.isEmpty()) return
+            val candidate = state.candidates[currentCandidateIndex]
+            activePreviewCandidateId = candidate.id
+            candidateLabelView.text = candidate.label
+            previewPlaceholderView.visibility = View.VISIBLE
+            previewPlaceholderView.text = getString(R.string.camera_preview_unavailable)
+            Thread {
+                val imageBytes = try {
+                    val conn = com.overdrive.app.util.DaemonHttpClient.open(
+                        buildCameraPreviewPath(candidate),
+                        "GET",
+                        2500,
+                        4000
+                    )
+                    val bytes = if (conn.responseCode == 200) conn.inputStream.use { it.readBytes() } else null
+                    conn.disconnect()
+                    bytes
+                } catch (_: Exception) {
+                    null
+                }
+
+                runOnUiThread {
+                    if (dialogClosed || activePreviewCandidateId != candidate.id) return@runOnUiThread
+                    if (imageBytes != null && imageBytes.isNotEmpty()) {
+                        val bitmap = android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                        if (bitmap != null) {
+                            previewImageView.setImageBitmap(bitmap)
+                            previewPlaceholderView.visibility = View.GONE
+                        } else {
+                            previewImageView.setImageDrawable(null)
+                            previewPlaceholderView.visibility = View.VISIBLE
+                        }
+                    } else {
+                        previewImageView.setImageDrawable(null)
+                        previewPlaceholderView.visibility = View.VISIBLE
+                    }
+                }
+            }.start()
+
+            if (scheduleNext) {
+                previewHandler.removeCallbacksAndMessages(null)
+                previewHandler.postDelayed({ refreshPreview(true) }, 2000)
+            }
+        }
+
+        fun updateCandidateSelection(schedulePreview: Boolean) {
+            if (state.candidates.isEmpty()) {
+                candidateLabelView.text = getString(R.string.camera_preview_unavailable)
+                previewImageView.setImageDrawable(null)
+                previewPlaceholderView.visibility = View.VISIBLE
+                return
+            }
+            if (currentCandidateIndex < 0) currentCandidateIndex = 0
+            if (currentCandidateIndex >= state.candidates.size) currentCandidateIndex = state.candidates.lastIndex
+            candidateLabelView.text = state.candidates[currentCandidateIndex].label
+            if (schedulePreview) refreshPreview(true)
+        }
+
+        roleSpinner.onItemSelectedListener = object : android.widget.AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: android.widget.AdapterView<*>?, view: View?, position: Int, id: Long) {
+                currentRoleIndex = position
+                currentCandidateIndex = mappedCandidateIndexForRole(state.roles[position].key)
+                updateCurrentMappingText()
+                updateCandidateSelection(true)
+            }
+
+            override fun onNothingSelected(parent: android.widget.AdapterView<*>?) = Unit
+        }
+
+        prevButton.setOnClickListener {
+            if (state.candidates.isEmpty()) return@setOnClickListener
+            currentCandidateIndex = if (currentCandidateIndex <= 0) state.candidates.lastIndex else currentCandidateIndex - 1
+            updateCandidateSelection(true)
+        }
+
+        nextButton.setOnClickListener {
+            if (state.candidates.isEmpty()) return@setOnClickListener
+            currentCandidateIndex = if (currentCandidateIndex >= state.candidates.lastIndex) 0 else currentCandidateIndex + 1
+            updateCandidateSelection(true)
+        }
+
         val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(this, R.style.Theme_Overdrive_M3_Dialog)
             .setView(dialogView)
             .setNegativeButton(getString(R.string.dialog_close), null)
             .create()
-        
-        // Save immediately on radio button selection — no Apply button needed
-        radioGroup.setOnCheckedChangeListener { _, checkedId ->
-            val selectedIndex = radioIds.indexOf(checkedId)
-            if (selectedIndex < 0) return@setOnCheckedChangeListener
-            
-            // Don't re-save if user tapped the already-selected option
-            if (selectedIndex == currentSelection) return@setOnCheckedChangeListener
-            
-            if (selectedIndex == 0) {
-                // Auto mode
-                Thread {
-                    try {
-                        val conn = com.overdrive.app.util.DaemonHttpClient.open(
-                            "/api/surveillance/config", "POST", 3000, 3000)
-                        conn.setRequestProperty("Content-Type", "application/json")
-                        conn.doOutput = true
-                        val body = """{"clearManualCameraId":true}"""
-                        conn.outputStream.use { it.write(body.toByteArray()) }
-                        val responseCode = conn.responseCode
-                        conn.disconnect()
 
-                        runOnUiThread {
-                            if (responseCode == 200) {
-                                Toast.makeText(this, getString(R.string.toast_camera_set_to_auto), Toast.LENGTH_SHORT).show()
-                            } else {
-                                Toast.makeText(this, getString(R.string.toast_failed_to_save_short), Toast.LENGTH_SHORT).show()
-                            }
-                            updateCameraProbeMenuItem()
-                        }
-                    } catch (e: Exception) {
-                        runOnUiThread { Toast.makeText(this, getString(R.string.toast_failed_with_message, e.message ?: ""), Toast.LENGTH_SHORT).show() }
-                    }
-                }.start()
-            } else {
-                // Manual camera ID
-                val selectedCamId = selectedIndex - 1
-                Thread {
-                    try {
-                        val conn = com.overdrive.app.util.DaemonHttpClient.open(
-                            "/api/surveillance/config", "POST", 3000, 3000)
-                        conn.setRequestProperty("Content-Type", "application/json")
-                        conn.doOutput = true
-                        val body = """{"manualCameraId":$selectedCamId}"""
-                        conn.outputStream.use { it.write(body.toByteArray()) }
-                        val responseCode = conn.responseCode
-                        conn.disconnect()
+        dialog.setOnDismissListener {
+            dialogClosed = true
+            previewHandler.removeCallbacksAndMessages(null)
+        }
 
-                        runOnUiThread {
-                            if (responseCode == 200) {
-                                Toast.makeText(this, getString(R.string.toast_camera_id_set, selectedCamId), Toast.LENGTH_SHORT).show()
-                            } else {
-                                Toast.makeText(this, getString(R.string.toast_failed_to_save_short), Toast.LENGTH_SHORT).show()
-                            }
-                            updateCameraProbeMenuItem()
-                        }
-                    } catch (e: Exception) {
-                        runOnUiThread { Toast.makeText(this, getString(R.string.toast_failed_with_message, e.message ?: ""), Toast.LENGTH_SHORT).show() }
-                    }
-                }.start()
+        saveMappingButton.setOnClickListener {
+            val role = state.roles.getOrNull(currentRoleIndex) ?: return@setOnClickListener
+            val candidate = state.candidates.getOrNull(currentCandidateIndex) ?: return@setOnClickListener
+            val payload = org.json.JSONObject().apply {
+                put("cameraRoleMapping", org.json.JSONObject().apply {
+                    put("role", role.key)
+                    put("source", candidate.toJson())
+                })
+            }.toString()
+            postSurveillanceConfig(payload) { success, message ->
+                if (success) {
+                    restartCameraDaemonForCameraSettings()
+                    dialog.dismiss()
+                } else {
+                    Toast.makeText(this, message ?: getString(R.string.toast_failed_to_save_short), Toast.LENGTH_SHORT).show()
+                }
             }
         }
-        
+
+        clearMappingButton.setOnClickListener {
+            val role = state.roles.getOrNull(currentRoleIndex) ?: return@setOnClickListener
+            val payload = org.json.JSONObject().apply {
+                put("cameraRoleMapping", org.json.JSONObject().apply {
+                    put("role", role.key)
+                    put("clear", true)
+                })
+            }.toString()
+            postSurveillanceConfig(payload) { success, message ->
+                if (success) {
+                    restartCameraDaemonForCameraSettings()
+                    dialog.dismiss()
+                } else {
+                    Toast.makeText(this, message ?: getString(R.string.toast_failed_to_save_short), Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+
+        updateCurrentMappingText()
+        updateCandidateSelection(true)
         dialog.show()
+    }
+
+    private fun postSurveillanceConfig(body: String, onComplete: (Boolean, String?) -> Unit) {
+        Thread {
+            try {
+                val conn = com.overdrive.app.util.DaemonHttpClient.open(
+                    "/api/surveillance/config", "POST", 3000, 4000)
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.doOutput = true
+                conn.outputStream.use { it.write(body.toByteArray()) }
+                val success = conn.responseCode == 200
+                val message = if (success) null else conn.errorStream?.bufferedReader()?.use { it.readText() }
+                conn.disconnect()
+                runOnUiThread { onComplete(success, message) }
+            } catch (e: Exception) {
+                runOnUiThread { onComplete(false, e.message) }
+            }
+        }.start()
+    }
+
+    private fun restartCameraDaemonForCameraSettings() {
+        Toast.makeText(this, getString(R.string.toast_camera_settings_saved_restarting), Toast.LENGTH_LONG).show()
+        logsViewModel.info("Camera", "Camera settings changed — restarting daemon to apply them immediately")
+
+        val adb = com.overdrive.app.launcher.AdbDaemonLauncher(this)
+        adb.killDaemon(object : com.overdrive.app.launcher.AdbDaemonLauncher.LaunchCallback {
+            override fun onLog(message: String) {
+                logsViewModel.debug("Camera", message)
+            }
+
+            override fun onLaunched() {
+                runOnUiThread {
+                    logsViewModel.info("Camera", "Camera daemon stopped — relaunching with updated camera settings")
+                    android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                        daemonStartupManager.initializeOnAppLaunch()
+                        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                            daemonStartupManager.checkAllDaemonStatuses()
+                        }, 5000)
+                    }, 3000)
+                }
+            }
+
+            override fun onError(error: String) {
+                runOnUiThread {
+                    logsViewModel.error("Camera", "Failed to restart daemon after camera settings save: $error")
+                    Toast.makeText(
+                        this@MainActivity,
+                        getString(R.string.toast_camera_settings_restart_failed),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        })
+    }
+
+    private fun buildCameraPreviewPath(candidate: CameraPreviewCandidate): String {
+        return if (candidate.kind.equals("direct", ignoreCase = true) && candidate.cameraId != null) {
+            "/api/surveillance/camera-preview?kind=direct&cameraId=${candidate.cameraId}&width=${candidate.width}&height=${candidate.height}"
+        } else {
+            "/api/surveillance/camera-preview?kind=panoramic&view=${candidate.view ?: "front"}"
+        }
     }
     
     /**

--- a/app/src/main/java/com/overdrive/app/util/Constants.kt
+++ b/app/src/main/java/com/overdrive/app/util/Constants.kt
@@ -1,5 +1,7 @@
 package com.overdrive.app.util
 
+import com.overdrive.app.camera.CameraProfiles
+
 /**
  * Shared constants for the BYD Champ application.
  */
@@ -16,10 +18,10 @@ object Constants {
     const val LOG_DIR = "/data/local/tmp"
     
     // Camera Configuration
-    const val PANO_WIDTH = 5120
-    const val PANO_HEIGHT = 960
-    const val VIEW_WIDTH = 1280
-    const val VIEW_HEIGHT = 960
+    val PANO_WIDTH = CameraProfiles.getLegacyDefault().panoWidth
+    val PANO_HEIGHT = CameraProfiles.getLegacyDefault().panoHeight
+    val VIEW_WIDTH = PANO_WIDTH / 4
+    val VIEW_HEIGHT = PANO_HEIGHT
     const val FRAME_RATE = 25
     const val BITRATE = 4_000_000
     const val KEYFRAME_INTERVAL = 2

--- a/app/src/main/res/layout/dialog_camera_mapping.xml
+++ b/app/src/main/res/layout/dialog_camera_mapping.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceContainerHigh"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:contentDescription="@string/cd_camera"
+                android:src="@drawable/ic_camera_select"
+                app:tint="?attr/colorPrimary" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="14dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/camera_mapping_title"
+                    android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+                    android:textColor="?attr/colorOnSurface" />
+
+                <TextView
+                    android:id="@+id/tvCameraProfileSummary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:text="@string/camera_role_label"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
+            android:textColor="?attr/colorOnSurface" />
+
+        <Spinner
+            android:id="@+id/spinnerCameraRole"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:id="@+id/tvCurrentRoleMapping"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnPrevCandidate"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_candidate_previous" />
+
+            <TextView
+                android:id="@+id/tvCandidateLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="?attr/colorOnSurface" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnNextCandidate"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_candidate_next" />
+        </LinearLayout>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp"
+            app:strokeColor="?attr/colorOutlineVariant"
+            app:strokeWidth="1dp">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="210dp">
+
+                <ImageView
+                    android:id="@+id/ivCameraCandidatePreview"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:adjustViewBounds="true"
+                    android:background="?attr/colorSurfaceContainerHighest"
+                    android:scaleType="centerCrop" />
+
+                <TextView
+                    android:id="@+id/tvCameraPreviewPlaceholder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:padding="16dp"
+                    android:text="@string/camera_preview_unavailable"
+                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+            </FrameLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:gravity="end"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnClearCameraRoleMapping"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_mapping_clear" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSaveCameraRoleMapping"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/camera_mapping_save" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/camera_mapping_hint"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
      <string name="camera_mapping_summary_probing">Panoramic stream: Legacy auto-detect / probing</string>
      <string name="camera_mapping_current_format">Current mapping: %1$s</string>
      <string name="camera_mapping_current_none">Current mapping: Auto / default</string>
-     <string name="camera_mapping_hint">OverDrive keeps the legacy Seal/Atto-style startup behavior by default. Use this dialog to preview live streams and pin each role to the direct stream or 360 subview that actually works on your vehicle. Saving restarts the camera daemon automatically.</string>
+     <string name="camera_mapping_hint">OverDrive keeps the legacy startup behavior by default, but now lets you calibrate the merged panoramic strip properly. Preview each raw merged slice, map the logical 360 roles to the slice that actually shows front/right/rear/left on your vehicle, and the daemon will reuse that layout for recording, streaming, and AI after restart.</string>
 
     <!-- fragment_dashboard -->
     <string name="dashboard_scan_to_connect">Scan to Connect</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,20 @@
     <string name="camera_option_4">Camera 4</string>
     <string name="camera_option_5">Camera 5</string>
     <string name="camera_selection_hint">Auto picks the right camera for your trim on every boot. Camera 1 = BYD Seal, Camera 0 = Atto trims. Restart the daemon after changing camera ID for the setting to take effect.</string>
+     <string name="camera_mapping_title">Camera Mapping</string>
+     <string name="camera_role_label">Role mapping</string>
+     <string name="camera_candidate_previous">Previous</string>
+     <string name="camera_candidate_next">Next</string>
+     <string name="camera_preview_unavailable">Preview unavailable yet. Try another candidate or refresh by reopening the dialog after the daemon restarts.</string>
+     <string name="camera_mapping_save">Save mapping</string>
+     <string name="camera_mapping_clear">Clear role</string>
+     <string name="camera_mapping_saved">Camera mapping saved.</string>
+     <string name="camera_mapping_cleared">Camera role mapping cleared.</string>
+     <string name="camera_mapping_summary_format">Panoramic stream: Camera %1$d · %2$dx%3$d</string>
+     <string name="camera_mapping_summary_probing">Panoramic stream: Legacy auto-detect / probing</string>
+     <string name="camera_mapping_current_format">Current mapping: %1$s</string>
+     <string name="camera_mapping_current_none">Current mapping: Auto / default</string>
+     <string name="camera_mapping_hint">OverDrive keeps the legacy Seal/Atto-style startup behavior by default. Use this dialog to preview live streams and pin each role to the direct stream or 360 subview that actually works on your vehicle. Saving restarts the camera daemon automatically.</string>
 
     <!-- fragment_dashboard -->
     <string name="dashboard_scan_to_connect">Scan to Connect</string>
@@ -334,6 +348,8 @@
     <string name="toast_restarting_camera_daemon">Restarting camera daemon…</string>
     <string name="toast_camera_daemon_restarting">Camera daemon restarting with full probe</string>
     <string name="toast_camera_restart_failed">Config cleared but daemon restart failed. Please restart manually.</string>
+     <string name="toast_camera_settings_saved_restarting">Camera settings saved — restarting camera daemon…</string>
+     <string name="toast_camera_settings_restart_failed">Camera settings were saved, but daemon restart failed. Please restart it manually.</string>
     <string name="toast_failed_with_message_x">Failed: %1$s</string>
     <string name="toast_soh_reset_success">SOH estimation reset — will recalculate from next data</string>
     <string name="toast_soh_reset_failed_no_daemon">Reset failed — daemon not responding and file not writable</string>


### PR DESCRIPTION
## Summary

This PR replaces the old destructive camera reprobe flow with a diagnostics-driven camera mapping workflow and adds panoramic slice calibration so different BYD panoramic stream layouts can be mapped correctly across recording, streaming, and AI.

### What changed

- Added a **Diagnostics camera mapping dialog** instead of relying on clearing camera config and forcing a full reprobe.
- Added **live preview candidates** for:
  - direct camera streams
  - raw panoramic merged-strip slices
- Added **saved role mappings** for:
  - windshield
  - cabin
  - 360 front
  - 360 right
  - 360 rear
  - 360 left
- Added **automatic daemon restart** after saving or clearing camera mappings so changes apply immediately.
- Added internal **panoramic slice calibration** support:
  - neutral merged slices (`slice1`..`slice4`)
  - logical front/right/rear/left derived from saved role mappings
- Propagated the resolved panoramic layout through:
  - `GpuDownscaler`
  - `GpuMosaicRecorder`
  - `GpuStreamScaler`
  - `PanoramicCameraGpu` / `FoveatedCropper`
- Preserved **runtime pano geometry resolution** from:
  - inferred vehicle profile
  - saved/persisted probe results (`cameraId`, `surfaceMode`, `width`, `height`)

### Why

Different vehicles can expose different panoramic configurations:

- different panoramic camera IDs
- different panoramic resolutions (for example Tang vs Seal/Atto)
- different merged-strip ordering for the panoramic slices

Before this change, the app could handle some camera/resolution differences, but downstream GPU consumers still assumed a fixed strip order. That meant the UI could appear configurable while recording, streaming, and AI still relied on legacy front/right/rear/left offsets.

This PR fixes that by separating:

- **geometry**: pano camera id, surface mode, width, height
- **layout**: which merged slice corresponds to front/right/rear/left

### How it works

#### 1. Panoramic stream selection / geometry

At startup, `CameraConfigResolver` resolves the pano stream using:

- inferred vehicle defaults (`CameraProfiles`)
- persisted probe results:
  - `probedCameraId`
  - `probedSurfaceMode`
  - `probedWidth`
  - `probedHeight`

This handles the panoramic stream source and resolution.

#### 2. Panoramic slice calibration

The merged strip is treated as four neutral raw slices:

- `slice1`
- `slice2`
- `slice3`
- `slice4`

These are physical quarters of the merged strip, not semantic views.

In Diagnostics, the user previews the raw slices and assigns logical pano roles:

- `360 Front`
- `360 Right`
- `360 Rear`
- `360 Left`

to the slice that actually shows that direction on the vehicle.

#### 3. Resolved logical layout

`ResolvedCameraConfig` combines:

- profile defaults
- saved role mappings

and derives the final logical pano layout. That resolved layout then produces the strip offsets used by the rest of the pipeline.

#### 4. Pipeline propagation

The resolved panoramic layout is now used consistently by:

- downscaled AI/motion input
- 2x2 mosaic recording
- streamed single-view/mosaic output
- foveated high-resolution AI crops

This keeps previews, recording, streaming, and AI aligned to the same calibrated slice mapping.

### User workflow

1. Open **Diagnostics**
2. Tap the camera button
3. Review direct streams and merged pano slices
4. Select a logical role (for example `360 Front`)
5. Save the candidate slice/stream that actually matches that role
6. The app saves the mapping and **automatically restarts the camera daemon**
7. The calibrated layout is reused across the full pipeline