### PR TITLE
Fix/camera auto probe no frame timeout

### DIFF
--- a/app/src/main/java/com/overdrive/app/camera/AvcHalWarmup.java
+++ b/app/src/main/java/com/overdrive/app/camera/AvcHalWarmup.java
@@ -47,6 +47,10 @@ public class AvcHalWarmup {
 
     private volatile Thread keepAliveThread;
     private volatile boolean active = false;
+    private volatile long lastStartedAtMs = 0L;
+    private volatile boolean lastResult = false;
+    private volatile String lastReason = "";
+    private volatile String lastError = "";
 
     public AvcHalWarmup() {
     }
@@ -62,18 +66,37 @@ public class AvcHalWarmup {
      * @return true if warmup completed, false if interrupted
      */
     public boolean warmupAndWait() {
+        return warmupAndWait("unspecified");
+    }
+
+    /**
+     * Launches com.byd.avc and blocks for HAL_WARMUP_DELAY_MS.
+     * Call this BEFORE opening the camera on ACC ON transitions.
+     *
+     * This is a blocking call — run it on a background thread.
+     *
+     * @param reason human-readable caller reason for logging/status
+     * @return true if warmup completed, false if interrupted
+     */
+    public synchronized boolean warmupAndWait(String reason) {
+        lastStartedAtMs = System.currentTimeMillis();
+        lastReason = reason == null ? "" : reason;
+        lastError = "";
         logger.info("Warming up camera HAL via com.byd.avc (waiting " +
-            HAL_WARMUP_DELAY_MS + "ms)...");
+            HAL_WARMUP_DELAY_MS + "ms, reason=" + lastReason + ")...");
 
         launchAvc();
 
         try {
             Thread.sleep(HAL_WARMUP_DELAY_MS);
             logger.info("HAL warmup complete — safe to open camera");
+            lastResult = true;
             return true;
         } catch (InterruptedException e) {
             logger.warn("HAL warmup interrupted");
             Thread.currentThread().interrupt();
+            lastResult = false;
+            lastError = e.getMessage();
             return false;
         }
     }
@@ -145,6 +168,22 @@ public class AvcHalWarmup {
      */
     public boolean isActive() {
         return active;
+    }
+
+    public long getLastStartedAtMs() {
+        return lastStartedAtMs;
+    }
+
+    public boolean getLastResult() {
+        return lastResult;
+    }
+
+    public String getLastReason() {
+        return lastReason;
+    }
+
+    public String getLastError() {
+        return lastError;
     }
 
     // ==================== Internal ====================

--- a/app/src/main/java/com/overdrive/app/camera/AvmCameraHelper.java
+++ b/app/src/main/java/com/overdrive/app/camera/AvmCameraHelper.java
@@ -8,7 +8,7 @@ import com.overdrive.app.logging.DaemonLogger;
  * Camera lifecycle (open/close/startPreview/addPreviewSurface) is already handled
  * inline in PanoramicCameraGpu and BydCameraCoordinator via reflection.
  * This class only adds genuinely new capabilities:
- * - BmmCameraInfo discovery (instant camera ID lookup)
+ * - BmmCameraInfo discovery (instant camera tuple lookup)
  * - setCameraFps (frame rate control)
  */
 public final class AvmCameraHelper {
@@ -29,21 +29,19 @@ public final class AvmCameraHelper {
     // ── Camera Discovery (REQ-1) ────────────────────────────────────────
 
     /**
-     * Discovers the panoramic camera ID via BmmCameraInfo.getCameraId() reflection.
-     * BmmCameraInfo reads the system property vehicle.config.cam_sort which maps
-     * camera tags to IDs. Tries pano_h → pano_l → byd_apa → apa.
+     * Discovers the panoramic camera tuple via BmmCameraInfo.getCameraId()
+     * reflection. BmmCameraInfo reads the system property vehicle.config.cam_sort
+     * which maps camera tags to IDs. Tries pano_h → pano_l → byd_apa → apa.
      *
-     * @return camera ID (>= 0) or -1 if not found
+     * @return tuple or null if no panoramic camera is available
      */
-    public static int discoverPanoCameraId() {
+    public static PanoCameraDiscovery discoverPanoCamera() {
         try {
             Class<?> bmmClass = Class.forName(BMM_CAMERA_INFO_CLASS);
 
             // Dump raw system property for debugging
             try {
-                Class<?> sp = Class.forName("android.os.SystemProperties");
-                java.lang.reflect.Method get = sp.getMethod("get", String.class);
-                String camSort = (String) get.invoke(null, "vehicle.config.cam_sort");
+                String camSort = CameraFirmwareInfo.readSystemProperty("vehicle.config.cam_sort");
                 logger.info("vehicle.config.cam_sort = "
                     + (camSort != null && !camSort.isEmpty() ? "'" + camSort + "'" : "(empty/null)"));
             } catch (Exception e) {
@@ -72,19 +70,33 @@ public final class AvmCameraHelper {
                     int id = (Integer) result;
                     if (id >= 0) {
                         logger.info("Discovered panoramic camera: " + tag + " → ID " + id);
-                        return id;
+                        // APA-family tags are intentionally flagged as a
+                        // different layout class so downstream rendering and
+                        // diagnostics can distinguish them from the standard
+                        // pano strip.
+                        int layout = ("byd_apa".equals(tag) || "apa".equals(tag)) ? 1 : 0;
+                        String camSort = CameraFirmwareInfo.readSystemProperty("vehicle.config.cam_sort");
+                        return new PanoCameraDiscovery(id, 0, layout, tag, "bmm:" + tag, camSort);
                     }
                 }
             }
             logger.info("BmmCameraInfo: no panoramic camera found for any tag");
-            return -1;
+            return null;
         } catch (ClassNotFoundException e) {
             logger.warn("BmmCameraInfo class not available on this device");
-            return -1;
+            return null;
         } catch (Exception e) {
             logger.warn("BmmCameraInfo discovery failed: " + e.getMessage());
-            return -1;
+            return null;
         }
+    }
+
+    /**
+     * Compatibility wrapper that returns only the camera ID.
+     */
+    public static int discoverPanoCameraId() {
+        PanoCameraDiscovery discovery = discoverPanoCamera();
+        return discovery != null ? discovery.cameraId : -1;
     }
 
     // ── Frame Rate Control (REQ-2) ──────────────────────────────────────

--- a/app/src/main/java/com/overdrive/app/camera/BydCameraCoordinator.java
+++ b/app/src/main/java/com/overdrive/app/camera/BydCameraCoordinator.java
@@ -41,6 +41,8 @@ public class BydCameraCoordinator {
 
     // Native app activity tracking (for polling fallback)
     private volatile boolean nativeAppActive = false;
+    private volatile String lastCameraOwnerPackage = "";
+    private volatile String arbitrationMode = "eventCallbackOnly";
 
     // Yield state
     private volatile boolean yielded = false;
@@ -66,6 +68,10 @@ public class BydCameraCoordinator {
 
     public void setActiveCameraId(int cameraId) {
         this.activeCameraId = cameraId;
+    }
+
+    public void setArbitrationMode(String mode) {
+        this.arbitrationMode = (mode == null || mode.isEmpty()) ? "eventCallbackOnly" : mode;
     }
 
     // ==================== IBYDCameraService Connection ====================
@@ -143,6 +149,11 @@ public class BydCameraCoordinator {
             // We don't participate in IBYDCameraService arbitration.
             // discoverCameraServiceApi();
             // registerCameraUser();
+            // Explicit experiment gate: only this mode is allowed to touch the
+            // registerUser path. The default modes remain polling/event-callback only.
+            if ("registeredUserExperiment".equals(arbitrationMode)) {
+                registerCameraUser();
+            }
 
         } catch (ClassNotFoundException e) {
             logger.info("IBYDCameraService not found — camera arbitration unavailable");
@@ -327,14 +338,6 @@ public class BydCameraCoordinator {
         return yielded;
     }
 
-    /**
-     * Whether we're using event-driven registration (true) or polling fallback (false).
-     * Permanently false — registerCameraUser is DISABLED.
-     */
-    public boolean isRegisteredAsUser() {
-        return false;
-    }
-
     // ==================== Polling Fallback ====================
 
     /**
@@ -355,10 +358,12 @@ public class BydCameraCoordinator {
                 if (currentUser != null) {
                     Method getPkg = currentUser.getClass().getMethod("getPackageName");
                     String pkg = (String) getPkg.invoke(currentUser);
+                    lastCameraOwnerPackage = pkg != null ? pkg : "";
                     if (pkg != null && !"com.overdrive.app".equals(pkg)) return pkg;
                 }
             } catch (Exception e) { /* ignore */ }
         }
+        lastCameraOwnerPackage = "";
         return null;
     }
 
@@ -389,6 +394,7 @@ public class BydCameraCoordinator {
 
                 boolean isUs = "com.overdrive.app".equals(pkg);
                 boolean wasActive = nativeAppActive;
+                lastCameraOwnerPackage = pkg != null ? pkg : "";
                 nativeAppActive = !isUs && pkg != null;
 
                 if (nativeAppActive && !wasActive) {
@@ -403,6 +409,7 @@ public class BydCameraCoordinator {
                 if (nativeAppActive) {
                     logger.info("No current camera user (polling) — native app released");
                     nativeAppActive = false;
+                    lastCameraOwnerPackage = "";
                     handleNativeAppClosed();
                 }
                 return false;
@@ -615,6 +622,9 @@ public class BydCameraCoordinator {
     public void unregister() {
         // Camera user unregistration DISABLED — we never register, so nothing to unregister.
         // unregisterCameraUser();
+        if (registeredAsUser) {
+            unregisterCameraUser();
+        }
         serviceAvailable = false;
         typedServiceProxy = null;
         reflectionServiceProxy = null;
@@ -624,10 +634,13 @@ public class BydCameraCoordinator {
     // ==================== State Queries ====================
 
     public boolean isNativeAppActive() { return nativeAppActive; }
+    public String getCurrentCameraOwnerPackage() { return lastCameraOwnerPackage; }
     // cameraUser is permanently null (registerCameraUser DISABLED), so polling 'yielded' is canonical.
     public boolean isYielded() { return yielded; }
     public boolean isRegistered() { return serviceAvailable; }
+    public boolean isRegisteredAsUser() { return registeredAsUser; }
     public boolean isEventCallbackActive() { return eventCallbackSet; }
+    public String getArbitrationMode() { return arbitrationMode; }
     public void resetEventCallbackState() { eventCallbackSet = false; }
 
     // ==================== AIDL Discovery ====================

--- a/app/src/main/java/com/overdrive/app/camera/CameraFirmwareInfo.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraFirmwareInfo.java
@@ -1,0 +1,105 @@
+package com.overdrive.app.camera;
+
+import android.os.Build;
+
+import org.json.JSONObject;
+
+import java.lang.reflect.Method;
+
+/**
+ * Snapshot of the current build/vehicle identity used to decide whether a
+ * previously validated BYD camera tuple is still trustworthy.
+ */
+public final class CameraFirmwareInfo {
+
+    public final String fingerprint;
+    public final String buildDisplay;
+    public final String buildIncremental;
+    public final String roBuildIncremental;
+    public final String device;
+    public final String vehicleCamSort;
+
+    public CameraFirmwareInfo(
+            String fingerprint,
+            String buildDisplay,
+            String buildIncremental,
+            String roBuildIncremental,
+            String device,
+            String vehicleCamSort) {
+        this.fingerprint = normalize(fingerprint);
+        this.buildDisplay = normalize(buildDisplay);
+        this.buildIncremental = normalize(buildIncremental);
+        this.roBuildIncremental = normalize(roBuildIncremental);
+        this.device = normalize(device);
+        this.vehicleCamSort = normalize(vehicleCamSort);
+    }
+
+    public static CameraFirmwareInfo current() {
+        // Capture a snapshot of the current runtime build identity. This is
+        // read-only metadata used to judge tuple trust, not a config writer.
+        return new CameraFirmwareInfo(
+                Build.FINGERPRINT,
+                Build.DISPLAY,
+                Build.VERSION.INCREMENTAL,
+                readSystemProperty("ro.build.version.incremental"),
+                Build.DEVICE,
+                readSystemProperty("vehicle.config.cam_sort"));
+    }
+
+    public static String readSystemProperty(String key) {
+        // Best-effort reflection only. These properties are useful for
+        // camera tuple trust decisions, but the app must still work if the
+        // hidden SystemProperties API is unavailable on a given build.
+        try {
+            Class<?> sp = Class.forName("android.os.SystemProperties");
+            Method get = sp.getMethod("get", String.class);
+            Object value = get.invoke(null, key);
+            return value != null ? value.toString() : "";
+        } catch (Throwable ignored) {
+            return "";
+        }
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        try {
+            json.put("firmwareFingerprint", fingerprint);
+            json.put("buildDisplay", buildDisplay);
+            json.put("buildIncremental", buildIncremental);
+            json.put("roBuildIncremental", roBuildIncremental);
+            json.put("productDevice", device);
+            json.put("vehicleCamSort", vehicleCamSort);
+        } catch (Exception ignored) {
+        }
+        return json;
+    }
+
+    public boolean matches(JSONObject cameraConfig) {
+        if (cameraConfig == null) return false;
+        // Treat the tuple as the unit of trust: every firmware signal must
+        // match before a saved BYD camera selection is considered current.
+        return eq(cameraConfig.optString("firmwareFingerprint", ""), fingerprint)
+                && eq(cameraConfig.optString("buildDisplay", ""), buildDisplay)
+                && eq(cameraConfig.optString("buildIncremental", ""), buildIncremental)
+                && eq(cameraConfig.optString("roBuildIncremental", ""), roBuildIncremental)
+                && eq(cameraConfig.optString("productDevice", ""), device)
+                && eq(cameraConfig.optString("vehicleCamSort", ""), vehicleCamSort);
+    }
+
+    public boolean hasAnySignal() {
+        return !fingerprint.isEmpty()
+                || !buildDisplay.isEmpty()
+                || !buildIncremental.isEmpty()
+                || !roBuildIncremental.isEmpty()
+                || !device.isEmpty()
+                || !vehicleCamSort.isEmpty();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static boolean eq(String a, String b) {
+        return normalize(a).equals(normalize(b));
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/PanoCameraDiscovery.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoCameraDiscovery.java
@@ -1,0 +1,61 @@
+package com.overdrive.app.camera;
+
+import org.json.JSONObject;
+
+/**
+ * Structured result of panoramic BYD camera discovery.
+ *
+ * Keep this richer than the legacy integer-only API so field debugging can
+ * tell which BMM tag and layout actually selected the tuple.
+ */
+public final class PanoCameraDiscovery {
+
+    public final int cameraId;
+    public final int surfaceMode;
+    public final int cameraLayout;
+    public final String sourceTag;
+    public final String method;
+    public final String vehicleCamSort;
+
+    public PanoCameraDiscovery(
+            int cameraId,
+            int surfaceMode,
+            int cameraLayout,
+            String sourceTag,
+            String method,
+            String vehicleCamSort) {
+        this.cameraId = cameraId;
+        this.surfaceMode = surfaceMode;
+        this.cameraLayout = cameraLayout;
+        this.sourceTag = sourceTag == null ? "" : sourceTag;
+        this.method = method == null ? "" : method;
+        this.vehicleCamSort = vehicleCamSort == null ? "" : vehicleCamSort;
+    }
+
+    public JSONObject toJson() {
+        JSONObject json = new JSONObject();
+        try {
+            // Persist the same field names used by the camera config/status
+            // payloads so a single discovery object can be written through
+            // without extra translation.
+            json.put("probedCameraId", cameraId);
+            json.put("probedSurfaceMode", surfaceMode);
+            json.put("cameraLayout", cameraLayout);
+            json.put("sourceBmmTag", sourceTag);
+            json.put("discoveryMethod", method);
+            json.put("vehicleCamSort", vehicleCamSort);
+        } catch (Exception ignored) {
+        }
+        return json;
+    }
+
+    @Override
+    public String toString() {
+        return "PanoCameraDiscovery{id=" + cameraId
+                + ", surfaceMode=" + surfaceMode
+                + ", layout=" + cameraLayout
+                + ", sourceTag='" + sourceTag + '\''
+                + ", method='" + method + '\''
+                + ", vehicleCamSort='" + vehicleCamSort + '\'' + '}';
+    }
+}

--- a/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
@@ -190,6 +190,11 @@ public class PanoramicCameraGpu {
     // When native app is active, use a longer threshold to avoid false yields
     // from transient CPU/IO load. The HAL needs time to settle into sharing mode.
     private static final long FRAME_STALL_CONTENTION_THRESHOLD_MS = 3000;
+    // Auto-probe normally advances at frame 15. If a camera/mode opens but
+    // produces no frames at all, frameCounter never reaches 15, so use this
+    // wall-clock guard to move to the next candidate instead of staying in
+    // probeComplete=false forever.
+    private static final long PROBE_NO_FRAME_TIMEOUT_MS = 6000;
     // Require consecutive stalls before yielding — a single stall could be transient
     private static final int CONTENTION_STALL_COUNT_TO_YIELD = 2;
     private volatile int consecutiveContentionStalls = 0;
@@ -1003,6 +1008,13 @@ public class PanoramicCameraGpu {
             lastGlThreadHeartbeat = System.currentTimeMillis();
             maybeLogImageReaderDiag();
 
+            // Auto-probe must advance even when a candidate camera/mode opens
+            // successfully but never produces enough frames to reach the
+            // frame-15 validation branch.
+            if (maybeAdvanceProbeAfterNoFrames()) {
+                return;
+            }
+
             // SOTA: Skip frame processing if camera is yielded to native app,
             // not yet open, or being torn down/reopened by the daemon thread
             // (reopenCamera/restartCameraAfterError). The restartInProgress
@@ -1411,6 +1423,37 @@ public class PanoramicCameraGpu {
         }
     }
 
+    private boolean maybeAdvanceProbeAfterNoFrames() {
+        if (!autoProbeCameras || probeComplete || skipFrameValidation || frameCounter >= 15) {
+            return false;
+        }
+        long startedAt = lastCameraStartTime;
+        if (startedAt <= 0) {
+            return false;
+        }
+        long elapsedMs = System.currentTimeMillis() - startedAt;
+        if (elapsedMs < PROBE_NO_FRAME_TIMEOUT_MS) {
+            return false;
+        }
+
+        int currentId = cameraIdOverride >= 0 ? cameraIdOverride : PHYSICAL_CAMERA_ID;
+        logger.warn("Auto-probe: camera ID " + currentId
+            + " surfaceMode=" + cameraSurfaceMode
+            + " produced only " + frameCounter + " frames in " + elapsedMs
+            + "ms; advancing probe");
+        recordValidationSnapshot(
+            false,
+            "probe_timeout_no_frames",
+            "low",
+            cameraLayout == 1 ? "unknown" : "low",
+            "probe_timeout_no_frames",
+            width,
+            height,
+            frameCounter);
+        advanceProbeToNext(currentId);
+        return true;
+    }
+
     private String summarizeQuadrantVariance(byte[] probe8x8) {
         // This is diagnostics only. It turns the 8x8 probe into a compact
         // summary so logs and persisted config can explain *why* a frame was
@@ -1512,10 +1555,8 @@ public class PanoramicCameraGpu {
     }
 
     /**
-     * SOTA: Advance to the next camera ID during probe.
-     * Surface mode 0 is confirmed working on all tested models — only probe camera IDs 0-5.
-     * 
-     * @param skipId Camera ID to skip (the one we just tested). -1 to start fresh.
+     * Builds the camera ID order for the surface-mode matrix fallback.
+     * The list starts with the best evidence we have, then fills in 0-5.
      */
     private int[] buildSurfaceModeProbeCameraIds() {
         java.util.LinkedHashSet<Integer> ids = new java.util.LinkedHashSet<>();

--- a/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
+++ b/app/src/main/java/com/overdrive/app/camera/PanoramicCameraGpu.java
@@ -23,14 +23,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * PanoramicCameraGpu - GPU Edition with Zero-Copy Pipeline.
  * 
- * This is the GPU-native version of PanoramicCamera that replaces ImageReader
- * with SurfaceTexture. Camera frames flow directly to GPU texture, enabling:
+ * This is the GPU-native version of PanoramicCamera that uses an
+ * ImageReader-backed HardwareBuffer path. Camera frames flow directly to a
+ * GPU external OES texture, enabling:
  * - Zero-copy recording (camera → GPU → encoder)
  * - Minimal AI readback (GPU downscales to 320x240)
  * - <10% total CPU usage
  * 
  * Architecture:
- * - Camera writes to GL_TEXTURE_EXTERNAL_OES via SurfaceTexture
+ * - Camera writes to GL_TEXTURE_EXTERNAL_OES via ImageReader + HardwareBuffer
  * - Render loop on dedicated GL thread distributes frames to:
  *   - Recording Lane: GpuMosaicRecorder (zero-copy to encoder)
  *   - AI Lane: GpuDownscaler (2 FPS readback for motion detection)
@@ -47,6 +48,8 @@ public class PanoramicCameraGpu {
     
     // Camera ID override — set via setCameraId() before start()
     private int cameraIdOverride = -1;  // -1 = use default PHYSICAL_CAMERA_ID
+    private volatile boolean manualOverrideActive = false;
+    private volatile boolean fallbackFromProbe = false;
     
     // SOTA: Full-matrix auto-probe — sweeps camera IDs 0-5 × surface modes 0-5
     // to find the first combination that produces panoramic image data.
@@ -56,6 +59,9 @@ public class PanoramicCameraGpu {
     private int probeStartId = -1;  // Tracks where probe started for wrap-around detection
     private int probeNextCameraId = 0;    // Next camera ID to try
     private int probeNextSurfaceMode = 0; // Next surface mode to try
+    private boolean probeSurfaceModeMatrixActive = false;
+    private int[] probeMatrixCameraIds = new int[0];
+    private int probeMatrixCameraIndex = 0;
     
     // SOTA: Probe gate — blocks recording/streaming/AI until probe finds a working camera.
     // Without this, the encoder records BLACK frames and the stream shows garbage during probe.
@@ -66,6 +72,26 @@ public class PanoramicCameraGpu {
     // If the probe exhausts all IDs without finding a verified strip, fall back
     // to this camera — it's better to record from a real camera than nothing.
     private int lastDataCameraId = -1;
+    private volatile int cameraLayout = 0;
+    private volatile String sourceBmmTag = "";
+    private volatile String discoveryMethod = "";
+    private volatile String vehicleCamSort = "";
+    private volatile CameraFirmwareInfo firmwareInfo = CameraFirmwareInfo.current();
+    private volatile String nativeProbeReport = "";
+    private volatile boolean nativeProbeReady = false;
+    private volatile String fpsSetCameraResult = "unknown";
+    private volatile String fpsSetMediaCodecResult = "not_wired";
+    private volatile long validatedAtMs = 0L;
+    private volatile int validatedFrameWidth = 0;
+    private volatile int validatedFrameHeight = 0;
+    private volatile int validationFrameCount = 0;
+    private volatile String validationSignal = "";
+    private volatile String stripConfidence = "";
+    private volatile String layoutConfidence = "";
+    private volatile String quadrantVariance = "";
+    private volatile String lastValidationFailure = "";
+    private volatile String lastCameraEvent = "";
+    private volatile String arbitrationMode = "eventCallbackOnly";
     
     // Callback when auto-probe discovers a working camera config
     public interface CameraProbeCallback {
@@ -83,7 +109,7 @@ public class PanoramicCameraGpu {
     private int cameraTextureId;
     // Camera consumer: ImageReader → AHardwareBuffer → EGLImage →
     // cameraTextureId. Bypasses SurfaceFlinger throttling that clamps the
-    // SurfaceTexture path to ~8.5 fps on DiLink50 5.0UI builds (verified by
+    // Legacy SurfaceTexture consumer path drops to ~8.5 fps on DiLink50 5.0UI builds (verified by
     // AvmImageReaderFpsProbe → 26 fps panoramic). cameraSurface is what we
     // hand to AVMCamera.addPreviewSurface — sourced from ImageReader.getSurface().
     // minSdk=28 enforces Image.getHardwareBuffer availability.
@@ -281,6 +307,7 @@ public class PanoramicCameraGpu {
         // SOTA: Initialize BYD camera coordinator for cooperative sharing
         if (cameraCoordinator == null) {
             cameraCoordinator = new BydCameraCoordinator();
+            cameraCoordinator.setArbitrationMode(arbitrationMode);
             cameraCoordinator.setYieldCallback(new BydCameraCoordinator.CameraYieldCallback() {
                 @Override
                 public void onYieldCamera() {
@@ -407,7 +434,9 @@ public class PanoramicCameraGpu {
         
         // Log GL info (now that context is current)
         GlUtil.logGlInfo();
-        
+
+        probeHardwareBufferBridge();
+
         // Create camera texture (OES type for external camera)
         cameraTextureId = GlUtil.createExternalTexture();
 
@@ -512,12 +541,12 @@ public class PanoramicCameraGpu {
     }
     
     /**
-     * Recreates the SurfaceTexture and Surface for camera switching.
+     * Recreates the ImageReader consumer for camera switching.
      * 
      * The BYD AVMCamera HAL doesn't properly deliver frames to a Surface
      * that was previously connected to a different camera ID. After the first
      * frame, subsequent frames are never delivered, causing a frozen image.
-     * Recreating the SurfaceTexture forces a clean connection to the new camera.
+     * Recreating the ImageReader consumer forces a clean connection to the new camera.
      */
     private void recreateCameraSurface() {
         logger.info("Recreating ImageReader consumer for camera switch...");
@@ -572,6 +601,100 @@ public class PanoramicCameraGpu {
         cameraImageReader.setOnImageAvailableListener(
             this::onHalImageAvailable, imageReaderHandler);
         cameraSurface = cameraImageReader.getSurface();
+    }
+
+    private void probeHardwareBufferBridge() {
+        if (!com.overdrive.app.surveillance.NativeMotion.isLibraryLoaded()) {
+            throw new IllegalStateException("libsurveillance not loaded before camera startup");
+        }
+
+        String report = HardwareBufferTextureBinder.probeExtensionsNative();
+        nativeProbeReport = report != null ? report : "";
+        nativeProbeReady = isHardwareBufferBridgeReady(nativeProbeReport);
+        logger.info("HardwareBuffer bridge probe: " + nativeProbeReport);
+
+        if (!nativeProbeReady) {
+            throw new IllegalStateException("HardwareBuffer bridge missing required extensions: " + nativeProbeReport);
+        }
+    }
+
+    private static boolean isHardwareBufferBridgeReady(String report) {
+        if (report == null || report.isEmpty()) {
+            return false;
+        }
+        String[] requiredTokens = new String[] {
+            "fnsResolved=true",
+            "ahbFromHwb=y",
+            "EGL_KHR_image_base=y",
+            "EGL_ANDROID_get_native_client_buffer=y",
+            "EGL_ANDROID_image_native_buffer=y",
+            "GL_OES_EGL_image_external=y",
+            "currentDisplay=yes"
+        };
+        for (String token : requiredTokens) {
+            if (!report.contains(token)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void persistCameraConfigSnapshot(boolean validated, String failureReason) {
+        try {
+            org.json.JSONObject existingCam = com.overdrive.app.config.UnifiedConfigManager
+                .loadConfig().optJSONObject("camera");
+            int currentId = getCameraId();
+            boolean existingManual = existingCam != null && existingCam.optBoolean("manualOverride", false);
+            int existingId = existingCam != null ? existingCam.optInt("probedCameraId", -1) : -1;
+
+            if (existingManual && existingId >= 0 && existingId != currentId && !manualOverrideActive) {
+                logger.info("Skipping config write — manual override exists (saved=" + existingId +
+                    ", running=" + currentId + ")");
+                return;
+            }
+
+            org.json.JSONObject camCfg = new org.json.JSONObject();
+            camCfg.put("probedCameraId", currentId);
+            camCfg.put("probedSurfaceMode", cameraSurfaceMode);
+            camCfg.put("cameraLayout", cameraLayout);
+            camCfg.put("probedAndValidated", validated);
+            camCfg.put("manualOverride", manualOverrideActive || existingManual);
+            camCfg.put("fallbackFromProbe", fallbackFromProbe);
+            camCfg.put("reprobeOnNextRestart", false);
+            camCfg.put("sourceBmmTag", sourceBmmTag);
+            camCfg.put("discoveryMethod", discoveryMethod);
+            camCfg.put("vehicleCamSort", vehicleCamSort);
+            camCfg.put("validatedAtMs", validatedAtMs);
+            camCfg.put("validatedFrameWidth", validatedFrameWidth);
+            camCfg.put("validatedFrameHeight", validatedFrameHeight);
+            camCfg.put("validationSignal", validationSignal);
+            camCfg.put("validationFrameCount", validationFrameCount);
+            camCfg.put("stripConfidence", stripConfidence);
+            camCfg.put("layoutConfidence", layoutConfidence);
+            camCfg.put("quadrantVariance", quadrantVariance);
+            camCfg.put("lastValidationFailure", failureReason == null ? lastValidationFailure : failureReason);
+            camCfg.put("nativeProbeReport", nativeProbeReport);
+            camCfg.put("nativeProbeReady", nativeProbeReady);
+            camCfg.put("arbitrationMode", arbitrationMode);
+            camCfg.put("fpsSetCameraResult", fpsSetCameraResult);
+            camCfg.put("fpsSetMediaCodecResult", fpsSetMediaCodecResult);
+            camCfg.put("lastCameraEvent", lastCameraEvent);
+            if (firmwareInfo != null) {
+                camCfg.put("firmwareFingerprint", firmwareInfo.fingerprint);
+                camCfg.put("buildDisplay", firmwareInfo.buildDisplay);
+                camCfg.put("buildIncremental", firmwareInfo.buildIncremental);
+                camCfg.put("roBuildIncremental", firmwareInfo.roBuildIncremental);
+                camCfg.put("productDevice", firmwareInfo.device);
+                camCfg.put("vehicleCamSort", firmwareInfo.vehicleCamSort);
+            }
+            com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+        } catch (Exception ex) {
+            logger.warn("Failed to save camera config: " + ex.getMessage());
+        }
+    }
+
+    public void persistCameraConfig(boolean validated, String failureReason) {
+        persistCameraConfigSnapshot(validated, failureReason);
     }
 
     /** Idempotent teardown of whichever consumer is active. */
@@ -695,7 +818,13 @@ public class PanoramicCameraGpu {
         // rejects setCameraFps once a preview surface is attached — even before
         // startPreview. Order must be open → setCameraFps → addPreviewSurface →
         // startPreview to match the BYD HAL state machine.
-        AvmCameraHelper.setCameraFps(cameraObj, targetFps);
+        boolean fpsOk = AvmCameraHelper.setCameraFps(cameraObj, targetFps);
+        fpsSetCameraResult = fpsOk
+            ? "startup:setCameraFps(" + targetFps + ")=ok"
+            : "startup:setCameraFps(" + targetFps + ")=failed";
+        // We intentionally stop at setCameraFps here. The encoder-owned
+        // MediaCodec path is surfaced only as diagnostics until a real owner
+        // passes the codec across the boundary.
 
         // Connect surface — mode 0 works on Seal, other models may need different mode
         Method mAddSurface = avmClass.getDeclaredMethod("addPreviewSurface", Surface.class, int.class);
@@ -922,6 +1051,13 @@ public class PanoramicCameraGpu {
                     }
                     int currentId = cameraIdOverride >= 0 ? cameraIdOverride : PHYSICAL_CAMERA_ID;
                     boolean isPanoramic = width >= 5000;
+                    boolean stripVerified = verifyPanoramicStrip(probe);
+                    String stripConfidenceValue = stripVerified ? "high" : "low";
+                    String layoutConfidenceValue = stripVerified
+                        ? (cameraLayout == 1 ? "apa_candidate" : "high")
+                        : (cameraLayout == 1 ? "unknown" : "low");
+                    String quadrantVarianceValue = summarizeQuadrantVariance(probe);
+                    setQuadrantVariance(quadrantVarianceValue);
                     logger.info("Camera ID " + currentId + " probe: " + 
                         (hasData ? "HAS DATA" : "BLACK") +
                         " | resolution=" + width + "x" + height +
@@ -931,6 +1067,15 @@ public class PanoramicCameraGpu {
                     if (hasData && isPanoramic) {
                         // Track this camera as having real data (for fallback if strip check fails)
                         lastDataCameraId = currentId;
+                        recordValidationSnapshot(
+                            stripVerified,
+                            stripVerified ? "frame15_non_black_5120x960" : "frame15_non_black_low_layout_confidence",
+                            stripConfidenceValue,
+                            layoutConfidenceValue,
+                            stripVerified ? "" : "frame15_low_layout_confidence",
+                            width,
+                            height,
+                            frameCounter);
                         
                         // During auto-probe: accept the first camera with non-black panoramic data.
                         // The 5120x960 resolution IS the panoramic strip identifier on BYD — no other
@@ -938,11 +1083,13 @@ public class PanoramicCameraGpu {
                         // strip check was producing false negatives in low-light/uniform scenes.
                         if (autoProbeCameras) {
                             logger.info("Auto-probe: SELECTED camera ID " + currentId + 
-                                " (panoramic data confirmed, surfaceMode=" + cameraSurfaceMode + ")");
+                                " (panoramic data confirmed, surfaceMode=" + cameraSurfaceMode +
+                                ", stripVerified=" + stripVerified + ")");
                             autoProbeCameras = false;
                             probeStartId = -1;
                             probeComplete = true;
                             lastDataCameraId = -1;
+                            persistCameraConfigSnapshot(stripVerified, stripVerified ? null : "frame15_low_layout_confidence");
                             logger.info("Probe complete — recording/streaming/AI lanes now active");
                             if (probeCallback != null) {
                                 probeCallback.onCameraFound(currentId, cameraSurfaceMode);
@@ -953,6 +1100,7 @@ public class PanoramicCameraGpu {
                             // No further validation needed (skipFrameValidation handles saved configs,
                             // but this path covers the default camera ID 1 on first boot).
                             probeComplete = true;
+                            persistCameraConfigSnapshot(stripVerified, stripVerified ? null : "frame15_low_layout_confidence");
                         }
                     } else if (autoProbeCameras) {
                         // Advance to next combination in the matrix
@@ -966,6 +1114,15 @@ public class PanoramicCameraGpu {
                         // Don't re-probe immediately (causes OEM dashcam "no signal").
                         // Instead, schedule a second check at frame 50 (~5s). If still black
                         // at that point, the saved config is genuinely wrong and we re-probe.
+                        recordValidationSnapshot(
+                            false,
+                            "frame15_black",
+                            "low",
+                            cameraLayout == 1 ? "unknown" : "low",
+                            "frame15_black",
+                            width,
+                            height,
+                            frameCounter);
                         logger.warn("Frame 15 readback BLACK for cam=" + currentId +
                             ", surfaceMode=" + cameraSurfaceMode +
                             " — will recheck at frame 50 before deciding");
@@ -990,12 +1147,24 @@ public class PanoramicCameraGpu {
                     }
                     if (!hasData) {
                         int currentId = cameraIdOverride >= 0 ? cameraIdOverride : PHYSICAL_CAMERA_ID;
+                        boolean stripVerified = verifyPanoramicStrip(probe);
+                        String quadrantVarianceValue = summarizeQuadrantVariance(probe);
+                        setQuadrantVariance(quadrantVarianceValue);
+                        recordValidationSnapshot(
+                            stripVerified,
+                            stripVerified ? "frame50_non_black_5120x960" : "frame50_non_black_low_layout_confidence",
+                            stripVerified ? "high" : "low",
+                            stripVerified ? (cameraLayout == 1 ? "apa_candidate" : "high")
+                                : (cameraLayout == 1 ? "unknown" : "low"),
+                            stripVerified ? "" : "frame50_low_layout_confidence",
+                            width,
+                            height,
+                            frameCounter);
                         logger.warn("Frame 50 STILL BLACK for cam=" + currentId +
                             " — saved config is wrong, starting re-probe");
-                        autoProbeCameras = true;
+                        persistCameraConfigSnapshot(false, "frame50_black");
+                        setAutoProbeCameras(true);
                         probeComplete = false;
-                        probeNextCameraId = 0;
-                        probeNextSurfaceMode = 0;
                         lastDataCameraId = -1;
                         advanceProbeToNext(currentId);
                     } else {
@@ -1004,26 +1173,25 @@ public class PanoramicCameraGpu {
                         // BUT: don't overwrite if user has a manual override set — they may have
                         // changed the camera ID in the UI and it hasn't taken effect yet.
                         int currentId = cameraIdOverride >= 0 ? cameraIdOverride : PHYSICAL_CAMERA_ID;
+                        boolean stripVerified = verifyPanoramicStrip(probe);
+                        String quadrantVarianceValue = summarizeQuadrantVariance(probe);
+                        setQuadrantVariance(quadrantVarianceValue);
+                        String stripConfidenceValue = stripVerified ? "high" : "low";
+                        String layoutConfidenceValue = stripVerified
+                            ? (cameraLayout == 1 ? "apa_candidate" : "high")
+                            : (cameraLayout == 1 ? "unknown" : "low");
                         logger.info("Frame 50 recheck: camera ID " + currentId + " confirmed working");
                         probeComplete = true;
-                        try {
-                            org.json.JSONObject existingCam = com.overdrive.app.config.UnifiedConfigManager
-                                .loadConfig().optJSONObject("camera");
-                            boolean hasManualOverride = existingCam != null && existingCam.optBoolean("manualOverride", false);
-                            int savedId = existingCam != null ? existingCam.optInt("probedCameraId", -1) : -1;
-                            
-                            // Only write back if there's no manual override, or if the manual override
-                            // matches what we're currently running (user's choice is already applied)
-                            if (!hasManualOverride || savedId == currentId) {
-                                org.json.JSONObject camCfg = new org.json.JSONObject();
-                                camCfg.put("probedCameraId", currentId);
-                                camCfg.put("probedSurfaceMode", cameraSurfaceMode);
-                                camCfg.put("probedAndValidated", true);
-                                com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
-                            } else {
-                                logger.info("Skipping config write — manual override exists (saved=" + savedId + ", running=" + currentId + ")");
-                            }
-                        } catch (Exception ignored) {}
+                        recordValidationSnapshot(
+                            stripVerified,
+                            stripVerified ? "frame50_non_black_5120x960" : "frame50_non_black_low_layout_confidence",
+                            stripConfidenceValue,
+                            layoutConfidenceValue,
+                            stripVerified ? "" : "frame50_low_layout_confidence",
+                            width,
+                            height,
+                            frameCounter);
+                        persistCameraConfigSnapshot(stripVerified, stripVerified ? null : "frame50_low_layout_confidence");
                     }
                 } catch (Exception e) {
                     logger.warn("Frame 50 recheck failed: " + e.getMessage());
@@ -1242,7 +1410,42 @@ public class PanoramicCameraGpu {
             }
         }
     }
-    
+
+    private String summarizeQuadrantVariance(byte[] probe8x8) {
+        // This is diagnostics only. It turns the 8x8 probe into a compact
+        // summary so logs and persisted config can explain *why* a frame was
+        // classified as low-confidence without storing the raw pixels.
+        if (probe8x8 == null || probe8x8.length < 192) {
+            return "";
+        }
+        int[] qLuma = new int[4];
+        int[] qCnt = new int[4];
+        int[] qMin = {255, 255, 255, 255};
+        int[] qMax = {0, 0, 0, 0};
+        int totalNonBlack = 0;
+        for (int y = 0; y < 8; y++) {
+            for (int x = 0; x < 8; x++) {
+                int idx = (y * 8 + x) * 3;
+                int r = probe8x8[idx] & 0xFF, g = probe8x8[idx+1] & 0xFF, b = probe8x8[idx+2] & 0xFF;
+                int luma = (r + g * 2 + b) / 4;
+                int q = x / 2;
+                qLuma[q] += luma;
+                qCnt[q]++;
+                if (luma < qMin[q]) qMin[q] = luma;
+                if (luma > qMax[q]) qMax[q] = luma;
+                if (luma > 10) totalNonBlack++;
+            }
+        }
+        for (int q = 0; q < 4; q++) {
+            if (qCnt[q] > 0) qLuma[q] /= qCnt[q];
+        }
+        return "Q0=" + qLuma[0] + "/" + (qMax[0] - qMin[0])
+            + " Q1=" + qLuma[1] + "/" + (qMax[1] - qMin[1])
+            + " Q2=" + qLuma[2] + "/" + (qMax[2] - qMin[2])
+            + " Q3=" + qLuma[3] + "/" + (qMax[3] - qMin[3])
+            + " nonBlack=" + totalNonBlack + "/64";
+    }
+
     /**
      * Verifies that the camera is producing a real panoramic strip (4 distinct views)
      * rather than a single camera stretched or AVM bird's-eye view.
@@ -1314,6 +1517,76 @@ public class PanoramicCameraGpu {
      * 
      * @param skipId Camera ID to skip (the one we just tested). -1 to start fresh.
      */
+    private int[] buildSurfaceModeProbeCameraIds() {
+        java.util.LinkedHashSet<Integer> ids = new java.util.LinkedHashSet<>();
+        if (lastDataCameraId >= 0) {
+            ids.add(lastDataCameraId);
+        }
+        if (probeStartId >= 0) {
+            ids.add(probeStartId);
+        }
+        ids.add(cameraIdOverride >= 0 ? cameraIdOverride : PHYSICAL_CAMERA_ID);
+        for (int i = 0; i <= MAX_CAMERA_ID; i++) {
+            ids.add(i);
+        }
+        int[] ordered = new int[ids.size()];
+        int idx = 0;
+        for (Integer id : ids) {
+            ordered[idx++] = id;
+        }
+        return ordered;
+    }
+
+    private boolean advanceProbeSurfaceModeMatrix(int skipId) {
+        if (probeMatrixCameraIds == null || probeMatrixCameraIds.length == 0) {
+            probeMatrixCameraIds = buildSurfaceModeProbeCameraIds();
+            probeMatrixCameraIndex = 0;
+        }
+
+        // Sweep one surface mode at a time so we can preserve the same
+        // cleanup/settle order across every candidate camera ID.
+        while (probeNextSurfaceMode <= 5) {
+            while (probeMatrixCameraIndex < probeMatrixCameraIds.length) {
+                int tryId = probeMatrixCameraIds[probeMatrixCameraIndex++];
+                if (tryId == skipId) {
+                    continue;
+                }
+
+                logger.info("Auto-probe: trying camera ID " + tryId +
+                    " [surfaceMode=" + probeNextSurfaceMode + "]");
+
+                cameraIdOverride = tryId;
+                cameraSurfaceMode = probeNextSurfaceMode;
+                frameCounter = 0;
+                lastStatsFrameCount = 0;
+                lastGlThreadHeartbeat = System.currentTimeMillis();
+
+                recreateCameraSurface();
+                lastGlThreadHeartbeat = System.currentTimeMillis();
+
+                try {
+                    try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+                    startCamera();
+                    if (cameraCoordinator != null && cameraObj != null) {
+                        cameraCoordinator.setupEventCallback(cameraObj);
+                    }
+                    return true;
+                } catch (Exception e) {
+                    logger.info("Auto-probe: camera ID " + tryId +
+                        " surfaceMode=" + probeNextSurfaceMode +
+                        " failed to open: " + e.getMessage());
+                    cameraObj = null;
+                    try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+                }
+            }
+
+            probeMatrixCameraIndex = 0;
+            probeNextSurfaceMode++;
+        }
+
+        return false;
+    }
+
     private void advanceProbeToNext(int skipId) {
         // Close current camera cleanly
         if (cameraObj != null) {
@@ -1333,50 +1606,63 @@ public class PanoramicCameraGpu {
         // and triggers a system watchdog reboot.
         try { Thread.sleep(1500); } catch (InterruptedException ignored) {}
         
-        // Probe camera IDs 0-5 with surface mode 0 (confirmed working on all models)
         boolean found = false;
-        while (probeNextCameraId <= MAX_CAMERA_ID) {
-            int tryId = probeNextCameraId;
-            probeNextCameraId++;
-            
-            // Skip the ID we just tested
-            if (tryId == skipId) {
-                continue;
-            }
-            
-            logger.info("Auto-probe: trying camera ID " + tryId + 
-                " [" + (tryId + 1) + "/" + (MAX_CAMERA_ID + 1) + "]");
-            
-            cameraIdOverride = tryId;
-            cameraSurfaceMode = 0;  // Surface mode 0 confirmed working
-            frameCounter = 0;
-            lastStatsFrameCount = 0;
-            lastGlThreadHeartbeat = System.currentTimeMillis();
-            
-            // Recreate SurfaceTexture — HAL won't deliver continuous frames
-            // to a Surface previously connected to a different camera/mode
-            recreateCameraSurface();
-            lastGlThreadHeartbeat = System.currentTimeMillis();
-            
-            try {
-                // Brief pause before opening next camera — HAL needs time to release resources
-                try { Thread.sleep(500); } catch (InterruptedException ignored) {}
-                
-                startCamera();
-                // Setup event callback (only for AVMCamera path — binder service handles its own events)
-                if (cameraCoordinator != null && cameraObj != null) {
-                    cameraCoordinator.setupEventCallback(cameraObj);
+        if (!probeSurfaceModeMatrixActive) {
+            // Probe camera IDs 0-5 with surface mode 0 first.
+            while (probeNextCameraId <= MAX_CAMERA_ID) {
+                int tryId = probeNextCameraId;
+                probeNextCameraId++;
+
+                // Skip the ID we just tested
+                if (tryId == skipId) {
+                    continue;
                 }
-                found = true;
-                break;
-            } catch (Exception e) {
-                // Camera ID doesn't exist or can't open — skip to next
-                logger.info("Auto-probe: camera ID " + tryId + " failed to open: " + e.getMessage());
-                cameraObj = null;
-                // Delay before trying next combo to avoid HAL overload
-                try { Thread.sleep(500); } catch (InterruptedException ignored) {}
-                continue;
+
+                logger.info("Auto-probe: trying camera ID " + tryId +
+                    " [" + (tryId + 1) + "/" + (MAX_CAMERA_ID + 1) + "]");
+
+                cameraIdOverride = tryId;
+                cameraSurfaceMode = 0;  // Surface mode 0 confirmed working
+                frameCounter = 0;
+                lastStatsFrameCount = 0;
+                lastGlThreadHeartbeat = System.currentTimeMillis();
+
+                // Recreate the ImageReader consumer — HAL won't deliver continuous
+                // frames to a surface previously connected to a different camera/mode.
+                recreateCameraSurface();
+                lastGlThreadHeartbeat = System.currentTimeMillis();
+
+                try {
+                    // Brief pause before opening next camera — HAL needs time to release resources
+                    try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+
+                    startCamera();
+                    // Setup event callback (only for AVMCamera path — binder service handles its own events)
+                    if (cameraCoordinator != null && cameraObj != null) {
+                        cameraCoordinator.setupEventCallback(cameraObj);
+                    }
+                    found = true;
+                    break;
+                } catch (Exception e) {
+                    // Camera ID doesn't exist or can't open — skip to next
+                    logger.info("Auto-probe: camera ID " + tryId + " failed to open: " + e.getMessage());
+                    cameraObj = null;
+                    // Delay before trying next combo to avoid HAL overload
+                    try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+                    continue;
+                }
             }
+
+            if (!found) {
+                probeSurfaceModeMatrixActive = true;
+                probeMatrixCameraIds = buildSurfaceModeProbeCameraIds();
+                probeMatrixCameraIndex = 0;
+                probeNextSurfaceMode = 0;
+                logger.warn("Auto-probe: ID-only probing exhausted; switching to surface-mode matrix");
+                found = advanceProbeSurfaceModeMatrix(skipId);
+            }
+        } else {
+            found = advanceProbeSurfaceModeMatrix(skipId);
         }
         
         if (!found) {
@@ -1421,6 +1707,9 @@ public class PanoramicCameraGpu {
             autoProbeCameras = false;
             probeStartId = -1;
             lastDataCameraId = -1;
+            probeSurfaceModeMatrixActive = false;
+            probeMatrixCameraIds = new int[0];
+            probeMatrixCameraIndex = 0;
             // Ungate consumers even on failure — better to record whatever we have
             // than to stay permanently blocked
             probeComplete = true;
@@ -1580,7 +1869,7 @@ public class PanoramicCameraGpu {
         
         // FORTIFY FIX: Stop encoder drainer threads BEFORE closing camera.
         // The drainer thread calls MediaCodec.dequeueOutputBuffer() which internally
-        // accesses the camera's SurfaceTexture buffer queue via EGL. If we destroy
+        // accesses the camera's ImageReader / HardwareBuffer-backed EGL chain. If we destroy
         // the camera (and its native mutex) while the drainer is mid-dequeue,
         // we get: FORTIFY: pthread_mutex_lock called on a destroyed mutex
         if (encoder != null) {
@@ -1664,8 +1953,8 @@ public class PanoramicCameraGpu {
             // Update heartbeat so watchdog doesn't kill us during restart
             lastGlThreadHeartbeat = System.currentTimeMillis();
             
-            // CRITICAL: Recreate SurfaceTexture before reopening camera.
-            // The BYD HAL won't deliver continuous frames to a Surface that was
+            // CRITICAL: Recreate the ImageReader consumer before reopening camera.
+            // The BYD HAL won't deliver continuous frames to a surface that was
             // previously connected to a different camera instance — only the first
             // frame arrives, then the stream freezes. This matches the fix already
             // present in the auto-probe path in renderLoop().
@@ -1981,7 +2270,7 @@ public class PanoramicCameraGpu {
             foveatedCropper = null;
         }
 
-        // Releases whichever consumer (SurfaceTexture or ImageReader) is active.
+        // Releases whichever consumer is active.
         releaseCameraConsumer();
 
         // Tear down the ImageReader callback thread (full shutdown only —
@@ -2108,8 +2397,12 @@ public class PanoramicCameraGpu {
         Object cam = cameraObj;
         if (cam != null) {
             try {
-                AvmCameraHelper.setCameraFps(cam, fps);
+                boolean ok = AvmCameraHelper.setCameraFps(cam, fps);
+                fpsSetCameraResult = ok
+                    ? "live:setCameraFps(" + fps + ")=ok"
+                    : "live:setCameraFps(" + fps + ")=failed";
             } catch (Throwable t) {
+                fpsSetCameraResult = "live:setCameraFps(" + fps + ")=error:" + t.getClass().getSimpleName();
                 logger.warn("Live setCameraFps failed: " + t.getMessage());
             }
         }
@@ -2141,8 +2434,14 @@ public class PanoramicCameraGpu {
         this.autoProbeCameras = enabled;
         if (enabled) {
             probeComplete = false;
+            probeStartId = getCameraId();
             probeNextCameraId = 0;
             probeNextSurfaceMode = 0;
+            probeSurfaceModeMatrixActive = false;
+            probeMatrixCameraIds = new int[0];
+            probeMatrixCameraIndex = 0;
+        } else {
+            probeSurfaceModeMatrixActive = false;
         }
         logger.info("Camera auto-probe: " + (enabled ? "ENABLED" : "DISABLED"));
     }
@@ -2153,6 +2452,205 @@ public class PanoramicCameraGpu {
     public void setSkipFrameValidation(boolean skip) {
         this.skipFrameValidation = skip;
         if (skip) logger.info("Frame validation SKIPPED (manual camera override)");
+    }
+
+    public void setManualOverrideActive(boolean manualOverride) {
+        this.manualOverrideActive = manualOverride;
+    }
+
+    public void setFallbackFromProbe(boolean fallbackFromProbe) {
+        this.fallbackFromProbe = fallbackFromProbe;
+    }
+
+    public void setCameraLayout(int layout) {
+        this.cameraLayout = layout;
+    }
+
+    public void setCameraSelectionMetadata(PanoCameraDiscovery discovery) {
+        if (discovery == null) return;
+        setCameraLayout(discovery.cameraLayout);
+        this.sourceBmmTag = discovery.sourceTag;
+        this.discoveryMethod = discovery.method;
+        this.vehicleCamSort = discovery.vehicleCamSort;
+        logger.info("Camera discovery metadata set: " + discovery);
+    }
+
+    public void setCameraSelectionMetadata(int layout, String sourceTag, String method, String camSort) {
+        this.cameraLayout = layout;
+        this.sourceBmmTag = sourceTag == null ? "" : sourceTag;
+        this.discoveryMethod = method == null ? "" : method;
+        this.vehicleCamSort = camSort == null ? "" : camSort;
+    }
+
+    public void setFirmwareInfo(CameraFirmwareInfo info) {
+        this.firmwareInfo = info != null ? info : CameraFirmwareInfo.current();
+    }
+
+    public void setNativeProbeReport(String report, boolean ready) {
+        this.nativeProbeReport = report == null ? "" : report;
+        this.nativeProbeReady = ready;
+    }
+
+    public void setArbitrationMode(String arbitrationMode) {
+        this.arbitrationMode = arbitrationMode == null || arbitrationMode.isEmpty()
+            ? "eventCallbackOnly" : arbitrationMode;
+        if (cameraCoordinator != null) {
+            cameraCoordinator.setArbitrationMode(this.arbitrationMode);
+        }
+    }
+
+    public void setFpsSetMediaCodecResult(String result) {
+        // Honest boundary: the pipeline does not currently own the encoder
+        // MediaCodec, so the diagnostic default is "not_wired" unless a
+        // future owner explicitly threads a real codec reference through.
+        this.fpsSetMediaCodecResult = result == null || result.isEmpty()
+            ? "not_wired" : result;
+    }
+
+    public void setLastCameraEvent(String event) {
+        this.lastCameraEvent = event == null ? "" : event;
+    }
+
+    public void setQuadrantVariance(String variance) {
+        this.quadrantVariance = variance == null ? "" : variance;
+    }
+
+    public int getCameraLayout() {
+        return cameraLayout;
+    }
+
+    public boolean isManualOverrideActive() {
+        return manualOverrideActive;
+    }
+
+    public boolean isFallbackFromProbe() {
+        return fallbackFromProbe;
+    }
+
+    public String getSourceBmmTag() {
+        return sourceBmmTag;
+    }
+
+    public String getDiscoveryMethod() {
+        return discoveryMethod;
+    }
+
+    public String getVehicleCamSort() {
+        return vehicleCamSort;
+    }
+
+    public CameraFirmwareInfo getFirmwareInfo() {
+        return firmwareInfo;
+    }
+
+    public String getNativeProbeReport() {
+        return nativeProbeReport;
+    }
+
+    public boolean isNativeProbeReady() {
+        return nativeProbeReady;
+    }
+
+    public String getFpsSetCameraResult() {
+        return fpsSetCameraResult;
+    }
+
+    public String getFpsSetMediaCodecResult() {
+        return fpsSetMediaCodecResult;
+    }
+
+    public long getValidatedAtMs() {
+        return validatedAtMs;
+    }
+
+    public int getValidatedFrameWidth() {
+        return validatedFrameWidth;
+    }
+
+    public int getValidatedFrameHeight() {
+        return validatedFrameHeight;
+    }
+
+    public int getValidationFrameCount() {
+        return validationFrameCount;
+    }
+
+    public String getValidationSignal() {
+        return validationSignal;
+    }
+
+    public String getStripConfidence() {
+        return stripConfidence;
+    }
+
+    public String getLayoutConfidence() {
+        return layoutConfidence;
+    }
+
+    public String getQuadrantVariance() {
+        return quadrantVariance;
+    }
+
+    public String getLastValidationFailure() {
+        return lastValidationFailure;
+    }
+
+    public String getLastCameraEvent() {
+        return lastCameraEvent;
+    }
+
+    public String getArbitrationMode() {
+        return arbitrationMode;
+    }
+
+    public long getLastFrameAgeMs() {
+        long last = lastFrameTime;
+        if (last <= 0L) {
+            return 0L;
+        }
+        return Math.max(0L, System.currentTimeMillis() - last);
+    }
+
+    public long getIrFireCount() {
+        return irFireCount;
+    }
+
+    public long getIrAcquireOkCount() {
+        return irAcquireOkCount;
+    }
+
+    public long getIrAcquireNullCount() {
+        return irAcquireNullCount;
+    }
+
+    public long getIrBindFailCount() {
+        return irBindFailCount;
+    }
+
+    public void recordValidationSnapshot(
+            boolean validated,
+            String signal,
+            String stripConfidence,
+            String layoutConfidence,
+            String failureReason,
+            int frameWidth,
+            int frameHeight,
+            int frameCount) {
+        if (validated) {
+            this.validatedAtMs = System.currentTimeMillis();
+            this.validatedFrameWidth = frameWidth;
+            this.validatedFrameHeight = frameHeight;
+            this.validationFrameCount = frameCount;
+        } else {
+            this.validatedAtMs = 0L;
+            this.validatedFrameWidth = 0;
+            this.validatedFrameHeight = 0;
+            this.validationFrameCount = 0;
+        }
+        this.validationSignal = signal == null ? "" : signal;
+        this.stripConfidence = stripConfidence == null ? "" : stripConfidence;
+        this.layoutConfidence = layoutConfidence == null ? "" : layoutConfidence;
+        this.lastValidationFailure = failureReason == null ? "" : failureReason;
     }
     
     /**

--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -125,6 +125,9 @@ public class CameraDaemon {
     // Prevents BYD system from killing the camera app, which destabilizes
     // the HAL and causes "no video signal" on the native DVR.
     private static com.overdrive.app.camera.AvcHalWarmup avcHalWarmup;
+    private static final Object avcWarmupLock = new Object();
+    private static volatile boolean avcWarmupCompletedThisWindow = false;
+    private static volatile String avcWarmupLastSkipReason = "";
     
     // ==================== STREAM MODE ====================
     public static final String STREAM_MODE_PRIVATE = "private";  // Local H.264 only
@@ -681,12 +684,10 @@ public class CameraDaemon {
         
         // GPU pipeline handles all cameras together
         if (gpuPipeline != null && !gpuPipeline.isRunning()) {
-            // If ACC is ON, warm up the camera HAL first on a background thread
-            // to avoid blocking the HTTP/TCP handler thread for 4 seconds.
-            if (AccMonitor.isAccOn() && avcHalWarmup != null) {
+            if (AccMonitor.isAccOn()) {
                 final boolean fViewOnly = viewOnly;
                 new Thread(() -> {
-                    avcHalWarmup.warmupAndWait();
+                    ensureAvcWarmupStarted("CameraDaemon.startCamera");
                     startPipelineInternal(viewId, fViewOnly);
                 }, "CameraWarmup").start();
             } else {
@@ -800,7 +801,47 @@ public class CameraDaemon {
             }
         }
     }
-    
+
+    /**
+     * Ensures the AVC warmup ran for the current cold-start window.
+     * Returns true when warmup is already satisfied or completed successfully,
+     * false only when the actual warmup attempt failed.
+     */
+    public static boolean ensureAvcWarmupStarted(String reason) {
+        synchronized (avcWarmupLock) {
+            if (avcHalWarmup == null) {
+                avcHalWarmup = new com.overdrive.app.camera.AvcHalWarmup();
+            }
+
+            if (gpuPipeline != null && gpuPipeline.isRunning()) {
+                avcWarmupLastSkipReason = "pipeline already running";
+                log("AVC warmup skipped (" + reason + "): " + avcWarmupLastSkipReason);
+                return true;
+            }
+
+            if (avcWarmupCompletedThisWindow && avcHalWarmup.getLastResult()) {
+                avcWarmupLastSkipReason = "already completed this cold-start window";
+                log("AVC warmup skipped (" + reason + "): " + avcWarmupLastSkipReason);
+                return true;
+            }
+
+            boolean ok = avcHalWarmup.warmupAndWait(reason);
+            if (ok) {
+                avcWarmupCompletedThisWindow = true;
+                avcWarmupLastSkipReason = "";
+            }
+            return ok;
+        }
+    }
+
+    private static void resetAvcWarmupWindow(String reason) {
+        synchronized (avcWarmupLock) {
+            avcWarmupCompletedThisWindow = false;
+            avcWarmupLastSkipReason = "";
+            log("AVC warmup window reset (" + reason + ")");
+        }
+    }
+
     /**
      * Stops the AVC keep-alive watchdog.
      * Called when pipeline stops or daemon shuts down.
@@ -810,6 +851,31 @@ public class CameraDaemon {
             avcHalWarmup.stopKeepAlive();
             log("AVC keep-alive stopped");
         }
+        resetAvcWarmupWindow("keep-alive stopped");
+    }
+
+    public static boolean isAvcWarmupAvailable() {
+        return avcHalWarmup != null;
+    }
+
+    public static long getAvcWarmupLastStartedAtMs() {
+        return avcHalWarmup != null ? avcHalWarmup.getLastStartedAtMs() : 0L;
+    }
+
+    public static boolean getAvcWarmupLastResult() {
+        return avcHalWarmup != null && avcHalWarmup.getLastResult();
+    }
+
+    public static boolean isAvcWarmupKeepAliveActive() {
+        return avcHalWarmup != null && avcHalWarmup.isActive();
+    }
+
+    public static String getAvcWarmupLastReason() {
+        return avcHalWarmup != null ? avcHalWarmup.getLastReason() : "";
+    }
+
+    public static String getAvcWarmupLastSkippedReason() {
+        return avcWarmupLastSkipReason;
     }
     
     // ==================== GETTERS ====================
@@ -2480,24 +2546,114 @@ public class CameraDaemon {
         
         // SOTA: BYD camera coordinator status
         if (gpuPipeline != null && gpuPipeline.getCamera() != null) {
+            // Keep the flat legacy keys for existing UI consumers, then add the
+            // nested cameraDiagnostics payload so field testers can export one
+            // complete JSON object without reading logs.
+            java.util.Map<String, Object> cameraDiagnostics = new java.util.HashMap<>();
             com.overdrive.app.camera.BydCameraCoordinator coordinator = 
                 gpuPipeline.getCamera().getCameraCoordinator();
             if (coordinator != null) {
                 status.put("cameraServiceRegistered", coordinator.isRegistered());
+                status.put("cameraServiceUserRegistered", coordinator.isRegisteredAsUser());
                 // cameraUserRegistered intentionally omitted — registerCameraUser is
                 // permanently DISABLED, the value is always false. Polling fallback
                 // is the only live path. See BydCameraCoordinator.register().
                 status.put("cameraYielded", coordinator.isYielded());
                 status.put("nativeAppActive", coordinator.isNativeAppActive());
                 status.put("cameraEventCallback", coordinator.isEventCallbackActive());
+                status.put("cameraOwnerPackage", coordinator.getCurrentCameraOwnerPackage());
+                status.put("nativeCameraOwnerPackage", coordinator.getCurrentCameraOwnerPackage());
+                status.put("cameraArbitrationMode", coordinator.getArbitrationMode());
+                cameraDiagnostics.put("nativeCameraOwnerPackage", coordinator.getCurrentCameraOwnerPackage());
+                cameraDiagnostics.put("arbitrationMode", coordinator.getArbitrationMode());
+                cameraDiagnostics.put("cameraYielded", coordinator.isYielded());
+                cameraDiagnostics.put("nativeAppActive", coordinator.isNativeAppActive());
+                cameraDiagnostics.put("cameraEventCallback", coordinator.isEventCallbackActive());
             }
             
             // SOTA: Camera probe status
             com.overdrive.app.camera.PanoramicCameraGpu cam = gpuPipeline.getCamera();
+            status.put("cameraId", cam.getCameraId());
+            status.put("surfaceMode", cam.getCameraSurfaceMode());
             status.put("probeComplete", cam.isProbeComplete());
             status.put("activeCameraId", cam.getCameraId());
             status.put("activeSurfaceMode", cam.getCameraSurfaceMode());
+            status.put("cameraLayout", cam.getCameraLayout());
+            status.put("manualOverride", cam.isManualOverrideActive());
+            status.put("fallbackFromProbe", cam.isFallbackFromProbe());
+            status.put("sourceBmmTag", cam.getSourceBmmTag());
+            status.put("discoveryMethod", cam.getDiscoveryMethod());
+            status.put("vehicleCamSort", cam.getVehicleCamSort());
+            status.put("firmwareFingerprint", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().fingerprint : "");
+            status.put("buildDisplay", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().buildDisplay : "");
+            status.put("buildIncremental", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().buildIncremental : "");
+            status.put("productDevice", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().device : "");
+            status.put("nativeProbeReport", cam.getNativeProbeReport());
+            status.put("eglHardwareBufferProbe", cam.getNativeProbeReport());
+            status.put("nativeProbeReady", cam.isNativeProbeReady());
+            status.put("fpsSetCameraResult", cam.getFpsSetCameraResult());
+            status.put("fpsSetMediaCodecResult", cam.getFpsSetMediaCodecResult());
+            status.put("validatedAtMs", cam.getValidatedAtMs());
+            status.put("validatedFrameWidth", cam.getValidatedFrameWidth());
+            status.put("validatedFrameHeight", cam.getValidatedFrameHeight());
+            status.put("validationFrameCount", cam.getValidationFrameCount());
+            status.put("validationSignal", cam.getValidationSignal());
+            status.put("stripConfidence", cam.getStripConfidence());
+            status.put("layoutConfidence", cam.getLayoutConfidence());
+            status.put("quadrantVariance", cam.getQuadrantVariance());
+            status.put("lastValidationFailure", cam.getLastValidationFailure());
+            status.put("lastCameraEvent", cam.getLastCameraEvent());
+            status.put("lastFrameAgeMs", cam.getLastFrameAgeMs());
+            status.put("measuredFps", cam.getMeasuredFps());
+            status.put("irFireCount", cam.getIrFireCount());
+            status.put("irAcquireOkCount", cam.getIrAcquireOkCount());
+            status.put("irAcquireNullCount", cam.getIrAcquireNullCount());
+            status.put("irBindFailCount", cam.getIrBindFailCount());
+
+            cameraDiagnostics.put("cameraId", cam.getCameraId());
+            cameraDiagnostics.put("surfaceMode", cam.getCameraSurfaceMode());
+            cameraDiagnostics.put("cameraLayout", cam.getCameraLayout());
+            cameraDiagnostics.put("sourceBmmTag", cam.getSourceBmmTag());
+            cameraDiagnostics.put("discoveryMethod", cam.getDiscoveryMethod());
+            cameraDiagnostics.put("probeComplete", cam.isProbeComplete());
+            cameraDiagnostics.put("manualOverride", cam.isManualOverrideActive());
+            cameraDiagnostics.put("firmwareFingerprint", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().fingerprint : "");
+            cameraDiagnostics.put("buildDisplay", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().buildDisplay : "");
+            cameraDiagnostics.put("buildIncremental", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().buildIncremental : "");
+            cameraDiagnostics.put("productDevice", cam.getFirmwareInfo() != null ? cam.getFirmwareInfo().device : "");
+            cameraDiagnostics.put("vehicleCamSort", cam.getVehicleCamSort());
+            cameraDiagnostics.put("validatedAtMs", cam.getValidatedAtMs());
+            cameraDiagnostics.put("validationSignal", cam.getValidationSignal());
+            cameraDiagnostics.put("layoutConfidence", cam.getLayoutConfidence());
+            cameraDiagnostics.put("quadrantVariance", cam.getQuadrantVariance());
+            cameraDiagnostics.put("lastFrameAgeMs", cam.getLastFrameAgeMs());
+            cameraDiagnostics.put("measuredFps", cam.getMeasuredFps());
+            cameraDiagnostics.put("irFireCount", cam.getIrFireCount());
+            cameraDiagnostics.put("irAcquireOkCount", cam.getIrAcquireOkCount());
+            cameraDiagnostics.put("irAcquireNullCount", cam.getIrAcquireNullCount());
+            cameraDiagnostics.put("irBindFailCount", cam.getIrBindFailCount());
+            cameraDiagnostics.put("lastCameraEvent", cam.getLastCameraEvent());
+            cameraDiagnostics.put("eglHardwareBufferProbe", cam.getNativeProbeReport());
+            cameraDiagnostics.put("avcWarmupLastResult", getAvcWarmupLastResult());
+            cameraDiagnostics.put("fpsSetCameraResult", cam.getFpsSetCameraResult());
+            cameraDiagnostics.put("fpsSetMediaCodecResult", cam.getFpsSetMediaCodecResult());
+            status.put("cameraDiagnostics", cameraDiagnostics);
         }
+
+        try {
+            org.json.JSONObject camCfg = com.overdrive.app.config.UnifiedConfigManager
+                .loadConfig().optJSONObject("camera");
+            if (camCfg != null) {
+                status.put("cameraReprobeOnNextRestart", camCfg.optBoolean("reprobeOnNextRestart", false));
+            }
+        } catch (Exception ignored) {}
+
+        status.put("avcWarmupAvailable", isAvcWarmupAvailable());
+        status.put("avcWarmupLastStartedAtMs", getAvcWarmupLastStartedAtMs());
+        status.put("avcWarmupLastResult", getAvcWarmupLastResult());
+        status.put("avcWarmupKeepAliveActive", isAvcWarmupKeepAliveActive());
+        status.put("avcWarmupLastReason", getAvcWarmupLastReason());
+        status.put("avcWarmupLastSkippedReason", getAvcWarmupLastSkippedReason());
         
         return status;
     }

--- a/app/src/main/java/com/overdrive/app/recording/RecordingModeManager.java
+++ b/app/src/main/java/com/overdrive/app/recording/RecordingModeManager.java
@@ -2,7 +2,6 @@ package com.overdrive.app.recording;
 
 import android.content.Context;
 
-import com.overdrive.app.camera.AvcHalWarmup;
 import com.overdrive.app.config.UnifiedConfigManager;
 import com.overdrive.app.daemon.CameraDaemon;
 import com.overdrive.app.logging.DaemonLogger;
@@ -53,7 +52,6 @@ public class RecordingModeManager {
     private final Context context;
     private final GpuSurveillancePipeline pipeline;
     private final ProximityGuardController proximityController;
-    private final AvcHalWarmup avcWarmup;
     
     private volatile Mode currentMode = Mode.NONE;  // Default: no recording
     private volatile boolean accIsOn = false;  // Default: ACC OFF — wait for AccSentryDaemon to confirm
@@ -76,7 +74,6 @@ public class RecordingModeManager {
         this.context = context;
         this.pipeline = pipeline;
         this.proximityController = new ProximityGuardController(context, pipeline);
-        this.avcWarmup = new AvcHalWarmup();
         
         // Load persisted mode from config
         loadPersistedMode();
@@ -229,7 +226,7 @@ public class RecordingModeManager {
         new Thread(() -> {
             // Only warmup if pipeline isn't already running.
             if (!pipeline.isRunning()) {
-                if (!avcWarmup.warmupAndWait()) {
+                if (!CameraDaemon.ensureAvcWarmupStarted("RecordingModeManager.activateModeWithWarmup:" + reason)) {
                     logger.warn("AVC warmup interrupted (" + reason + ") — skipping mode activation");
                     return;
                 }
@@ -386,15 +383,15 @@ public class RecordingModeManager {
             
             // Start AVC keep-alive and activate mode after warmup
             final Mode modeToActivate = currentMode;
-            new Thread(() -> {
-                // Only warmup if pipeline isn't already running
-                // (if it's running, camera is already open — no need to poke com.byd.avc)
-                if (!pipeline.isRunning()) {
-                    if (!avcWarmup.warmupAndWait()) {
-                        logger.warn("AVC warmup interrupted — skipping mode activation");
-                        return;
-                    }
+        new Thread(() -> {
+            // Only warmup if pipeline isn't already running
+            // (if it's running, camera is already open — no need to poke com.byd.avc)
+            if (!pipeline.isRunning()) {
+                if (!CameraDaemon.ensureAvcWarmupStarted("RecordingModeManager.onAccStateChanged")) {
+                    logger.warn("AVC warmup interrupted — skipping mode activation");
+                    return;
                 }
+            }
                 
                 synchronized (RecordingModeManager.this) {
                     if (!accIsOn) {

--- a/app/src/main/java/com/overdrive/app/server/StreamingApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/StreamingApiHandler.java
@@ -80,8 +80,9 @@ public class StreamingApiHandler {
         if (!pipeline.isRunning()) {
             try {
                 CameraDaemon.log("handleEnableStreaming: warming up AVC HAL before pipeline cold start");
-                com.overdrive.app.camera.AvcHalWarmup warmup = new com.overdrive.app.camera.AvcHalWarmup();
-                warmup.warmupAndWait();
+                if (!CameraDaemon.ensureAvcWarmupStarted("StreamingApiHandler.handleEnableStreaming")) {
+                    throw new IllegalStateException("AVC warmup failed");
+                }
                 CameraDaemon.log("handleEnableStreaming: auto-starting pipeline for streaming");
                 pipeline.start();
                 Thread.sleep(500);
@@ -238,8 +239,9 @@ public class StreamingApiHandler {
         if (!pipeline.isRunning()) {
             try {
                 CameraDaemon.log("handleStreamViewMode: warming up AVC HAL before pipeline cold start");
-                com.overdrive.app.camera.AvcHalWarmup warmup = new com.overdrive.app.camera.AvcHalWarmup();
-                warmup.warmupAndWait();   // Blocks ~4s; safe — runs on the HTTP worker thread
+                if (!CameraDaemon.ensureAvcWarmupStarted("StreamingApiHandler.handleStreamViewMode")) {
+                    throw new IllegalStateException("AVC warmup failed");
+                }   // Blocks ~4s; safe — runs on the HTTP worker thread
                 CameraDaemon.log("handleStreamViewMode: auto-starting pipeline");
                 pipeline.start();
                 Thread.sleep(500);

--- a/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/SurveillanceApiHandler.java
@@ -302,6 +302,15 @@ public class SurveillanceApiHandler {
                 if (camCfg != null) {
                     config.put("cameraId", camCfg.optInt("probedCameraId", -1));
                     config.put("cameraManualOverride", camCfg.optBoolean("manualOverride", false));
+                    config.put("cameraLayout", camCfg.optInt("cameraLayout", -1));
+                    config.put("cameraArbitrationMode", camCfg.optString("arbitrationMode", "eventCallbackOnly"));
+                    config.put("cameraReprobeOnNextRestart", camCfg.optBoolean("reprobeOnNextRestart", false));
+                    config.put("cameraSourceBmmTag", camCfg.optString("sourceBmmTag", ""));
+                    config.put("cameraDiscoveryMethod", camCfg.optString("discoveryMethod", ""));
+                    config.put("cameraVehicleCamSort", camCfg.optString("vehicleCamSort", ""));
+                    config.put("cameraFirmwareFingerprint", camCfg.optString("firmwareFingerprint", ""));
+                    config.put("cameraValidationSignal", camCfg.optString("validationSignal", ""));
+                    config.put("cameraLayoutConfidence", camCfg.optString("layoutConfidence", ""));
                 }
             } catch (Exception ignored) {}
         } else {
@@ -358,6 +367,47 @@ public class SurveillanceApiHandler {
             }
             
             boolean configChanged = false;
+
+            if (configJson.has("reprobeCameraOnNextRestart")
+                    && configJson.optBoolean("reprobeCameraOnNextRestart", false)) {
+                try {
+                    // Reprobe clears the trust chain but preserves manualOverride
+                    // so a user can intentionally keep a hand-picked tuple.
+                    org.json.JSONObject camCfg = new org.json.JSONObject();
+                    camCfg.put("reprobeOnNextRestart", true);
+                    camCfg.put("probedCameraId", -1);
+                    camCfg.put("probedSurfaceMode", -1);
+                    camCfg.put("cameraLayout", -1);
+                    camCfg.put("probedAndValidated", false);
+                    camCfg.put("fallbackFromProbe", false);
+                    camCfg.put("sourceBmmTag", "");
+                    camCfg.put("discoveryMethod", "");
+                    camCfg.put("vehicleCamSort", "");
+                    camCfg.put("firmwareFingerprint", "");
+                    camCfg.put("buildDisplay", "");
+                    camCfg.put("buildIncremental", "");
+                    camCfg.put("roBuildIncremental", "");
+                    camCfg.put("productDevice", "");
+                    camCfg.put("validatedAtMs", 0);
+                    camCfg.put("validatedFrameWidth", 0);
+                    camCfg.put("validatedFrameHeight", 0);
+                    camCfg.put("validationFrameCount", 0);
+                    camCfg.put("validationSignal", "");
+                    camCfg.put("stripConfidence", "");
+                    camCfg.put("layoutConfidence", "");
+                    camCfg.put("lastValidationFailure", "reprobe_requested");
+                    camCfg.put("nativeProbeReport", "");
+                    camCfg.put("nativeProbeReady", false);
+                    camCfg.put("fpsSetCameraResult", "");
+                    camCfg.put("fpsSetMediaCodecResult", "");
+                    camCfg.put("lastCameraEvent", "");
+                    com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                    CameraDaemon.log("Camera will reprobe on next restart (manual override preserved)");
+                } catch (Exception e) {
+                    CameraDaemon.log("Failed to mark camera for reprobe: " + e.getMessage());
+                }
+                configChanged = true;
+            }
             
             if (sentry != null && configJson.has("sadThreshold")) {
                 sentry.setSadThreshold((float) configJson.optDouble("sadThreshold", 0.05));
@@ -820,17 +870,78 @@ public class SurveillanceApiHandler {
                     CameraDaemon.log("Schedule parse error: " + e.getMessage());
                 }
             }
-            
+
+            if (configJson.has("cameraArbitrationMode")) {
+                String mode = configJson.optString("cameraArbitrationMode", "eventCallbackOnly");
+                // Accept only the three supported arbitration modes. Anything
+                // else is ignored so we do not accidentally flip the camera
+                // service into an unreviewed experiment state.
+                if (!"polling".equals(mode)
+                        && !"eventCallbackOnly".equals(mode)
+                        && !"registeredUserExperiment".equals(mode)) {
+                    CameraDaemon.log("Ignoring invalid cameraArbitrationMode: " + mode);
+                } else {
+                    try {
+                        // Update the live coordinator if it already exists, then
+                        // persist the same value so the next restart reuses it.
+                        GpuSurveillancePipeline cameraPipeline = CameraDaemon.getGpuPipeline();
+                        if (cameraPipeline != null && cameraPipeline.getCamera() != null) {
+                            cameraPipeline.getCamera().setArbitrationMode(mode);
+                        }
+                        org.json.JSONObject camCfg = new org.json.JSONObject();
+                        camCfg.put("arbitrationMode", mode);
+                        com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                        CameraDaemon.log("Camera arbitration mode set to: " + mode);
+                    } catch (Exception e) {
+                        CameraDaemon.log("Failed to save camera arbitration mode: " + e.getMessage());
+                    }
+                    configChanged = true;
+                }
+            }
+
             // Manual camera ID override
             if (configJson.has("manualCameraId")) {
                 int camId = configJson.optInt("manualCameraId", -1);
                 if (camId >= 0 && camId <= 5) {
                     try {
+                        // Manual override stores a full tuple immediately so the
+                        // next restart can reuse the selection without probing.
+                        int layout = configJson.has("cameraLayout")
+                            ? configJson.optInt("cameraLayout", 0) : 0;
+                        if (!configJson.has("cameraLayout")) {
+                            CameraDaemon.log("Manual camera ID set without cameraLayout; assuming layout 0");
+                        }
+                        com.overdrive.app.camera.CameraFirmwareInfo firmware =
+                            com.overdrive.app.camera.CameraFirmwareInfo.current();
                         org.json.JSONObject camCfg = new org.json.JSONObject();
                         camCfg.put("probedCameraId", camId);
                         camCfg.put("probedSurfaceMode", 0);
+                        camCfg.put("cameraLayout", layout);
                         camCfg.put("probedAndValidated", true);
                         camCfg.put("manualOverride", true);
+                        camCfg.put("fallbackFromProbe", false);
+                        camCfg.put("reprobeOnNextRestart", false);
+                        camCfg.put("sourceBmmTag", "manual");
+                        camCfg.put("discoveryMethod", "manual");
+                        camCfg.put("vehicleCamSort", firmware.vehicleCamSort);
+                        camCfg.put("firmwareFingerprint", firmware.fingerprint);
+                        camCfg.put("buildDisplay", firmware.buildDisplay);
+                        camCfg.put("buildIncremental", firmware.buildIncremental);
+                        camCfg.put("roBuildIncremental", firmware.roBuildIncremental);
+                        camCfg.put("productDevice", firmware.device);
+                        camCfg.put("validatedAtMs", 0);
+                        camCfg.put("validatedFrameWidth", 0);
+                        camCfg.put("validatedFrameHeight", 0);
+                        camCfg.put("validationFrameCount", 0);
+                        camCfg.put("validationSignal", "");
+                        camCfg.put("stripConfidence", "");
+                        camCfg.put("layoutConfidence", "");
+                        camCfg.put("lastValidationFailure", "");
+                        camCfg.put("nativeProbeReport", "");
+                        camCfg.put("nativeProbeReady", false);
+                        camCfg.put("fpsSetCameraResult", "");
+                        camCfg.put("fpsSetMediaCodecResult", "");
+                        camCfg.put("lastCameraEvent", "");
                         com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
                         CameraDaemon.log("Manual camera ID set: " + camId + " (will take effect on next restart)");
                     } catch (Exception e) {
@@ -841,11 +952,38 @@ public class SurveillanceApiHandler {
             }
             if (configJson.has("clearManualCameraId") && configJson.optBoolean("clearManualCameraId", false)) {
                 try {
+                    // Clear the whole selection tuple, not just the camera ID,
+                    // so the next boot path rediscover from scratch instead of
+                    // reusing stale camera metadata.
                     org.json.JSONObject camCfg = new org.json.JSONObject();
                     camCfg.put("probedCameraId", -1);
                     camCfg.put("probedSurfaceMode", -1);
+                    camCfg.put("cameraLayout", -1);
                     camCfg.put("probedAndValidated", false);
                     camCfg.put("manualOverride", false);
+                    camCfg.put("fallbackFromProbe", false);
+                    camCfg.put("reprobeOnNextRestart", false);
+                    camCfg.put("sourceBmmTag", "");
+                    camCfg.put("discoveryMethod", "");
+                    camCfg.put("vehicleCamSort", "");
+                    camCfg.put("firmwareFingerprint", "");
+                    camCfg.put("buildDisplay", "");
+                    camCfg.put("buildIncremental", "");
+                    camCfg.put("roBuildIncremental", "");
+                    camCfg.put("productDevice", "");
+                    camCfg.put("validationSignal", "");
+                    camCfg.put("stripConfidence", "");
+                    camCfg.put("layoutConfidence", "");
+                    camCfg.put("lastValidationFailure", "");
+                    camCfg.put("validatedAtMs", 0);
+                    camCfg.put("validatedFrameWidth", 0);
+                    camCfg.put("validatedFrameHeight", 0);
+                    camCfg.put("validationFrameCount", 0);
+                    camCfg.put("nativeProbeReport", "");
+                    camCfg.put("nativeProbeReady", false);
+                    camCfg.put("fpsSetCameraResult", "");
+                    camCfg.put("fpsSetMediaCodecResult", "");
+                    camCfg.put("lastCameraEvent", "");
                     com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
                     CameraDaemon.log("Manual camera ID cleared — will auto-detect on next restart");
                 } catch (Exception e) {

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
@@ -3,6 +3,8 @@ import com.overdrive.app.logging.DaemonLogger;
 import com.overdrive.app.storage.StorageManager;
 import com.overdrive.app.telemetry.TelemetryDataCollector;
 
+import com.overdrive.app.camera.CameraFirmwareInfo;
+import com.overdrive.app.camera.PanoCameraDiscovery;
 import com.overdrive.app.camera.PanoramicCameraGpu;
 
 import java.io.File;
@@ -91,6 +93,186 @@ public class GpuSurveillancePipeline {
         this.encoderHeight = 1920;
         this.eventOutputDir = eventOutputDir;
         this.config = new GpuPipelineConfig();
+    }
+
+    private static org.json.JSONObject loadCameraConfigSection() {
+        try {
+            return com.overdrive.app.config.UnifiedConfigManager.loadConfig().optJSONObject("camera");
+        } catch (Exception e) {
+            logger.warn("Unable to load camera config: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void applyCameraLayoutToConsumers(int layout) {
+        if (recorder != null) {
+            recorder.setCameraLayout(layout);
+        }
+        if (streamScaler != null) {
+            streamScaler.setCameraLayout(layout);
+        }
+    }
+
+    private boolean configureCameraFromSavedConfig(
+            org.json.JSONObject cameraConfig,
+            CameraFirmwareInfo currentFirmware) {
+        if (camera == null || cameraConfig == null) {
+            return false;
+        }
+
+        int savedId = cameraConfig.optInt("probedCameraId", -1);
+        int savedMode = cameraConfig.optInt("probedSurfaceMode", -1);
+        boolean validated = cameraConfig.optBoolean("probedAndValidated", false);
+        boolean manual = cameraConfig.optBoolean("manualOverride", false);
+        boolean fallback = cameraConfig.optBoolean("fallbackFromProbe", false);
+        if (savedId < 0 || savedMode < 0 || (!validated && !manual)) {
+            return false;
+        }
+
+        int layout = cameraConfig.has("cameraLayout")
+            ? cameraConfig.optInt("cameraLayout", 0) : 0;
+        boolean reprobeOnNextRestart = cameraConfig.optBoolean("reprobeOnNextRestart", false);
+        String sourceTag = cameraConfig.optString(
+            "sourceBmmTag", manual ? "manual" : (fallback ? "probe-fallback" : ""));
+        String method = cameraConfig.optString(
+            "discoveryMethod", manual ? "manual" : (fallback ? "probe" : "saved"));
+        String camSort = cameraConfig.optString(
+            "vehicleCamSort", currentFirmware != null ? currentFirmware.vehicleCamSort : "");
+
+        camera.setCameraId(savedId);
+        camera.setCameraSurfaceMode(savedMode);
+        camera.setAutoProbeCameras(false);
+        camera.setManualOverrideActive(manual);
+        camera.setFallbackFromProbe(fallback);
+        camera.setCameraSelectionMetadata(layout, sourceTag, method, camSort);
+        camera.setFirmwareInfo(currentFirmware);
+        camera.setArbitrationMode(cameraConfig.optString("arbitrationMode", "eventCallbackOnly"));
+
+        boolean firmwareMatches = currentFirmware != null
+            && currentFirmware.hasAnySignal()
+            && currentFirmware.matches(cameraConfig);
+        if (reprobeOnNextRestart) {
+            logger.info("Saved camera tuple marked for reprobe on next restart; ignoring tuple trust (" +
+                "id=" + savedId + ", surfaceMode=" + savedMode + ", layout=" + layout + ")");
+            return false;
+        }
+        if (manual) {
+            logger.info("Using MANUAL camera config: id=" + savedId + ", surfaceMode=" + savedMode
+                + ", layout=" + layout);
+            if (!firmwareMatches) {
+                logger.info("Manual override firmware mismatch is expected when the tuple was selected on a different build");
+            }
+            camera.setSkipFrameValidation(false);
+        } else if (validated && firmwareMatches) {
+            logger.info("Using validated saved camera config: id=" + savedId + ", surfaceMode=" + savedMode
+                + ", layout=" + layout);
+            camera.setSkipFrameValidation(true);
+        } else {
+            logger.info("Using saved camera config but keeping validation enabled because firmware metadata is missing or changed: id="
+                + savedId + ", surfaceMode=" + savedMode + ", layout=" + layout);
+            if (!firmwareMatches) {
+                logger.info("Camera firmware mismatch detected, current build will revalidate before trusting the tuple");
+            }
+            camera.setSkipFrameValidation(false);
+        }
+
+        applyCameraLayoutToConsumers(layout);
+        camera.persistCameraConfig(validated && firmwareMatches && !manual, null);
+        return true;
+    }
+
+    private void configureCameraFromDiscovery(
+            PanoCameraDiscovery discovery,
+            CameraFirmwareInfo currentFirmware) {
+        if (camera == null || discovery == null) {
+            return;
+        }
+
+        camera.setCameraId(discovery.cameraId);
+        camera.setCameraSurfaceMode(discovery.surfaceMode);
+        camera.setAutoProbeCameras(false);
+        camera.setManualOverrideActive(false);
+        camera.setFallbackFromProbe(false);
+        camera.setCameraSelectionMetadata(discovery);
+        camera.setFirmwareInfo(currentFirmware);
+        camera.setSkipFrameValidation(false);
+        camera.setArbitrationMode("eventCallbackOnly");
+        applyCameraLayoutToConsumers(discovery.cameraLayout);
+        camera.persistCameraConfig(false, null);
+        logger.info("Using BMM discovered camera tuple: " + discovery);
+    }
+
+    private void configureDefaultCamera(CameraFirmwareInfo currentFirmware) {
+        if (camera == null) {
+            return;
+        }
+
+        camera.setCameraId(1);
+        camera.setCameraSurfaceMode(0);
+        camera.setAutoProbeCameras(false);
+        camera.setManualOverrideActive(false);
+        camera.setFallbackFromProbe(false);
+        camera.setCameraSelectionMetadata(0, "default", "default", currentFirmware != null ? currentFirmware.vehicleCamSort : "");
+        camera.setFirmwareInfo(currentFirmware);
+        camera.setSkipFrameValidation(false);
+        camera.setArbitrationMode("eventCallbackOnly");
+        applyCameraLayoutToConsumers(0);
+        camera.persistCameraConfig(false, null);
+        logger.info("Using default camera tuple: id=1, surfaceMode=0, layout=0");
+    }
+
+    private void configureAutoProbeFallback(CameraFirmwareInfo currentFirmware) {
+        if (camera == null) {
+            return;
+        }
+
+        camera.setCameraSelectionMetadata(0, "probe", "auto-probe", currentFirmware != null ? currentFirmware.vehicleCamSort : "");
+        camera.setFirmwareInfo(currentFirmware);
+        camera.setManualOverrideActive(false);
+        camera.setFallbackFromProbe(true);
+        camera.setSkipFrameValidation(false);
+        camera.setArbitrationMode("eventCallbackOnly");
+        camera.setAutoProbeCameras(true);
+        applyCameraLayoutToConsumers(0);
+        logger.warn("All camera config strategies failed — enabling auto-probe");
+    }
+
+    private void configureCameraSelection(
+            CameraFirmwareInfo currentFirmware,
+            boolean allowDiscovery,
+            boolean allowDefault,
+            String phase) {
+        // Selection order is intentional:
+        // 1) trust a saved tuple only if firmware metadata still matches or the
+        //    user explicitly forced a manual override,
+        // 2) fall back to BMM discovery when available,
+        // 3) use the known-good default tuple,
+        // 4) finally enable auto-probe so the HAL can self-discover.
+        org.json.JSONObject cameraConfig = loadCameraConfigSection();
+        if (cameraConfig != null) {
+            boolean reprobeRequested = cameraConfig.optBoolean("reprobeOnNextRestart", false);
+            if (reprobeRequested) {
+                logger.info("Camera reprobe requested for " + phase + " — skipping saved tuple trust");
+            } else if (configureCameraFromSavedConfig(cameraConfig, currentFirmware)) {
+                return;
+            }
+        }
+
+        if (allowDiscovery) {
+            PanoCameraDiscovery discovery = com.overdrive.app.camera.AvmCameraHelper.discoverPanoCamera();
+            if (discovery != null) {
+                logger.info("Using BMM discovered camera tuple during " + phase + ": " + discovery);
+                configureCameraFromDiscovery(discovery, currentFirmware);
+                return;
+            }
+        }
+
+        if (allowDefault) {
+            configureDefaultCamera(currentFirmware);
+            return;
+        }
+
+        configureAutoProbeFallback(currentFirmware);
     }
     
     /**
@@ -692,73 +874,23 @@ public class GpuSurveillancePipeline {
         logger.info("Vehicle model: " + model);
 
         boolean configured = false;
+        CameraFirmwareInfo currentFirmware = CameraFirmwareInfo.current();
         
-        // Step 1: Validated saved config (probedAndValidated=true OR manualOverride=true)
-        if (!configured) {
-            try {
-                org.json.JSONObject cameraConfig = com.overdrive.app.config.UnifiedConfigManager
-                    .loadConfig().optJSONObject("camera");
-                int savedId = cameraConfig != null ? cameraConfig.optInt("probedCameraId", -1) : -1;
-                int savedMode = cameraConfig != null ? cameraConfig.optInt("probedSurfaceMode", -1) : -1;
-                boolean validated = cameraConfig != null && cameraConfig.optBoolean("probedAndValidated", false);
-                boolean manual = cameraConfig != null && cameraConfig.optBoolean("manualOverride", false);
-                boolean fallback = cameraConfig != null && cameraConfig.optBoolean("fallbackFromProbe", false);
-                
-                if (savedId >= 0 && savedMode >= 0 && (validated || manual)) {
-                    logger.info("Using " + (manual ? "MANUAL" : fallback ? "fallback" : "validated") + 
-                        " camera config: id=" + savedId + ", surfaceMode=" + savedMode);
-                    camera.setCameraId(savedId);
-                    camera.setCameraSurfaceMode(savedMode);
-                    camera.setAutoProbeCameras(false);
-                    // Skip frame validation for ALL saved configs. The strip check uses
-                    // an 8x8 luma heuristic that produces false negatives when all 4 cameras
-                    // see similar scenes (parked in garage, night, uniform lighting).
-                    // A saved config was already validated — no need to re-check every startup.
-                    camera.setSkipFrameValidation(true);
-                    configured = true;
-                }
-            } catch (Exception e) {
-                logger.warn("Failed to load saved camera config: " + e.getMessage());
-            }
-        }
-        
-        // Step 2: BmmCameraInfo discovery — asks the system which camera ID is panoramic.
-        // This is how DiPlus resolves camera IDs across different vehicle models.
-        if (!configured) {
-            int discoveredId = com.overdrive.app.camera.AvmCameraHelper.discoverPanoCameraId();
-            if (discoveredId >= 0) {
-                logger.info("Using BmmCameraInfo discovered camera ID: " + discoveredId);
-                camera.setCameraId(discoveredId);
-                camera.setCameraSurfaceMode(0);
-                camera.setAutoProbeCameras(false);
-                configured = true;
-            }
-        }
-        
-        // Step 3: Default camera ID 1 (correct for Seal, most common model).
-        // If wrong for other models, frame-50 recheck will detect and re-probe.
-        if (!configured) {
-            logger.info("Using default camera ID 1");
-            camera.setCameraId(1);
-            camera.setCameraSurfaceMode(0);
-            camera.setAutoProbeCameras(false);
+        try {
+            configureCameraSelection(currentFirmware, true, true, "init");
             configured = true;
-        }
-        
-        // Step 4: Full auto-probe as last resort (shouldn't reach here)
-        if (!configured) {
-            logger.warn("All camera config strategies failed — enabling auto-probe");
-            camera.setAutoProbeCameras(true);
+        } catch (Exception e) {
+            logger.warn("Failed to resolve camera selection during init: " + e.getMessage());
         }
         
         // Register probe callback — only used when manual probe is triggered via API
         camera.setCameraProbeCallback((cameraId, surfaceMode) -> {
             logger.info("Probe found working camera: id=" + cameraId + ", surfaceMode=" + surfaceMode);
             try {
-                org.json.JSONObject camCfg = new org.json.JSONObject();
-                camCfg.put("probedCameraId", cameraId);
-                camCfg.put("probedSurfaceMode", surfaceMode);
-                com.overdrive.app.config.UnifiedConfigManager.updateSection("camera", camCfg);
+                if (camera != null) {
+                    boolean validated = camera.getValidatedAtMs() > 0;
+                    camera.persistCameraConfig(validated, validated ? null : "probe_callback_unvalidated");
+                }
                 logger.info("Saved camera config for next launch");
             } catch (Exception ex) {
                 logger.warn("Failed to save camera config: " + ex.getMessage());
@@ -771,7 +903,7 @@ public class GpuSurveillancePipeline {
         
         // Always 4-camera mosaic — both devices output the same strip format
         if (recorder != null) {
-            recorder.setCameraLayout(0);
+            recorder.setCameraLayout(camera != null ? camera.getCameraLayout() : 0);
         }
         
         // 6. Create adaptive bitrate controller
@@ -825,8 +957,9 @@ public class GpuSurveillancePipeline {
                     int savedMode = cameraConfig.optInt("probedSurfaceMode", -1);
                     boolean validated = cameraConfig.optBoolean("probedAndValidated", false);
                     boolean manual = cameraConfig.optBoolean("manualOverride", false);
+                    boolean reprobeRequested = cameraConfig.optBoolean("reprobeOnNextRestart", false);
                     
-                    if (savedId >= 0 && savedMode >= 0 && (validated || manual)) {
+                    if (!reprobeRequested && savedId >= 0 && savedMode >= 0 && (validated || manual)) {
                         int currentId = camera.getCameraId();
                         if (currentId != savedId) {
                             logger.info("Camera config changed since init: " + currentId + " → " + savedId +
@@ -1322,7 +1455,7 @@ public class GpuSurveillancePipeline {
         streamScaler = new com.overdrive.app.streaming.GpuStreamScaler(streamWidth, streamHeight);
         
         // Always 4-camera mosaic for streaming
-        streamScaler.setCameraLayout(0);
+        streamScaler.setCameraLayout(camera != null ? camera.getCameraLayout() : 0);
         
         // Initialize on GL thread and WAIT for completion
         // This ensures the scaler is ready before we set streaming components

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
@@ -190,13 +190,17 @@ public class GpuSurveillancePipeline {
 
         camera.setCameraId(discovery.cameraId);
         camera.setCameraSurfaceMode(discovery.surfaceMode);
-        camera.setAutoProbeCameras(false);
         camera.setManualOverrideActive(false);
         camera.setFallbackFromProbe(false);
         camera.setCameraSelectionMetadata(discovery);
         camera.setFirmwareInfo(currentFirmware);
         camera.setSkipFrameValidation(false);
         camera.setArbitrationMode("eventCallbackOnly");
+        // BMM tells us which AVM tuple the firmware advertises, but it does
+        // not prove that addPreviewSurface/startPreview will deliver frames
+        // in this process. Keep auto-probe armed so the frame-15 validator, or
+        // the no-frame timeout, can promote or reject the tuple at runtime.
+        camera.setAutoProbeCameras(true);
         applyCameraLayoutToConsumers(discovery.cameraLayout);
         camera.persistCameraConfig(false, null);
         logger.info("Using BMM discovered camera tuple: " + discovery);
@@ -209,16 +213,20 @@ public class GpuSurveillancePipeline {
 
         camera.setCameraId(1);
         camera.setCameraSurfaceMode(0);
-        camera.setAutoProbeCameras(false);
         camera.setManualOverrideActive(false);
         camera.setFallbackFromProbe(false);
         camera.setCameraSelectionMetadata(0, "default", "default", currentFirmware != null ? currentFirmware.vehicleCamSort : "");
         camera.setFirmwareInfo(currentFirmware);
         camera.setSkipFrameValidation(false);
         camera.setArbitrationMode("eventCallbackOnly");
+        // ID 1/mode 0 is a good first guess on Seal, not a validated fact.
+        // If the HAL opens this tuple but produces zero ImageReader callbacks,
+        // auto-probe must stay enabled so PanoramicCameraGpu can advance to
+        // the next camera/surface tuple instead of streaming a blank view.
+        camera.setAutoProbeCameras(true);
         applyCameraLayoutToConsumers(0);
         camera.persistCameraConfig(false, null);
-        logger.info("Using default camera tuple: id=1, surfaceMode=0, layout=0");
+        logger.info("Using default camera tuple as first auto-probe candidate: id=1, surfaceMode=0, layout=0");
     }
 
     private void configureAutoProbeFallback(CameraFirmwareInfo currentFirmware) {


### PR DESCRIPTION
This is cherry-picked from or part of the branch that fixes this app to work on 2026 BYD Seal 5 DM-i Premium.

apk release for testing: https://github.com/andrewloable/Overdrive/releases/tag/2026-seal-5-dmi-phev-fix

- add AVC HAL warmup and firmware/config discovery for BYD panoramic cameras
- persist and expose camera tuple/config details through daemon and API paths
- keep camera auto-probe enabled until frame delivery is validated
- add a no-frame timeout so probe candidates that open but never produce frames advance instead of hanging on a blank stream
