### PR TITLE
Enhance door lock handling and UI updates for vehicle control

### DIFF
--- a/app/src/main/assets/web/i18n/en.json
+++ b/app/src/main/assets/web/i18n/en.json
@@ -1322,6 +1322,7 @@
     "cloud_connected": "Cloud Connected",
     "cloud_not_configured": "Cloud Not Configured",
     "locked": "Locked",
+    "lock_status_unavailable": "Lock unavailable",
     "checking": "Checking...",
     "cloud_required": "Cloud Account Required",
     "cloud_required_text": "This action requires a connected BYD Cloud account. Go to Surveillance Settings to link your credentials.",

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -13,7 +13,7 @@
     <script src="../shared/theme.js?v=3"></script>
     <script src="../shared/app-shell.js"></script>
     <link rel="stylesheet" href="../shared/styles.css?v=12">
-    <link rel="stylesheet" href="../shared/vehicle-control.css?v=12">
+    <link rel="stylesheet" href="../shared/vehicle-control.css?v=14">
     <!-- Web fonts loaded async + non-blocking. WebView falls back to system sans-serif if offline. -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" media="print" onload="this.media='all'">
 </head>
@@ -43,29 +43,20 @@
                         </svg>
                     </button>
 
-                    <!-- Floating status — row 1: connection state pills only -->
+                    <!-- Floating status — one row for connection state and
+                         appearance controls so the car UI keeps every top
+                         control in a single scan line. -->
                     <div class="vc-status-bar">
                         <div class="vc-pill">
                             <span class="dot green"></span><span id="lockStatus" data-i18n="vehicle.locked">Locked</span>
                         </div>
-                        <div class="vc-pill" id="cloudStatus">
-                            <span class="dot amber"></span><span id="cloudStatusText" data-i18n="vehicle.checking">Checking...</span>
-                        </div>
-                    </div>
-                    <!-- Floating status — row 2: vehicle appearance controls.
-                         Keeps the picker/dropdown out of the connection-state row so they
-                         can never overlap the cloud pill on narrow screens. The 3D toggle
-                         lives here so flex alignment keeps it visually flush with the
-                         color/model controls instead of floating off-axis. -->
-                    <div class="vc-status-bar-secondary">
                         <div class="vc-colors" id="colorPicker"></div>
                         <select class="vc-model-select" id="modelPicker" title="Vehicle model">
                             <option value="seal">BYD Seal</option>
                         </select>
-                        <button class="vc-3d-btn" id="btn3dView" title="Toggle 3D Surround View">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/><path d="M2 12h20"/></svg>
-                            <span>3D</span>
-                        </button>
+                        <div class="vc-pill" id="cloudStatus">
+                            <span class="dot amber"></span><span id="cloudStatusText" data-i18n="vehicle.checking">Checking...</span>
+                        </div>
                     </div>
 
                     <div class="vc-tyre-overlay" id="vcTyreOverlay">
@@ -471,7 +462,7 @@
     <script src="../shared/vendor/GLTFLoader.js?v=12"></script>
     <script src="../shared/vendor/OrbitControls.js?v=12"></script>
     <script src="../shared/vendor/gsap.min.js?v=12"></script>
-    <script src="../shared/vehicle-control.js?v=15"></script>
+    <script src="../shared/vehicle-control.js?v=16"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/shared/vehicle-control.css
+++ b/app/src/main/assets/web/shared/vehicle-control.css
@@ -102,30 +102,19 @@
 .vc-nav-btn:hover { background: var(--vc-pill-bg-hover); }
 .vc-nav-btn:active { -webkit-transform: scale(0.92); transform: scale(0.92); }
 
