### PR TITLE
Fix PHEV battery capacity and SOH display

### DIFF
--- a/app/src/main/assets/web/i18n/en.json
+++ b/app/src/main/assets/web/i18n/en.json
@@ -1042,6 +1042,10 @@
   "soh": {
     "fallback_caption": "From last charge · {pct}% · {date}",
     "unavailable_caption": "SOH unavailable — drive or charge to calibrate",
+    "oem_caption": "Vehicle SOH readout — waiting for calculated estimate",
+    "oem_hint": "Using the vehicle-reported SOH until Overdrive has enough trusted capacity data.",
+    "nominal_caption": "Nominal baseline — waiting for trusted battery-health data",
+    "nominal_hint": "Using configured battery capacity until the car provides valid SOH inputs.",
     "last_verified": "Last verified: {pct}% · {date}",
     "tap_to_set": "Tap to set",
     "set_battery_capacity_prompt": "Set battery capacity",

--- a/app/src/main/assets/web/shared/models/manifest.json
+++ b/app/src/main/assets/web/shared/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "default": "seal",
   "baseUrl": "https://github.com/yash-srivastava/Overdrive-release/releases/download/models-v1/",
   "paintPresets": [
@@ -113,6 +113,24 @@
     {
       "id": "destroyer",
       "name": "BYD Destroyer 05",
+      "file": "destroyer.glb",
+      "sizeBytes": 1708884,
+      "sha256": "f2728598afcaaafc09899a36bd3f06900644935b14ec373a825b03bc6b13799b",
+      "bundled": false,
+      "nominalKwh": 18.3
+    },
+    {
+      "id": "seal5-dmi-dynamic",
+      "name": "BYD Seal 5 DM-i Dynamic",
+      "file": "destroyer.glb",
+      "sizeBytes": 1708884,
+      "sha256": "f2728598afcaaafc09899a36bd3f06900644935b14ec373a825b03bc6b13799b",
+      "bundled": false,
+      "nominalKwh": 8.3
+    },
+    {
+      "id": "seal5-dmi-premium",
+      "name": "BYD Seal 5 DM-i Premium",
       "file": "destroyer.glb",
       "sizeBytes": 1708884,
       "sha256": "f2728598afcaaafc09899a36bd3f06900644935b14ec373a825b03bc6b13799b",

--- a/app/src/main/assets/web/shared/performance.js
+++ b/app/src/main/assets/web/shared/performance.js
@@ -2243,6 +2243,30 @@ BYD.performance = {
                 fallbackEl.textContent = BYD.i18n.t('soh.fallback_caption', {pct: capPct, date: calDateStr});
                 fallbackEl.hidden = false;
             }
+        } else if (displaySource === 'oem' && displaySoh > 0) {
+            if (percentEl) {
+                percentEl.style.display = '';
+                percentEl.textContent = displaySoh.toFixed(1) + '%';
+            }
+            if (fallbackEl) {
+                // OEM SOH comes from BYD's StatisticBatteryHealthyIndex, a
+                // recovered legacy signal. Label it separately from calculated
+                // SOH so it remains a diagnostics readout, not a capacity proof.
+                fallbackEl.textContent = BYD.i18n.t('soh.oem_caption') || 'Vehicle SOH readout - waiting for calculated estimate';
+                fallbackEl.hidden = false;
+            }
+        } else if (displaySource === 'nominal' && displaySoh > 0) {
+            if (percentEl) {
+                percentEl.style.display = '';
+                percentEl.textContent = displaySoh.toFixed(1) + '%';
+            }
+            if (fallbackEl) {
+                // Nominal is a display-only fallback for cars whose raw BMS
+                // remain-kWh signal is rejected. Keep the caption explicit so
+                // developers and users do not confuse it with measured SOH.
+                fallbackEl.textContent = BYD.i18n.t('soh.nominal_caption') || 'Nominal baseline - waiting for trusted battery-health data';
+                fallbackEl.hidden = false;
+            }
         } else {
             if (percentEl) {
                 percentEl.style.display = 'none';
@@ -2299,6 +2323,12 @@ BYD.performance = {
             if (!nominalSet) {
                 hint.style.display = 'block';
                 hint.textContent = BYD.i18n.t('soh.set_battery_capacity_prompt');
+            } else if (displaySource === 'oem') {
+                hint.style.display = 'block';
+                hint.textContent = BYD.i18n.t('soh.oem_hint') || 'Using the vehicle-reported SOH until Overdrive has enough trusted capacity data.';
+            } else if (displaySource === 'nominal') {
+                hint.style.display = 'block';
+                hint.textContent = BYD.i18n.t('soh.nominal_hint') || 'Using configured battery capacity until the car provides valid SOH inputs.';
             } else if (!data.hasEstimate) {
                 hint.style.display = 'block';
                 hint.textContent = BYD.i18n.t('performance.soh_no_estimate');
@@ -2312,6 +2342,9 @@ BYD.performance = {
         // Best-effort: capitalize first letter. Manifest titles aren't cached
         // here; the modal has the full list when the user opens it.
         if (!id) return '';
+        if (id === 'seal5-dmi-dynamic') return 'BYD Seal 5 DM-i Dynamic';
+        if (id === 'seal5-dmi-premium') return 'BYD Seal 5 DM-i Premium';
+        if (id === 'destroyer') return 'BYD Destroyer 05';
         return id.charAt(0).toUpperCase() + id.slice(1);
     },
 
@@ -2427,8 +2460,8 @@ BYD.performance = {
         var input = document.getElementById('sohCapacityModalInput');
         var modelSel = document.getElementById('sohCapacityModalModel');
         var kwh = input ? parseFloat(input.value) : NaN;
-        if (isNaN(kwh) || kwh < 15 || kwh > 120) {
-            alert(BYD.i18n.t('soh.modal_capacity_label') + ': 15 - 120');
+        if (isNaN(kwh) || kwh < 8 || kwh > 120) {
+            alert(BYD.i18n.t('soh.modal_capacity_label') + ': 8 - 120');
             return;
         }
         var modelId = modelSel ? modelSel.value : '';

--- a/app/src/main/java/com/overdrive/app/abrp/SohEstimator.java
+++ b/app/src/main/java/com/overdrive/app/abrp/SohEstimator.java
@@ -1,6 +1,7 @@
 package com.overdrive.app.abrp;
 
 import com.overdrive.app.byd.BydVehicleData;
+import com.overdrive.app.byd.BydDataCollector;
 import com.overdrive.app.config.UnifiedConfigManager;
 import com.overdrive.app.logging.DaemonLogger;
 import com.overdrive.app.monitor.BatterySocData;
@@ -58,9 +59,9 @@ public class SohEstimator {
     // remainKwh happens to be numerically close to SOC% by coincidence.
     private boolean fuelSignalsLookBev = false;
 
-    // Plausible BYD pack range. Smallest is Sealion 6 DM-i PHEV at 18.3 kWh;
-    // largest is Tang at 108.8 kWh.
-    private static final double MIN_PLAUSIBLE_KWH = 15.0;
+    // Plausible BYD pack range. Seal 5 DM-i Dynamic uses an 8.3 kWh PHEV
+    // pack; Tang EV is the upper production bound we currently support.
+    private static final double MIN_PLAUSIBLE_KWH = 8.0;
     private static final double MAX_PLAUSIBLE_KWH = 120.0;
 
     // BYD Blade LFP reference cell voltage. 3.22 V derived from BYD's
@@ -960,6 +961,47 @@ public class SohEstimator {
     public long getCalibrationTimestampMs() { return calibrationTimestampMs; }
     public boolean hasEstimate() { return currentSoh > 0; }
 
+    private boolean isPhevVehicle() {
+        try {
+            return BydDataCollector.getInstance().isPhevVehicle();
+        } catch (Throwable t) {
+            // If the collector is not ready yet, fall back to pack size. All
+            // supported BYD PHEV packs are below 30 kWh; BEVs are larger.
+            return nominalCapacityKwh > 0 && nominalCapacityKwh < 30.0;
+        }
+    }
+
+    /**
+     * Returns the OEM battery-health index published by BYD's Statistic device,
+     * or -1 when the current firmware/car does not expose a valid value.
+     *
+     * This is intentionally separate from currentSoh: the Shape B estimator is
+     * capacity math from remain-kWh/SOC/nominal-kWh, while the OEM index is an
+     * opaque dashboard readout that is useful for Diagnostics only.
+     */
+    public double getOemSohPercent() {
+        try {
+            // The recovered legacy signal is only trusted for the PHEV bug path.
+            // BEVs continue to use the calculated Shape B estimate or calibration.
+            if (!isPhevVehicle()) {
+                return -1;
+            }
+            // Prefer a fresh direct Statistic-device read for the PHEV path.
+            // The snapshot is still used as a fallback if a poll captured SOH
+            // but the direct getter is temporarily unavailable.
+            double directSoh = BydDataCollector.getInstance().readOemSohPercent();
+            if (directSoh > 0) {
+                return directSoh;
+            }
+            BydVehicleData vd = VehicleDataMonitor.getInstance().getVd();
+            if (vd == null || Double.isNaN(vd.sohPercent)) return -1;
+            double soh = vd.sohPercent;
+            return (soh > 0 && soh <= 100.0) ? soh : -1;
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
     public double getEstimatedCapacityKwh() {
         if (!hasEstimate()) return -1;
         return (currentSoh / 100.0) * nominalCapacityKwh;
@@ -1015,6 +1057,7 @@ public class SohEstimator {
             status.put("estimatedCapacityKwh", estCap > 0 ? Math.round(estCap * 10) / 10.0 : -1);
             status.put("hasEstimate", hasEstimate());
             status.put("nominalSource", nominalSource);
+            status.put("isPhev", isPhevVehicle());
 
             org.json.JSONObject calibration = new org.json.JSONObject();
             calibration.put("soh", calibrationSoh > 0 ? Math.round(calibrationSoh * 10) / 10.0 : -1);
@@ -1023,11 +1066,27 @@ public class SohEstimator {
 
             double displaySoh;
             String displaySource;
+            double oemSoh = getOemSohPercent();
             if (currentSoh > 0) { displaySoh = currentSoh; displaySource = "live"; }
             else if (calibrationSoh > 0) { displaySoh = calibrationSoh; displaySource = "calibration"; }
+            // Recovered legacy app code used BYD's StatisticBatteryHealthyIndex
+            // for battery health. Keep it as a labeled diagnostics fallback
+            // instead of a real estimate because the OEM value's semantics vary
+            // by firmware and it is not derived from our capacity calculation.
+            else if (oemSoh > 0) { displaySoh = oemSoh; displaySource = "oem"; }
+            // PHEV-class models can expose a bogus raw remain-kWh signal that is
+            // rejected for real SOH estimation. Keep hasEstimate=false, but give
+            // Diagnostics a conservative nominal readout so the card is useful
+            // instead of blank while we wait for a trusted calibration source.
+            else if (nominalCapacityKwh > 0) { displaySoh = 100.0; displaySource = "nominal"; }
             else { displaySoh = -1; displaySource = "unavailable"; }
             status.put("displaySoh", displaySoh > 0 ? Math.round(displaySoh * 10) / 10.0 : -1);
             status.put("displaySource", displaySource);
+            // Always include OEM availability so PHEV debugging can tell the
+            // difference between "not a PHEV" and "PHEV but firmware did not
+            // return StatisticBatteryHealthyIndex".
+            status.put("oemSohAvailable", oemSoh > 0);
+            status.put("oemSoh", oemSoh > 0 ? Math.round(oemSoh * 10) / 10.0 : -1);
 
             // Read fresh — model can change without touching SOH state.
             try {
@@ -1208,7 +1267,7 @@ public class SohEstimator {
     // E6 (71.7 kWh) intentionally omitted: legacy taxi model, virtually
     // indistinguishable from Seal U (71.8 kWh).
     private static final double[] KNOWN_PACK_KWH = {
-        18.3, 26.6, 30.08, 38.0, 43.2, 44.9, 56.4,
+        8.3, 18.3, 26.6, 30.08, 38.0, 43.2, 44.9, 56.4,
         60.48, 61.44, 71.8, 82.56, 85.44, 87.0, 91.3, 108.8
     };
 

--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -159,6 +159,65 @@ public class BydDataCollector {
         return initialized;
     }
 
+    /**
+     * Public drivetrain classifier for consumers that need PHEV-specific data
+     * handling. The actual detection stays centralized in computeIsPhev() so
+     * SOH, range, and charging code all agree on the same fuel-signal logic.
+     */
+    public boolean isPhevVehicle() {
+        try {
+            return computeIsPhev();
+        } catch (Throwable t) {
+            logger.debug("PHEV detection failed: " + t.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Directly reads the recovered legacy OEM SOH value from the BYD Statistic
+     * device. Returns -1 when the firmware does not expose a sane 1..100 value.
+     *
+     * This remains a collector-level helper so every consumer uses the same
+     * getter/feature-id fallback and validation rules.
+     */
+    public double readOemSohPercent() {
+        if (statisticDevice == null) return -1;
+        try {
+            Integer sohValue = null;
+            try {
+                Object result = BydDeviceHelper.callGetter(statisticDevice, "getStatisticBatteryHealthyIndex");
+                if (result instanceof Number) {
+                    sohValue = ((Number) result).intValue();
+                }
+            } catch (NoSuchMethodError nsme) {
+                // Method missing — try feature ID below.
+            } catch (Exception e) {
+                if (!(e.getCause() instanceof NoSuchMethodError)) {
+                    logger.debug("SOH getter failed: " + e.getMessage());
+                }
+            }
+
+            if (sohValue == null || sohValue <= 0 || sohValue > 100) {
+                try {
+                    Object sohVal = BydDeviceHelper.callGet(statisticDevice, BydFeatureIds.STAT_BATTERY_HEALTHY_INDEX, Integer.class);
+                    if (sohVal != null) {
+                        int raw = BydDeviceHelper.getIntValue(sohVal);
+                        if (raw > 0 && raw <= 100) {
+                            sohValue = raw;
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.debug("SOH feature ID failed: " + e.getMessage());
+                }
+            }
+
+            return (sohValue != null && sohValue > 0 && sohValue <= 100) ? sohValue : -1;
+        } catch (Exception e) {
+            logger.debug("readOemSohPercent error: " + e.getMessage());
+            return -1;
+        }
+    }
+
     // ==================== INITIALIZATION ====================
 
     /**
@@ -2431,39 +2490,8 @@ public class BydDataCollector {
         // SohEstimator no longer consumes this signal — Shape B drives the
         // live SOH from the energy formula, calibration is a separate anchor.
         try {
-            Integer sohValue = null;
-            try {
-                Object result = BydDeviceHelper.callGetter(statisticDevice, "getStatisticBatteryHealthyIndex");
-                if (result instanceof Integer) {
-                    sohValue = (Integer) result;
-                } else if (result instanceof Double) {
-                    sohValue = (int) ((Double) result).doubleValue();
-                } else if (result instanceof Float) {
-                    sohValue = (int) ((Float) result).floatValue();
-                }
-            } catch (NoSuchMethodError nsme) {
-                // method missing — try feature ID below
-            } catch (Exception e) {
-                if (!(e.getCause() instanceof NoSuchMethodError)) {
-                    logger.debug("SOH getter failed: " + e.getMessage());
-                }
-            }
-
-            if (sohValue == null || sohValue < 0 || sohValue > 100) {
-                try {
-                    Object sohVal = BydDeviceHelper.callGet(statisticDevice, BydFeatureIds.STAT_BATTERY_HEALTHY_INDEX, Integer.class);
-                    if (sohVal != null) {
-                        int raw = BydDeviceHelper.getIntValue(sohVal);
-                        if (raw >= 0 && raw <= 100) {
-                            sohValue = raw;
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.debug("SOH feature ID failed: " + e.getMessage());
-                }
-            }
-
-            if (sohValue != null && sohValue >= 0 && sohValue <= 100) {
+            double sohValue = readOemSohPercent();
+            if (sohValue > 0) {
                 b.sohPercent(sohValue);
             }
         } catch (Exception e) {

--- a/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
@@ -31,9 +31,10 @@ public final class BydDeviceHelper {
             }
             return device;
         } catch (ClassNotFoundException e) {
-            logger.debug("Device class not found: " + className);
+            // Different BYD trims ship different SDK device classes, so absence is expected.
+            logger.debug("Optional device class absent: " + className);
         } catch (Exception e) {
-            logger.debug("Device init failed: " + className + " — " + e.getMessage());
+            logger.debug("Optional device unavailable: " + className + " — " + e.getMessage());
         }
         return null;
     }
@@ -169,7 +170,7 @@ public final class BydDeviceHelper {
             if (m != null) {
                 Class<?>[] params = m.getParameterTypes();
                 if (params.length == 2 && params[0] == int[].class) {
-                    return m.invoke(device, new int[]{featureId}, returnType);
+                    return m.invoke(device, new int[]{featureId}, normalizeFeatureReturnType(returnType));
                 } else if (params.length == 2 && params[0] == int.class) {
                     return m.invoke(device, featureId, 0);
                 }
@@ -178,6 +179,17 @@ public final class BydDeviceHelper {
             logger.debug("callGet failed for id=" + featureId + " — " + e.getMessage());
         }
         return null;
+    }
+
+    private static Class<?> normalizeFeatureReturnType(Class<?> returnType) {
+        // BYD's get(int[], Class) expects primitive class tokens
+        // (Integer.TYPE/Double.TYPE). Passing boxed classes works on some
+        // firmware but logs "Param type is invalid:Integer!" on this head unit.
+        if (returnType == Integer.class) return Integer.TYPE;
+        if (returnType == Double.class) return Double.TYPE;
+        if (returnType == Float.class) return Float.TYPE;
+        if (returnType == Boolean.class) return Boolean.TYPE;
+        return returnType;
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
+++ b/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
@@ -509,7 +509,9 @@ public class SocHistoryDatabase {
                             }
                         }
                     } else {
-                        logger.info("SOH persisted file not found at /data/local/tmp/abrp_soh_estimate.properties");
+                        // New installs and reset diagnostics legitimately start without a
+                        // persisted SOH estimate; keep that out of warning-focused logs.
+                        logger.debug("SOH persisted file absent at /data/local/tmp/abrp_soh_estimate.properties");
                     }
                 }
             } catch (Exception e) {
@@ -1174,10 +1176,34 @@ public class SocHistoryDatabase {
             }
             
             com.overdrive.app.abrp.SohEstimator sohEst = getSohEstimator();
+            double oemSoh = sohEst != null ? sohEst.getOemSohPercent() : -1;
             if (sohEst != null && sohEst.hasEstimate()) {
                 current.put("soh", Math.round(sohEst.getCurrentSoh() * 10) / 10.0);
                 current.put("estimatedCapacityKwh", Math.round(sohEst.getEstimatedCapacityKwh() * 10) / 10.0);
                 current.put("nominalCapacityKwh", sohEst.getNominalCapacityKwh());
+                current.put("sohSource", "live");
+            } else if (sohEst != null && oemSoh > 0) {
+                // Use the recovered legacy app's OEM SOH signal for display
+                // only. It keeps Diagnostics useful on cars whose raw
+                // remain-kWh input is invalid, but sohSource="oem" makes clear
+                // that this is not the Shape B capacity estimate.
+                double nominal = sohEst.getNominalCapacityKwh();
+                current.put("soh", Math.round(oemSoh * 10) / 10.0);
+                if (nominal > 0) {
+                    current.put("estimatedCapacityKwh", Math.round((nominal * oemSoh / 100.0) * 10) / 10.0);
+                    current.put("nominalCapacityKwh", nominal);
+                }
+                current.put("sohSource", "oem");
+            } else if (sohEst != null && sohEst.getNominalCapacityKwh() > 0) {
+                // Some PHEV BYD SDK builds report raw remaining energy using a
+                // BEV-sized value. The estimator rejects that for real SOH, but
+                // the health card can still show a clearly-marked nominal
+                // baseline instead of looking broken.
+                double nominal = sohEst.getNominalCapacityKwh();
+                current.put("soh", 100.0);
+                current.put("estimatedCapacityKwh", Math.round(nominal * 10) / 10.0);
+                current.put("nominalCapacityKwh", nominal);
+                current.put("sohSource", "nominal");
             } else {
                 // Fallback: read persisted SOH from file if estimator reference not wired yet
                 logger.info("SOH estimator " + (sohEst == null ? "is null" : "has no estimate") + " for health report, trying persisted file fallback");
@@ -1197,7 +1223,9 @@ public class SocHistoryDatabase {
                             }
                         }
                     } else {
-                        logger.info("SOH persisted file not found for health report");
+                        // A missing persisted estimate only means the health report should rely
+                        // on OEM SOH or calibration data when available.
+                        logger.debug("SOH persisted file absent for health report");
                     }
                 } catch (Exception e) {
                     logger.debug("Failed to read persisted SOH for health report: " + e.getMessage());

--- a/app/src/main/java/com/overdrive/app/monitor/VehicleDataMonitor.java
+++ b/app/src/main/java/com/overdrive/app/monitor/VehicleDataMonitor.java
@@ -257,7 +257,18 @@ public class VehicleDataMonitor {
                 com.overdrive.app.monitor.SocHistoryDatabase.getInstance().getSohEstimator();
             if (soh != null && soh.getNominalCapacityKwh() > 0 && soc > 0) {
                 double nominal = soh.getNominalCapacityKwh();
+                boolean isPhev = isPhevVehicle(nominal);
                 double sohPercent = soh.hasEstimate() ? soh.getCurrentSoh() : 100.0;
+                if (isPhev && !soh.hasEstimate()) {
+                    double oemSoh = soh.getOemSohPercent();
+                    if (oemSoh > 0) {
+                        // PHEV firmwares can report an impossible raw remain-kWh
+                        // value. When the recovered OEM SOH is available, use it
+                        // to compute an actual PHEV remaining-energy readout from
+                        // SOC × nominal capacity × vehicle SOH.
+                        sohPercent = oemSoh;
+                    }
+                }
                 double computedKwh = (soc / 100.0) * nominal * (sohPercent / 100.0);
                 
                 // Validate raw BMS value: if implied capacity is wildly off from nominal,
@@ -272,7 +283,6 @@ public class VehicleDataMonitor {
                     }
                 }
                 
-                boolean isPhev = nominal < 30.0;
                 if (isPhev) {
                     return computedKwh;
                 }
@@ -287,6 +297,19 @@ public class VehicleDataMonitor {
         if (rawKwh > 0) return rawKwh;
 
         return 0.0;
+    }
+
+    private boolean isPhevVehicle(double nominalCapacityKwh) {
+        try {
+            BydDataCollector collector = BydDataCollector.getInstance();
+            if (collector.isInitialized()) {
+                return collector.isPhevVehicle();
+            }
+        } catch (Throwable ignored) {
+            // Fall through to pack-size heuristic below.
+        }
+        // Fallback for early daemon startup before fuel HAL probes complete.
+        return nominalCapacityKwh > 0 && nominalCapacityKwh < 30.0;
     }
     
     public JSONObject getAllData() {

--- a/app/src/main/java/com/overdrive/app/server/PerformanceApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/PerformanceApiHandler.java
@@ -792,7 +792,7 @@ public class PerformanceApiHandler {
      * POST /api/performance/soh/nominal — set or clear the user-set nominal kWh.
      * Body: {"nominalKwh": 82.5}  → sets user override
      *       {"nominalKwh": null}  → clears override, re-runs auto-detect
-     * Validates 15-120 kWh range.
+     * Validates 8-120 kWh range.
      */
     private static boolean handleSohSetNominal(String body, OutputStream out) throws Exception {
         try {
@@ -817,10 +817,10 @@ public class PerformanceApiHandler {
                 sohEst.clearUserNominal();
             } else {
                 double kwh = req.getDouble("nominalKwh");
-                if (kwh < 15.0 || kwh > 120.0) {
+                if (kwh < 8.0 || kwh > 120.0) {
                     JSONObject err = new JSONObject();
                     err.put("success", false);
-                    err.put("error", "nominalKwh must be between 15 and 120");
+                    err.put("error", "nominalKwh must be between 8 and 120");
                     HttpResponse.sendJson(out, err.toString());
                     return true;
                 }

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -1138,6 +1138,7 @@ class MainActivity : AppCompatActivity() {
             var samples = "--"
             var lastUpdated = "--"
             var hasEstimate = false
+            var displaySource = "unavailable"
 
             // Vehicle section state. Populated from /api/performance/soh status JSON
             // when available; falls back to legacy properties-file values otherwise.
@@ -1191,11 +1192,27 @@ class MainActivity : AppCompatActivity() {
                 if (conn.responseCode == 200) {
                     val body = conn.inputStream.bufferedReader().use { it.readText() }
                     val json = org.json.JSONObject(body)
+                    hasEstimate = json.optBoolean("hasEstimate", hasEstimate)
+                    val apiDisplaySoh = json.optDouble("displaySoh", -1.0)
+                    val apiDisplaySource = json.optString("displaySource", displaySource)
+                    // Prefer the daemon's display fields. They separate real
+                    // estimates from nominal fallbacks, so the dialog can show
+                    // useful battery data without pretending the fallback is a
+                    // measured SOH value.
+                    if (apiDisplaySoh > 0) {
+                        sohPercent = String.format("%.1f%%", apiDisplaySoh)
+                        method = apiDisplaySource.ifEmpty { method }
+                        displaySource = apiDisplaySource.ifEmpty { displaySource }
+                    }
                     if (!json.isNull("modelId")) {
                         modelId = json.optString("modelId", "").ifEmpty { null }
                     }
                     nominalKwhValue = json.optDouble("nominalCapacityKwh", nominalKwhValue)
                     nominalSourceVal = json.optString("nominalSource", nominalSourceVal)
+                    source = nominalSourceVal
+                    if (nominalKwhValue > 0) {
+                        nominalKwh = String.format("%.1f kWh", nominalKwhValue)
+                    }
                     val est = json.optDouble("estimatedCapacityKwh", -1.0)
                     if (est > 0) estimatedKwhValue = est
                     val calObj = json.optJSONObject("calibration")
@@ -1214,6 +1231,7 @@ class MainActivity : AppCompatActivity() {
             val finalSamples = samples
             val finalLastUpdated = lastUpdated
             val finalHasEstimate = hasEstimate
+            val finalDisplaySource = displaySource
             val finalModelId = modelId
             val finalNominalKwh = nominalKwhValue
             val finalNominalSource = nominalSourceVal
@@ -1282,6 +1300,12 @@ class MainActivity : AppCompatActivity() {
                 if (finalHasEstimate) {
                     statusView.text = getString(R.string.soh_estimation_active)
                     statusView.setTextColor(resources.getColor(R.color.brand_primary, null))
+                } else if (finalDisplaySource == "oem") {
+                    statusView.text = getString(R.string.soh_oem_readout)
+                    statusView.setTextColor(resources.getColor(R.color.text_muted, null))
+                } else if (finalDisplaySource == "nominal") {
+                    statusView.text = getString(R.string.soh_nominal_baseline)
+                    statusView.setTextColor(resources.getColor(R.color.text_muted, null))
                 } else {
                     statusView.text = getString(R.string.soh_no_estimate_yet)
                     statusView.setTextColor(resources.getColor(R.color.text_muted, null))
@@ -1289,7 +1313,9 @@ class MainActivity : AppCompatActivity() {
 
                 // SOH percent color based on health
                 val sohView = dialogView.findViewById<TextView>(R.id.tvSohPercent)
-                if (finalHasEstimate) {
+                // OEM and nominal fallbacks are still visible percentages, but
+                // only finalHasEstimate means Overdrive calculated capacity SOH.
+                if (finalHasEstimate || finalDisplaySource == "oem" || finalDisplaySource == "nominal") {
                     val sohVal = finalSoh.replace("%", "").toDoubleOrNull() ?: 0.0
                     val colorRes = when {
                         sohVal >= 85 -> R.color.brand_primary   // Good
@@ -1331,6 +1357,8 @@ class MainActivity : AppCompatActivity() {
             "sealion6" -> "BYD Sealion 6"
             "sealion7" -> "BYD Sealion 7"
             "sealu", "seal-u" -> "BYD Seal U"
+            "seal5-dmi-dynamic" -> "BYD Seal 5 DM-i Dynamic"
+            "seal5-dmi-premium" -> "BYD Seal 5 DM-i Premium"
             else -> modelId.replaceFirstChar { it.uppercase() }
         }
     }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
@@ -913,7 +913,7 @@ class DashboardFragment : Fragment() {
                 if (!isAdded || view == null) return@post
                 if (nominalKwh > 0) {
                     tile.text = if (modelId != null) {
-                        getString(R.string.dashboard_vehicle_summary, nominalKwh, modelId.replaceFirstChar { it.uppercase() })
+                        getString(R.string.dashboard_vehicle_summary, nominalKwh, modelDisplayName(modelId))
                     } else {
                         String.format("%.1f kWh", nominalKwh)
                     }
@@ -1120,6 +1120,13 @@ class DashboardFragment : Fragment() {
                         String.format("%.1f%% (live)", finalDisplaySoh)
                     finalDisplaySoh > 0 && finalDisplaySource == "calibration" ->
                         String.format("%.1f%% (from last charge)", finalDisplaySoh)
+                    // OEM is the BYD StatisticBatteryHealthyIndex recovered
+                    // from the legacy app. Surface it in the vehicle summary,
+                    // but label it so it is not mistaken for calculated SOH.
+                    finalDisplaySoh > 0 && finalDisplaySource == "oem" ->
+                        String.format("%.1f%% (vehicle)", finalDisplaySoh)
+                    finalDisplaySoh > 0 && finalDisplaySource == "nominal" ->
+                        String.format("%.1f%% (nominal)", finalDisplaySoh)
                     else -> getString(R.string.vehicle_dialog_soh_unavailable)
                 }
                 summarySoh.text = getString(R.string.vehicle_dialog_summary_soh, sohText)
@@ -1154,7 +1161,7 @@ class DashboardFragment : Fragment() {
             .setPositiveButton(getString(R.string.vehicle_dialog_save)) { _, _ ->
                 val raw = capInput.text?.toString()?.trim().orEmpty()
                 val kwh = raw.toDoubleOrNull()
-                if (kwh == null || kwh < 15.0 || kwh > 120.0) {
+                if (kwh == null || kwh < 8.0 || kwh > 120.0) {
                     Toast.makeText(ctx, getString(R.string.vehicle_dialog_invalid_capacity), Toast.LENGTH_SHORT).show()
                     return@setPositiveButton
                 }
@@ -1231,6 +1238,8 @@ class DashboardFragment : Fragment() {
             "sealion6" -> "BYD Sealion 6"
             "sealion7" -> "BYD Sealion 7"
             "sealu", "seal-u" -> "BYD Seal U"
+            "seal5-dmi-dynamic" -> "BYD Seal 5 DM-i Dynamic"
+            "seal5-dmi-premium" -> "BYD Seal 5 DM-i Premium"
             else -> modelId.replaceFirstChar { it.uppercase() }
         }
     }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DiagnosticsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DiagnosticsFragment.kt
@@ -458,11 +458,10 @@ class DiagnosticsFragment : Fragment() {
     // ============== Battery tile ==============
 
     /**
-     * Reads the persisted SOH estimate from /data/local/tmp/abrp_soh_estimate.properties
-     * (same source MainActivity.showBatteryHealthDialog uses). Property keys:
-     *   - "soh_percent"  → float, 0..100
-     * If the file doesn't exist or can't be parsed, the tile shows
-     * "Pending data" + neutral dot — never a fake number.
+     * Reads the daemon SOH display status first, falling back to the legacy
+     * persisted SOH file when the daemon is unavailable. The daemon exposes
+     * displaySource so OEM and nominal fallbacks can be shown as data without
+     * marking them as Overdrive's measured capacity estimate.
      */
     private fun refreshBatteryTile() {
         val executor = batteryExecutor ?: Executors.newSingleThreadExecutor()
@@ -470,24 +469,47 @@ class DiagnosticsFragment : Fragment() {
 
         executor.execute {
             var sohPercent: Double? = null
+            var displaySource = "unavailable"
             try {
-                val sohFile = File("/data/local/tmp/abrp_soh_estimate.properties")
-                if (sohFile.exists() && sohFile.canRead()) {
-                    val props = java.util.Properties()
-                    java.io.FileInputStream(sohFile).use { props.load(it) }
-                    val v = props.getProperty("soh_percent")?.toDoubleOrNull()
-                    // Accept up to 110% — BYD packs are factory over-provisioned
-                    // 102-104% so a near-new pack legitimately reads >100%.
-                    // Matches SohEstimator.applyWeightedSoh's accept band.
-                    if (v != null && v >= 60.0 && v <= 110.0) {
-                        sohPercent = v
+                val conn = com.overdrive.app.util.DaemonHttpClient.open(
+                    "/api/performance/soh", "GET", 2000, 3000)
+                if (conn.responseCode == 200) {
+                    val body = conn.inputStream.bufferedReader().use { it.readText() }
+                    val json = org.json.JSONObject(body)
+                    val displaySoh = json.optDouble("displaySoh", -1.0)
+                    if (displaySoh >= 60.0 && displaySoh <= 110.0) {
+                        sohPercent = displaySoh
+                        displaySource = json.optString("displaySource", displaySource)
                     }
                 }
+                conn.disconnect()
             } catch (_: Throwable) {
-                // Stay null — UI will show "Pending data".
+                // Fall through to file fallback below.
+            }
+
+            if (sohPercent == null) {
+                try {
+                    val sohFile = File("/data/local/tmp/abrp_soh_estimate.properties")
+                    if (sohFile.exists() && sohFile.canRead()) {
+                        val props = java.util.Properties()
+                        java.io.FileInputStream(sohFile).use { props.load(it) }
+                        val v = props.getProperty("soh_percent")?.toDoubleOrNull()
+                        // Accept up to 110% — BYD packs are factory over-provisioned
+                        // 102-104% so a near-new pack legitimately reads >100%.
+                        // Matches SohEstimator.applyWeightedSoh's accept band.
+                        if (v != null && v >= 60.0 && v <= 110.0) {
+                            sohPercent = v
+                            displaySource = "live"
+                        }
+                    }
+                } catch (_: Throwable) {
+                    // Stay null — UI will show "Pending data" unless the daemon
+                    // branch already supplied a display value.
+                }
             }
 
             val finalSoh = sohPercent
+            val finalDisplaySource = displaySource
             mainHandler.post {
                 if (!isAdded) return@post
                 val tv = tvBatteryValue ?: return@post
@@ -498,6 +520,7 @@ class DiagnosticsFragment : Fragment() {
                 } else {
                     tv.text = getString(R.string.diagnostics_battery_value_soh, finalSoh)
                     val dotRes = when {
+                        finalDisplaySource == "nominal" -> R.drawable.status_dot_neutral
                         finalSoh >= 80.0 -> R.drawable.status_dot_online
                         finalSoh >= 50.0 -> R.drawable.status_dot_starting
                         else -> R.drawable.status_dot_offline

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Setzte Batteriekapazität</string>
     <string name="vehicle_dialog_capacity_label">Kapazität (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 bis 120 kWh. Lassen Sie es, um die Modellvorgabe zu verwenden.</string>
+    <string name="vehicle_dialog_capacity_helper">8 bis 120 kWh. Lassen Sie es, um die Modellvorgabe zu verwenden.</string>
     <string name="vehicle_dialog_model_label">Modell</string>
     <string name="vehicle_dialog_save">Speichern</string>
     <string name="vehicle_dialog_reset">Zur Autodetektion zurückgesetzt</string>
-    <string name="vehicle_dialog_invalid_capacity">Die Kapazität muss 15 - 120 kWh betragen.</string>
+    <string name="vehicle_dialog_invalid_capacity">Die Kapazität muss 8 - 120 kWh betragen.</string>
     <string name="vehicle_dialog_summary_capacity">Kapazität: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Wirksam: %1$.1f kWh</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Capacidad de la batería</string>
     <string name="vehicle_dialog_capacity_label">Capacidad (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 a 120 kWh. Dejar para usar el modelo predeterminado.</string>
+    <string name="vehicle_dialog_capacity_helper">8 a 120 kWh. Dejar para usar el modelo predeterminado.</string>
     <string name="vehicle_dialog_model_label">Modelo</string>
     <string name="vehicle_dialog_save">Guardar</string>
     <string name="vehicle_dialog_reset">Se restablece a la detección automática</string>
-    <string name="vehicle_dialog_invalid_capacity">La capacidad debe ser de 15 a 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">La capacidad debe ser de 8 a 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Capacidad: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Efectivo: %1$.1f kWh</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Réglage de la capacité de la batterie</string>
     <string name="vehicle_dialog_capacity_label">Capacité (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 à 120 kWh. Laissez utiliser le modèle par défaut.</string>
+    <string name="vehicle_dialog_capacity_helper">8 à 120 kWh. Laissez utiliser le modèle par défaut.</string>
     <string name="vehicle_dialog_model_label">Modèle</string>
     <string name="vehicle_dialog_save">Enregistrer</string>
     <string name="vehicle_dialog_reset">Réinitialiser à la détection automatique</string>
-    <string name="vehicle_dialog_invalid_capacity">La capacité doit être comprise entre 15 et 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">La capacité doit être comprise entre 8 et 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Capacité: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Effectif: %1$.1f kWh</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">बैटरी क्षमता सेट करें</string>
     <string name="vehicle_dialog_capacity_label">क्षमता (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 से 120 kWh। मॉडल डिफ़ॉल्ट का उपयोग करने के लिए छोड़ दें।</string>
+    <string name="vehicle_dialog_capacity_helper">8 से 120 kWh। मॉडल डिफ़ॉल्ट का उपयोग करने के लिए छोड़ दें।</string>
     <string name="vehicle_dialog_model_label">मॉडल</string>
     <string name="vehicle_dialog_save">सहेजें</string>
     <string name="vehicle_dialog_reset">ऑटो-डिटेक्ट करने के लिए रीसेट करें</string>
-    <string name="vehicle_dialog_invalid_capacity">क्षमता 15 से 120 kWh होनी चाहिए</string>
+    <string name="vehicle_dialog_invalid_capacity">क्षमता 8 से 120 kWh होनी चाहिए</string>
     <string name="vehicle_dialog_summary_capacity">क्षमताः %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">प्रभावी: %1$.1f kWh</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Capacità della batteria impostata</string>
     <string name="vehicle_dialog_capacity_label">Capacità (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 a 120 kWh. Lasciare per utilizzare il modello predefinito.</string>
+    <string name="vehicle_dialog_capacity_helper">8 a 120 kWh. Lasciare per utilizzare il modello predefinito.</string>
     <string name="vehicle_dialog_model_label">Modello</string>
     <string name="vehicle_dialog_save">Salva</string>
     <string name="vehicle_dialog_reset">Risetto a rilevamento automatico</string>
-    <string name="vehicle_dialog_invalid_capacity">La capacità deve essere compresa tra 15 e 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">La capacità deve essere compresa tra 8 e 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Capacità: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Fatto: %1$.1f kWh</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">バッテリーの容量設定</string>
     <string name="vehicle_dialog_capacity_label">容量 (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 ～ 120 kWh.モデルのデフォルトを使用する場合はそのままにします。</string>
+    <string name="vehicle_dialog_capacity_helper">8 ～ 120 kWh.モデルのデフォルトを使用する場合はそのままにします。</string>
     <string name="vehicle_dialog_model_label">モデル</string>
     <string name="vehicle_dialog_save">保存</string>
     <string name="vehicle_dialog_reset">自動検出にリセット</string>
-    <string name="vehicle_dialog_invalid_capacity">容量は15~120ZkWh</string>
+    <string name="vehicle_dialog_invalid_capacity">容量は8~120ZkWh</string>
     <string name="vehicle_dialog_summary_capacity">容量: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">効力: %1$.1f kWh</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">배터리 용량을 설정</string>
     <string name="vehicle_dialog_capacity_label">용량 (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 ~ 120kWh. 모델 기본값을 사용하려면 그대로 둡니다.</string>
+    <string name="vehicle_dialog_capacity_helper">8 ~ 120kWh. 모델 기본값을 사용하려면 그대로 둡니다.</string>
     <string name="vehicle_dialog_model_label">모델</string>
     <string name="vehicle_dialog_save">저장</string>
     <string name="vehicle_dialog_reset">자동 탐지 설정</string>
-    <string name="vehicle_dialog_invalid_capacity">용량은 15 ~ 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">용량은 8 ~ 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">용량: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">유효성: %1$.1f kWh</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Sette batterikapacitet</string>
     <string name="vehicle_dialog_capacity_label">Kapasitet (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 til 120 kWh. La stå for å bruke standardmodellen.</string>
+    <string name="vehicle_dialog_capacity_helper">8 til 120 kWh. La stå for å bruke standardmodellen.</string>
     <string name="vehicle_dialog_model_label">Modell</string>
     <string name="vehicle_dialog_save">Lagre</string>
     <string name="vehicle_dialog_reset">Omsett til automatisk oppdagelse</string>
-    <string name="vehicle_dialog_invalid_capacity">Kapasitet må være 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">Kapasitet må være 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Kapasitet: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Effektivitet: %1$.1f kWh</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Stel de batterijcapaciteit</string>
     <string name="vehicle_dialog_capacity_label">Capaciteit (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 tot 120 kWh. Laat het model standaard gebruiken.</string>
+    <string name="vehicle_dialog_capacity_helper">8 tot 120 kWh. Laat het model standaard gebruiken.</string>
     <string name="vehicle_dialog_model_label">Model</string>
     <string name="vehicle_dialog_save">Opslaan</string>
     <string name="vehicle_dialog_reset">Herstellen op automatische detectie</string>
-    <string name="vehicle_dialog_invalid_capacity">De capaciteit moet 15 - 120 kWh zijn.</string>
+    <string name="vehicle_dialog_invalid_capacity">De capaciteit moet 8 - 120 kWh zijn.</string>
     <string name="vehicle_dialog_summary_capacity">Capaciteit: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Effectief: %1$.1f kWh</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Capacidade de bateria definida</string>
     <string name="vehicle_dialog_capacity_label">Capacidade (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 a 120 kWh. Deixe para usar o padrão do modelo.</string>
+    <string name="vehicle_dialog_capacity_helper">8 a 120 kWh. Deixe para usar o padrão do modelo.</string>
     <string name="vehicle_dialog_model_label">Modelo</string>
     <string name="vehicle_dialog_save">Salvar</string>
     <string name="vehicle_dialog_reset">Reset para detecção automática</string>
-    <string name="vehicle_dialog_invalid_capacity">A capacidade deve ser de 15 a 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">A capacidade deve ser de 8 a 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Capacidade: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Eficaz: %1$.1f kWh</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Установка емкости батареи</string>
     <string name="vehicle_dialog_capacity_label">Пропускная способность (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">от 15 до 120 kWh. Оставьте, чтобы использовать модель по умолчанию.</string>
+    <string name="vehicle_dialog_capacity_helper">от 8 до 120 kWh. Оставьте, чтобы использовать модель по умолчанию.</string>
     <string name="vehicle_dialog_model_label">Модель</string>
     <string name="vehicle_dialog_save">Сохранить</string>
     <string name="vehicle_dialog_reset">Перезагрузка на автоматическое обнаружение</string>
-    <string name="vehicle_dialog_invalid_capacity">Пропускная способность должна быть 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">Пропускная способность должна быть 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Пропускная способность: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Эффективность: %1$.1f kWh</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -470,11 +470,11 @@
     <string name="vehicle_dialog_title">ตั้งค่าความจุแบตเตอรี่</string>
     <string name="vehicle_dialog_capacity_label">ความจุ</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">ตั้งแต่ 15 ถึง 120 kWh ปล่อยว่างไว้เพื่อใช้ค่ามาตรฐานของรุ่นรถ</string>
+    <string name="vehicle_dialog_capacity_helper">ตั้งแต่ 8 ถึง 120 kWh ปล่อยว่างไว้เพื่อใช้ค่ามาตรฐานของรุ่นรถ</string>
     <string name="vehicle_dialog_model_label">รุ่น</string>
     <string name="vehicle_dialog_save">บันทึก</string>
     <string name="vehicle_dialog_reset">รีเซ็ตเพื่อตรวจจับอัตโนมัติ</string>
-    <string name="vehicle_dialog_invalid_capacity">ความจุต้องอยู่ระหว่าง 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">ความจุต้องอยู่ระหว่าง 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">ความจุ: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">ใช้งานได้จริง: %1$.1f kWh</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Batarya kapasitesini ayarlayın</string>
     <string name="vehicle_dialog_capacity_label">Kapasite (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 ila 120 kWh. Model varsayılanını kullanmak için bırakın.</string>
+    <string name="vehicle_dialog_capacity_helper">8 ila 120 kWh. Model varsayılanını kullanmak için bırakın.</string>
     <string name="vehicle_dialog_model_label">Model</string>
     <string name="vehicle_dialog_save">Kaydet</string>
     <string name="vehicle_dialog_reset">Otomatik tespit için yeniden ayarlayın</string>
-    <string name="vehicle_dialog_invalid_capacity">Kapasite 15 - 120 kWh olmalıdır.</string>
+    <string name="vehicle_dialog_invalid_capacity">Kapasite 8 - 120 kWh olmalıdır.</string>
     <string name="vehicle_dialog_summary_capacity">Kapasite: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Etkili: %1$.1f kWh</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">Capacity pin được thiết lập</string>
     <string name="vehicle_dialog_capacity_label">Công suất (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 đến 120 kWh. Thoát để sử dụng mô hình mặc định.</string>
+    <string name="vehicle_dialog_capacity_helper">8 đến 120 kWh. Thoát để sử dụng mô hình mặc định.</string>
     <string name="vehicle_dialog_model_label">Mô hình</string>
     <string name="vehicle_dialog_save">Lưu</string>
     <string name="vehicle_dialog_reset">Đặt lại để tự phát hiện</string>
-    <string name="vehicle_dialog_invalid_capacity">Công suất phải là 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">Công suất phải là 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Công suất: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Tính hiệu quả: %1$.1f kWh</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -468,11 +468,11 @@
     <string name="vehicle_dialog_title">设置电池容量</string>
     <string name="vehicle_dialog_capacity_label">产能 (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15至120 kWh。保留以使用模型默认值。</string>
+    <string name="vehicle_dialog_capacity_helper">8至120 kWh。保留以使用模型默认值。</string>
     <string name="vehicle_dialog_model_label">模型</string>
     <string name="vehicle_dialog_save">保存</string>
     <string name="vehicle_dialog_reset">重新设置为自动检测</string>
-    <string name="vehicle_dialog_invalid_capacity">容量必须为15-120kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">容量必须为8-120kWh</string>
     <string name="vehicle_dialog_summary_capacity">容量:%1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">有效:%1$.1f kWh</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -469,11 +469,11 @@
     <string name="vehicle_dialog_title">設定電池容量</string>
     <string name="vehicle_dialog_capacity_label">容量 (kWh)</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15至120 kWh。保留以使用模型預設值。</string>
+    <string name="vehicle_dialog_capacity_helper">8至120 kWh。保留以使用模型預設值。</string>
     <string name="vehicle_dialog_model_label">模型</string>
     <string name="vehicle_dialog_save">儲存</string>
     <string name="vehicle_dialog_reset">預定自动檢測</string>
-    <string name="vehicle_dialog_invalid_capacity">容量必須為 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">容量必須為 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">容量:%1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">有效: %1$.1f kWh</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,6 +477,8 @@
     <string name="camera_current_manual">Current: Camera %1$d (Manual)</string>
     <string name="camera_current_auto_label">Current: Auto</string>
     <string name="soh_estimation_active">Estimation active</string>
+    <string name="soh_oem_readout">Vehicle SOH readout — waiting for calculated estimate</string>
+    <string name="soh_nominal_baseline">Nominal baseline — waiting for trusted SOH data</string>
     <string name="soh_no_estimate_yet">No estimate yet — waiting for data</string>
 
     <!-- Recording tabs -->
@@ -688,11 +690,11 @@
     <string name="vehicle_dialog_title">Set battery capacity</string>
     <string name="vehicle_dialog_capacity_label">Capacity</string>
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
-    <string name="vehicle_dialog_capacity_helper">15 to 120 kWh. Leave to use the model default.</string>
+    <string name="vehicle_dialog_capacity_helper">8 to 120 kWh. Leave to use the model default.</string>
     <string name="vehicle_dialog_model_label">Model</string>
     <string name="vehicle_dialog_save">Save</string>
     <string name="vehicle_dialog_reset">Reset to auto-detect</string>
-    <string name="vehicle_dialog_invalid_capacity">Capacity must be 15 - 120 kWh</string>
+    <string name="vehicle_dialog_invalid_capacity">Capacity must be 8 - 120 kWh</string>
     <string name="vehicle_dialog_summary_capacity">Capacity: %1$s</string>
     <string name="vehicle_dialog_summary_soh">SOH: %1$s</string>
     <string name="vehicle_dialog_summary_effective">Effective: %1$.1f kWh</string>


### PR DESCRIPTION
This is cherry-picked from or part of the branch that fixes this app to work on 2026 BYD Seal 5 DM-i Premium

apk release for testing: https://github.com/andrewloable/Overdrive/releases/tag/2026-seal-5-dmi-phev-fix

This branch extends SOH handling and vehicle support for BYD PHEV variants, especially the Seal 5 DM-i trims. It adds a recovered OEM battery-health readout path, updates nominal capacity handling down to 8.0 kWh, and propagates the new status fields through the Android UI and web diagnostics views.

### What changed
- Added OEM SOH retrieval from the BYD Statistic device, with feature-ID fallback and validation.
- Introduced `displaySource`-based SOH reporting so the UI can distinguish:
  - live calculated SOH
  - calibration SOH
  - OEM readout
  - nominal fallback
- Updated PHEV detection and remaining-energy logic to use the OEM SOH path when the normal capacity estimate is unavailable.
- Added Seal 5 DM-i Dynamic and Premium model support in the manifest and UI model-name mapping.
- Lowered the minimum accepted nominal battery capacity from 15 kWh to 8 kWh across the API, app UI, and web UI.
- Added new localized strings and diagnostics copy for OEM and nominal fallback states.
- Updated diagnostics and dashboard surfaces to show the new SOH sources clearly.

### Notes
- Existing data files and SOH persistence are still used as fallbacks when the daemon API is unavailable.
- Model manifest version was bumped to invalidate stale cached model data.