-/* Status bar floating on 3D — two rows.
-   Row 1 (.vc-status-bar) holds connection state pills (lock, cloud).
-   Row 2 (.vc-status-bar-secondary) holds appearance controls (color, model picker).
-   Splitting the rows guarantees the model dropdown never overlaps the cloud pill on
-   narrow screens, no matter how long the model name or how cramped the device. */
+/* Status bar floating on 3D — single scan line for state + appearance controls. */
 .vc-status-bar {
     position: absolute; top: calc(10px + env(safe-area-inset-top, 0px)); left: 10px; right: 10px;
     display: -webkit-flex; display: flex;
-    -webkit-justify-content: space-between; justify-content: space-between;
+    -webkit-justify-content: flex-start; justify-content: flex-start;
     -webkit-align-items: center; align-items: center;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: nowrap;
     z-index: 10; pointer-events: none;
 }
 .vc-status-bar > * { pointer-events: auto; margin: 0 3px; }
-
-.vc-status-bar-secondary {
-    position: absolute; top: calc(56px + env(safe-area-inset-top, 0px)); left: 10px; right: 10px;
-    display: -webkit-flex; display: flex;
-    -webkit-align-items: center; align-items: center;
-    -webkit-flex-wrap: wrap; flex-wrap: wrap;
-    -webkit-justify-content: flex-start; justify-content: flex-start;
-    gap: 6px;
-    z-index: 10; pointer-events: none;
-}
-.vc-status-bar-secondary > * { pointer-events: auto; }
+#cloudStatus { margin-left: auto; }
 .vc-pill {
     display: -webkit-inline-flex; display: inline-flex;
     -webkit-align-items: center; align-items: center;
@@ -210,17 +199,17 @@
 .vc-toast.error { border-color: #EF4444; color: #EF4444; }
 .vc-toast.info { border-color: #0EA5E9; color: #0EA5E9; }
 
-/* 3D Surround View button — laid out as a flex item inside .vc-status-bar-secondary
-   so vertical alignment is automatic, no manual top:50px to keep in sync with the row. */
+/* Legacy browser-only 3D button. The Android car WebView no longer renders it,
+   and this hard-hide protects browsers that still have older HTML cached. */
 .vc-3d-btn {
-    display: -webkit-inline-flex; display: inline-flex;
+    display: none !important;
     -webkit-flex-direction: column; flex-direction: column;
     -webkit-align-items: center; align-items: center;
     -webkit-justify-content: center; justify-content: center;
     width: 44px; height: 44px;
     -webkit-flex-shrink: 0; flex-shrink: 0;
     -webkit-flex-grow: 0; flex-grow: 0;
-    margin-left: auto;  /* push to far right within the secondary row */
+    margin-left: auto;
     border-radius: 22px;
     border: 1px solid var(--vc-border);
     background: var(--vc-pill-bg);
@@ -858,10 +847,6 @@ button.vc-pill:active { -webkit-transform: scale(.95); transform: scale(.95); }
     .vc-swatch { width: 20px; height: 20px; margin: 0 2px; }
     .vc-swatch-custom { width: 20px; height: 20px; margin: 0 2px; }
     .vc-model-select { padding: 4px 22px 4px 10px; font-size: 11px; max-width: 140px; }
-    /* Clear the hamburger button (left:10 width:40 = right edge at 50) so the
-       secondary row can't slide under it. Drop the row a touch since the smaller
-       pills make the primary row shorter. */
-    .vc-status-bar-secondary { top: calc(56px + env(safe-area-inset-top, 0px)); left: 56px; right: 10px; }
     .vc-3d-btn { width: 40px; height: 40px; border-radius: 20px; }
     .vc-3d-btn svg { width: 16px; height: 16px; }
 
@@ -878,15 +863,27 @@ button.vc-pill:active { -webkit-transform: scale(.95); transform: scale(.95); }
 }
 
 @media (max-width: 480px) {
-    .vc-status-bar { left: 54px; right: 8px; }
+    /* Phone viewports cannot fit lock + swatches + model + cloud beside the
+       hamburger. Wrap into two stable rows instead of relying on horizontal
+       overflow, which causes iOS Safari to paint pills on top of each other. */
+    .vc-status-bar {
+        left: 54px; right: 8px;
+        -webkit-flex-wrap: wrap; flex-wrap: wrap;
+        -webkit-align-content: flex-start; align-content: flex-start;
+        overflow: visible;
+        white-space: normal;
+    }
     .vc-status-bar > * { margin: 0 2px; }
+    .vc-status-bar .vc-pill:first-child { -webkit-order: 1; order: 1; }
+    #cloudStatus { -webkit-order: 2; order: 2; margin-left: auto; }
+    .vc-colors { -webkit-order: 3; order: 3; margin-top: 6px; }
+    .vc-model-select { -webkit-order: 4; order: 4; margin-top: 6px; }
     .vc-pill { padding: 3px 7px; font-size: 9px; }
     .vc-pill .dot { width: 5px; height: 5px; margin-right: 4px; }
     .vc-colors { padding: 2px 4px; }
     .vc-swatch { width: 18px; height: 18px; margin: 0 1px; }
     .vc-swatch-custom { width: 18px; height: 18px; margin: 0 1px; }
     .vc-model-select { padding: 3px 20px 3px 8px; font-size: 10px; max-width: 110px; border-radius: 14px; }
-    .vc-status-bar-secondary { top: 50px; left: 54px; right: 8px; gap: 4px; }
     .vc-3d-btn { width: 36px; height: 36px; border-radius: 18px; }
     .vc-3d-btn svg { width: 14px; height: 14px; }
     .vc-3d-btn span { font-size: 6px; }
@@ -911,6 +908,16 @@ button.vc-pill:active { -webkit-transform: scale(.95); transform: scale(.95); }
     .vc-seg { padding: 0 7px; height: 24px; font-size: 9px; }
     .vc-day { height: 26px; min-width: 28px; font-size: 8px; padding: 0 4px; }
     .vc-soc-slider { width: 120px; }
+}
+
+@media (max-width: 480px) and (orientation: portrait) {
+    /* Portrait phones have the least horizontal space and the hamburger sits
+       in the same visual band. Put appearance controls first, then state
+       pills underneath, so no pill paints behind another. */
+    .vc-colors { -webkit-order: 1; order: 1; }
+    .vc-model-select { -webkit-order: 2; order: 2; }
+    .vc-status-bar .vc-pill:first-child { -webkit-order: 3; order: 3; margin-top: 6px; }
+    #cloudStatus { -webkit-order: 4; order: 4; margin-top: 6px; margin-left: auto; }
 }
 
 /* Ultra-short viewports (landscape phone) — keep labels but compact heights. */
@@ -1008,4 +1015,3 @@ button.vc-pill:active { -webkit-transform: scale(.95); transform: scale(.95); }
 .vc-modal-btn:active {
     -webkit-transform: scale(0.95); transform: scale(0.95);
 }
-

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -2014,7 +2014,12 @@ var VC = {
         if (lockBtn) { if (locked === true) lockBtn.classList.add('on'); else lockBtn.classList.remove('on'); }
         if (unlockBtn) { if (locked === false) unlockBtn.classList.add('on'); else unlockBtn.classList.remove('on'); }
         if (lockStatus) {
-            lockStatus.textContent = locked === true ? BYD.i18n.t('vehicle.locked') : (locked === false ? BYD.i18n.t('vehicle.unlocked') : BYD.i18n.t('common.unknown'));
+            // The head unit often reports -1 for lock state while the car is
+            // asleep or cloud fallback is unavailable. Use a vehicle-specific
+            // message instead of the generic "Unknown" pill.
+            lockStatus.textContent = locked === true
+                ? BYD.i18n.t('vehicle.locked')
+                : (locked === false ? BYD.i18n.t('vehicle.unlocked') : BYD.i18n.t('vehicle.lock_status_unavailable'));
             var dot = lockStatus.previousElementSibling;
             if (dot) {
                 dot.className = 'dot ' + (locked === true ? 'green' : (locked === false ? 'amber' : 'grey'));

--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -22,6 +22,16 @@ public class BydDataCollector {
     private static final String TAG = "BydDataCollector";
     private static final DaemonLogger logger = DaemonLogger.getInstance(TAG);
 
+    // Door-lock API contract used by /api/vehicle/state.
+    // BYD SDK reports 1=unlock and 2=lock; the web API historically exposes
+    // 1=locked and 2=unlocked, so collection converts at the boundary.
+    private static final int LOCK_API_UNKNOWN = -1;
+    private static final int LOCK_API_LOCKED = 1;
+    private static final int LOCK_API_UNLOCKED = 2;
+    private static final int LOCK_SDK_INVALID = 0;
+    private static final int LOCK_SDK_UNLOCKED = 1;
+    private static final int LOCK_SDK_LOCKED = 2;
+
     private static BydDataCollector instance;
     private static final Object lock = new Object();
 
@@ -60,6 +70,16 @@ public class BydDataCollector {
 
     private final List<String> availableDevices = new ArrayList<>();
     private final List<String> unavailableDevices = new ArrayList<>();
+
+    // Door-lock getters can return INVALID while the typed listener still
+    // emits real transitions. Cache listener values so the UI can stay accurate
+    // after a lock/unlock event even when the direct poll path is blank.
+    private final int[] doorLockEventCache = new int[] {
+        LOCK_API_UNKNOWN, LOCK_API_UNKNOWN, LOCK_API_UNKNOWN,
+        LOCK_API_UNKNOWN, LOCK_API_UNKNOWN, LOCK_API_UNKNOWN,
+        LOCK_API_UNKNOWN
+    };
+    private String lastDoorLockSnapshotLog = "";
 
     // ==================== EVENT LISTENERS ====================
     // Subscribers receive door/lock events from the typed BYD HAL listeners.
@@ -2350,24 +2370,119 @@ public class BydDataCollector {
     }
 
     private void collectDoorLock(BydVehicleData.Builder b) {
-        // The BYDAutoDoorLockDevice service does not expose lock state to
-        // user-UID processes on most BYD firmwares — every getDoorLockStatus(area)
-        // call returns INVALID(0) and onDoorLockStatusChanged never fires.
-        // Field testing confirmed this on Sealion 6 / Atto 3 / others.
-        //
-        // Lock state is sourced exclusively from the BYD cloud REST/MQTT path
-        // via BydCloudDataProvider. The vehicle-control page calls the cloud
-        // API directly on load; the lock-gate uses CloudLockStateListener.
-        //
-        // We still publish a doorLockStatus[] array on the snapshot for
-        // compatibility with downstream consumers, but with all-UNAVAILABLE
-        // values — the cloud-lock fields on the JSON response carry the
-        // authoritative state.
-        if (b.doorLockStatus == null) {
-            int[] locks = new int[7];
-            for (int i = 0; i < 7; i++) locks[i] = -1;
-            b.doorLockStatus(locks);
+        int[] locks = new int[7];
+        for (int i = 0; i < locks.length; i++) locks[i] = LOCK_API_UNKNOWN;
+        int[] rawStates = new int[] {
+            LOCK_API_UNKNOWN, LOCK_API_UNKNOWN, LOCK_API_UNKNOWN,
+            LOCK_API_UNKNOWN, LOCK_API_UNKNOWN, LOCK_API_UNKNOWN,
+            LOCK_API_UNKNOWN
+        };
+
+        if (doorLockDevice != null) {
+            // The recovered legacy daemon uses getDoorLockStatus(1) first and
+            // falls back to getDoorLockState(). Here we poll all known lock
+            // areas so the vehicle page can derive an accurate local "all
+            // locked" state even when BYD cloud is disabled or unconfigured.
+            for (int area = 1; area <= 5; area++) {
+                Object raw = BydDeviceHelper.callGetter(doorLockDevice, "getDoorLockStatus", area);
+                rawStates[area - 1] = sdkLockInt(raw);
+                locks[area - 1] = apiLockFromSdk(raw);
+            }
+
+            mergeCachedDoorLocks(locks);
+            locks[6] = deriveOverallLock(locks);
+            if (locks[6] == LOCK_API_UNKNOWN && locks[0] != LOCK_API_UNKNOWN) {
+                // Legacy surveillance used SDK area 1 as the central lock
+                // indicator. Keep that fallback so one valid driver/central
+                // lock event can drive the top-level vehicle status.
+                locks[6] = locks[0];
+            }
+
+            if (locks[6] == LOCK_API_UNKNOWN) {
+                Object allArea = BydDeviceHelper.callGetter(doorLockDevice, "getDoorLockStatus", 0);
+                rawStates[5] = sdkLockInt(allArea);
+                int allAreaApi = apiLockFromSdk(allArea);
+                if (allAreaApi != LOCK_API_UNKNOWN) locks[6] = allAreaApi;
+            }
+
+            if (locks[6] == LOCK_API_UNKNOWN) {
+                Object aggregateRaw = BydDeviceHelper.callGetter(doorLockDevice, "getDoorLockState");
+                rawStates[6] = sdkLockInt(aggregateRaw);
+                int aggregate = apiLockFromSdk(aggregateRaw);
+                if (aggregate != LOCK_API_UNKNOWN) locks[6] = aggregate;
+            }
         }
+
+        logDoorLockSnapshot(locks, rawStates);
+        b.doorLockStatus(locks);
+    }
+
+    private int sdkLockInt(Object raw) {
+        if (!(raw instanceof Number)) return LOCK_API_UNKNOWN;
+        return ((Number) raw).intValue();
+    }
+
+    private int apiLockFromSdk(Object raw) {
+        if (!(raw instanceof Number)) return LOCK_API_UNKNOWN;
+        int sdkState = ((Number) raw).intValue();
+        if (sdkState == LOCK_SDK_LOCKED) return LOCK_API_LOCKED;
+        if (sdkState == LOCK_SDK_UNLOCKED) return LOCK_API_UNLOCKED;
+        if (sdkState == LOCK_SDK_INVALID) return LOCK_API_UNKNOWN;
+        return LOCK_API_UNKNOWN;
+    }
+
+    private int deriveOverallLock(int[] locks) {
+        boolean sawLockedDoor = false;
+        for (int i = 0; i < 4; i++) {
+            if (locks[i] == LOCK_API_UNLOCKED) return LOCK_API_UNLOCKED;
+            if (locks[i] != LOCK_API_LOCKED) return LOCK_API_UNKNOWN;
+            sawLockedDoor = true;
+        }
+        return sawLockedDoor ? LOCK_API_LOCKED : LOCK_API_UNKNOWN;
+    }
+
+    private void mergeCachedDoorLocks(int[] locks) {
+        synchronized (doorLockEventCache) {
+            for (int i = 0; i < locks.length && i < doorLockEventCache.length; i++) {
+                if (locks[i] == LOCK_API_UNKNOWN && doorLockEventCache[i] != LOCK_API_UNKNOWN) {
+                    locks[i] = doorLockEventCache[i];
+                }
+            }
+        }
+    }
+
+    private void updateDoorLockEventCache(int area, int sdkState) {
+        int apiState = apiLockFromSdk(Integer.valueOf(sdkState));
+        if (apiState == LOCK_API_UNKNOWN) return;
+        int index = area - 1;
+        if (index < 0 || index >= 5) return;
+        synchronized (doorLockEventCache) {
+            doorLockEventCache[index] = apiState;
+            doorLockEventCache[6] = deriveOverallLock(doorLockEventCache);
+            if (doorLockEventCache[6] == LOCK_API_UNKNOWN && index == 0) {
+                // The recovered daemon only watched area 1 for its lock gate,
+                // so preserve that central-lock fallback for listener events.
+                doorLockEventCache[6] = apiState;
+            }
+        }
+    }
+
+    private void logDoorLockSnapshot(int[] locks, int[] rawStates) {
+        String state = joinInts(locks) + " raw=" + joinInts(rawStates);
+        if (!state.equals(lastDoorLockSnapshotLog)) {
+            lastDoorLockSnapshotLog = state;
+            logger.info("DoorLock snapshot api=" + joinInts(locks)
+                + " raw=[area1,area2,area3,area4,area5,all,state]=" + joinInts(rawStates));
+        }
+    }
+
+    private String joinInts(int[] values) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append(values[i]);
+        }
+        return sb.append(']').toString();
     }
 
     private void collectSensor(BydVehicleData.Builder b) {
@@ -3131,14 +3246,21 @@ public class BydDataCollector {
     private void onDoorLockCallback(String method, Object[] args) {
         BydVehicleData current = snapshot.get();
         if (current == null) return;
+
+        int area = -1;
+        int sdkState = -1;
+        if ("onDoorLockStatusChanged".equals(method) && args != null && args.length >= 2) {
+            area = (args[0] instanceof Integer) ? (Integer) args[0] : -1;
+            sdkState = (args[1] instanceof Integer) ? (Integer) args[1] : -1;
+            updateDoorLockEventCache(area, sdkState);
+        }
+
         BydVehicleData.Builder b = current.toBuilder();
         collectDoorLock(b);
         BydVehicleData updated = b.build();
         snapshot.set(updated);
 
         if ("onDoorLockStatusChanged".equals(method) && args != null && args.length >= 2) {
-            int area = (args[0] instanceof Integer) ? (Integer) args[0] : -1;
-            int sdkState = (args[1] instanceof Integer) ? (Integer) args[1] : -1;
             notifyDoorLockListeners(area, sdkState);
         }
         notifyLockSnapshotListeners(updated);

--- a/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDeviceHelper.java
@@ -620,8 +620,8 @@ public final class BydDeviceHelper {
 
     /**
      * Register a typed door-lock listener. Captures the canonical
-     * onDoorLockStatusChanged(area, state) event the BMS emits when the gun is
-     * connected and the lock state transitions.
+     * onDoorLockStatusChanged(area, state) event emitted by the BYD door-lock
+     * HAL when a lock state transitions.
      */
     public static boolean registerDoorLockListener(Object device, ListenerCallback callback) {
         if (device == null) return false;

--- a/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
@@ -177,10 +177,11 @@ public class VehicleControlApiHandler {
         // Door lock status: 1=locked, 2=unlocked, -1=unknown
         // Index: 0=LF, 1=RF, 2=LR, 3=RR, 4=trunk, 5=unused, 6=overall(derived)
         //
-        // The BYDAutoDoorLockDevice service does not expose lock state to user-UID
-        // processes on most BYD firmwares (returns INVALID(0) for every area).
-        // So we overlay the BYD cloud snapshot's per-door lock fields here. If
-        // both the SDK and cloud are unavailable, values stay at -1.
+        // BydDataCollector first reads BYDAutoDoorLockDevice locally using the
+        // recovered legacy app's getDoorLockStatus(area)/getDoorLockState path.
+        // BYD cloud values are still overlaid when available because some
+        // firmwares return INVALID(0) for every local area. If both sources are
+        // unavailable, values stay at -1.
         // BYD bodywork SDK area numbering swaps L↔R on the FRONT axis vs the
         // physical doors: array index 0 (SDK "LEFT_FRONT") is physically
         // right-front, index 1 is left-front. The REAR axis on this car


### PR DESCRIPTION
This is cherry-picked from or part of the branch that fixes this app to work on 2026 BYD Seal 5 DM-i Premium

apk release for testing: https://github.com/andrewloable/Overdrive/releases/tag/2026-seal-5-dmi-phev-fix

## Summary
This branch improves vehicle control door-lock handling by reading local BYD lock state more reliably and updating the UI to better reflect unavailable lock data.

## What changed
- Added local door-lock polling through the recovered BYD HAL path using `getDoorLockStatus(area)` and `getDoorLockState()`.
- Normalized BYD SDK lock values to the web API contract so lock/unlock state is consistent for the UI.
- Cached door-lock listener events so the UI can stay accurate even when direct polling returns `INVALID(0)`.
- Improved overall lock derivation so the vehicle state can still resolve correctly when only partial door data is available.
- Updated the vehicle control UI to show a vehicle-specific `Lock unavailable` message instead of a generic unknown state.
- Reworked the floating status bar layout for narrower screens and hid the legacy 3D button in the current WebView.

## Notes
- BYD cloud values still act as a fallback where available.
- This change primarily targets reliability on firmwares where local lock state was previously unavailable or inconsistent.

## Testing
- Not run locally.