### PR TITLE
Add performance diagnostics card and navigation to performance dashboard

### DIFF
--- a/app/src/main/assets/web/local/performance.html
+++ b/app/src/main/assets/web/local/performance.html
@@ -149,7 +149,8 @@
         
         .chart-legend {
             display: flex;
-            gap: 16px;
+            gap: 0;
+            flex-wrap: wrap;
             font-size: 12px;
         }
         
@@ -157,6 +158,8 @@
             display: flex;
             align-items: center;
             gap: 6px;
+            margin-right: 16px;
+            margin-bottom: 6px;
             color: var(--text-secondary);
         }
         
@@ -291,7 +294,7 @@
         
         .soc-stats-row {
             display: flex;
-            gap: 16px;
+            gap: 0;
             flex-wrap: wrap;
             margin-bottom: 16px;
             padding: 12px 16px;
@@ -303,7 +306,9 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            min-width: 60px;
+            min-width: 88px;
+            margin-right: 16px;
+            margin-bottom: 8px;
         }
         
         .soc-stat-value {
@@ -351,6 +356,52 @@
             background: var(--bg-surface);
             box-shadow: 0 1px 3px var(--panel-overlay-bg-faint);
         }
+
+        /* SOH detail card: keep the editable capacity summary readable on
+           phones. The original flex row let the large SOH percentage consume
+           most of the width, leaving the vehicle model in a one-word column. */
+        .soh-detail-body {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin: 16px 0;
+        }
+
+        .soh-headline {
+            flex: 0 0 180px;
+            min-width: 0;
+            text-align: center;
+        }
+
+        .soh-capacity-panel {
+            flex: 1 1 0;
+            min-width: 220px;
+        }
+
+        .soh-capacity-card {
+            background: var(--bg-elevated);
+            padding: 14px 16px;
+            border-radius: 12px;
+            cursor: pointer;
+            border: 1px solid var(--border-subtle);
+        }
+
+        .soh-capacity-value {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-top: 4px;
+            overflow-wrap: normal;
+            word-break: normal;
+            line-height: 1.35;
+        }
+
+        .soh-meta-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 8px;
+        }
         
         /* Responsive */
         @media (max-width: 768px) {
@@ -364,16 +415,47 @@
                 grid-template-columns: 1fr;
             }
             .soc-stats-row {
-                justify-content: space-between;
+                justify-content: flex-start;
             }
             .soc-stat {
-                min-width: 50px;
+                min-width: 74px;
+                margin-right: 12px;
             }
             .soc-stat-value {
                 font-size: 16px;
             }
             .soc-time-selector {
                 flex-wrap: wrap;
+            }
+
+            .soh-detail-body {
+                align-items: stretch;
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .soh-headline {
+                flex-basis: auto;
+                width: 100%;
+            }
+
+            .soh-capacity-panel {
+                min-width: 0;
+                width: 100%;
+            }
+
+            .soh-capacity-card {
+                padding: 12px 14px;
+            }
+
+            .soh-capacity-value {
+                font-size: 14px;
+            }
+        }
+
+        @media (max-width: 420px) {
+            .soh-meta-grid {
+                grid-template-columns: 1fr;
             }
         }
         
@@ -630,26 +712,25 @@
                     </div>
 
                     <!-- Live SOH headline -->
-                    <div style="display:flex;align-items:center;gap:16px;margin:16px 0;">
-                        <div style="text-align:center;min-width:120px;">
+                    <div class="soh-detail-body">
+                        <div class="soh-headline">
                             <div id="sohDetailPercent" style="font-family:'JetBrains Mono',monospace;font-size:42px;font-weight:700;color:var(--chart-soh);line-height:1;">--%</div>
                             <div style="font-size:12px;color:var(--text-muted);margin-top:4px;" data-i18n="performance.active_soh">Active SOH</div>
                             <div id="sohCalibrationAnchor" style="font-size:11px;color:var(--text-muted);margin-top:2px;display:none;"></div>
                             <div id="sohFallbackCaption" class="soh-caption" hidden></div>
                         </div>
-                        <div style="flex:1;min-width:0;">
+                        <div class="soh-capacity-panel">
                             <!-- Battery capacity row — tappable, opens modal -->
-                            <div id="sohCapacityRow" onclick="BYD.performance.openSohCapacityModal()"
-                                 style="background:var(--bg-elevated);padding:14px 16px;border-radius:12px;cursor:pointer;border:1px solid var(--border-subtle);">
+                            <div id="sohCapacityRow" class="soh-capacity-card" onclick="BYD.performance.openSohCapacityModal()">
                                 <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;" data-i18n="soh.battery_capacity_label">Battery capacity</div>
-                                <div id="sohCapacitySummary" style="font-family:'JetBrains Mono',monospace;font-size:16px;font-weight:600;color:var(--text-primary);margin-top:4px;" data-i18n="soh.tap_to_set">Tap to set</div>
+                                <div id="sohCapacitySummary" class="soh-capacity-value" data-i18n="soh.tap_to_set">Tap to set</div>
                                 <div id="sohCapacitySource" style="font-size:11px;color:var(--text-muted);margin-top:2px;"></div>
                             </div>
                         </div>
                     </div>
 
                     <!-- Metadata row -->
-                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+                    <div class="soh-meta-grid">
                         <div style="background:var(--bg-elevated);padding:8px 10px;border-radius:6px;">
                             <div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;" data-i18n="performance.meta_nominal">Nominal</div>
                             <div id="sohDetailNominal" style="font-family:'JetBrains Mono',monospace;font-size:12px;font-weight:600;color:var(--text-primary);margin-top:2px;">-- kWh</div>
@@ -989,7 +1070,7 @@
     <script src="../shared/auth.js"></script>
     <script src="../shared/core.js"></script>
     <script src="../shared/update-flow.js"></script>
-    <script src="../shared/performance.js?v=2"></script>
+    <script src="../shared/performance.js?v=3"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/shared/performance.js
+++ b/app/src/main/assets/web/shared/performance.js
@@ -105,6 +105,20 @@ BYD.performance = {
             attributeFilter: ['data-theme']
         });
     },
+
+    _withAlpha(color, alpha) {
+        const hex = /^#?([0-9a-f]{6})$/i.exec(color || '');
+        if (!hex) return color;
+
+        const raw = hex[1];
+        const r = parseInt(raw.slice(0, 2), 16);
+        const g = parseInt(raw.slice(2, 4), 16);
+        const b = parseInt(raw.slice(4, 6), 16);
+
+        // Android 7 / Chrome 58 cannot parse 8-digit hex colors in canvas
+        // gradients, so keep chart fills on the older rgba() syntax.
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    },
     
     async init() {
         console.log('[Performance] Initializing...');
@@ -1114,8 +1128,8 @@ BYD.performance = {
         
         // Gradient fill
         const gradient = ctx.createLinearGradient(0, padding.top, 0, padding.top + chartHeight);
-        gradient.addColorStop(0, color + '40');
-        gradient.addColorStop(1, color + '05');
+        gradient.addColorStop(0, this._withAlpha(color, 0.25));
+        gradient.addColorStop(1, this._withAlpha(color, 0.02));
         ctx.fillStyle = gradient;
         ctx.fill();
         
@@ -1450,8 +1464,8 @@ BYD.performance = {
         
         // Gradient fill
         const gradient = ctx.createLinearGradient(0, padding.top, 0, padding.top + chartHeight);
-        gradient.addColorStop(0, this.colors.soc + '40');
-        gradient.addColorStop(1, this.colors.soc + '05');
+        gradient.addColorStop(0, this._withAlpha(this.colors.soc, 0.25));
+        gradient.addColorStop(1, this._withAlpha(this.colors.soc, 0.02));
         ctx.fillStyle = gradient;
         ctx.fill();
         

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DiagnosticsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DiagnosticsFragment.kt
@@ -97,6 +97,14 @@ class DiagnosticsFragment : Fragment() {
         view.findViewById<View>(R.id.cardBattery).setOnClickListener {
             (activity as? MainActivity)?.invokeBatteryHealthAction()
         }
+        view.findViewById<View>(R.id.cardPerformance)?.setOnClickListener {
+            // Reuse the daemon-hosted performance dashboard so the native car
+            // diagnostics menu reaches the same view exposed by the mobile web UI.
+            findNavController().navigateDrillDown(
+                R.id.performanceFragment,
+                Bundle().apply { putString(WebViewFragment.ARG_PAGE_PATH, "/performance") }
+            )
+        }
         view.findViewById<View>(R.id.cardSettingsShortcut)?.setOnClickListener {
             // Settings is a peer rail destination — match rail fade-through
             // motion so the cardSettings shortcut feels like rail navigation.

--- a/app/src/main/res/layout-land/fragment_diagnostics.xml
+++ b/app/src/main/res/layout-land/fragment_diagnostics.xml
@@ -9,7 +9,7 @@
         - HEALTH section (label-medium "Health")
         - 2×2 health-tile grid (Network, Storage, Camera, Battery)
         - TOOLS section (label-medium "Tools")
-        - 2×2 tool grid (ADB, Traffic, Camera probe, Battery health) — outlined cards
+        - 2×2 tool grid plus Performance + Settings shortcuts
       RIGHT COLUMN (~480dp / weight 0.54):
         - "Live event log" container card hosting LogsPanelFragment
 
@@ -19,7 +19,7 @@
     row so it always fills the right column.
 
   IDs preserved (DiagnosticsFragment.kt findViewById targets):
-    cardAdb, cardTraffic, cardCameraProbe, cardBattery, logsPanelContainer
+    cardAdb, cardTraffic, cardCameraProbe, cardBattery, cardPerformance, logsPanelContainer
 
   Health-tile IDs (DiagnosticsFragment.kt findViewById targets):
     Network : tvNetworkValue / viewNetworkTunnelDot / tvNetworkTunnelState
@@ -595,43 +595,92 @@
                 </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
 
-            <!-- TOOLS row 3: Settings shortcut. -->
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/cardSettingsShortcut"
+            <!-- TOOLS row 3: Performance + Settings shortcuts. Performance is
+                 daemon-hosted, but this native tile makes it available on the
+                 car diagnostics screen instead of only from the mobile web UI. -->
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/card_gap_vertical"
-                android:clickable="true"
-                android:focusable="true"
-                android:foreground="?attr/selectableItemBackground"
-                app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
-                app:cardCornerRadius="@dimen/card_radius_standard"
-                app:cardElevation="0dp">
+                android:orientation="horizontal"
+                android:baselineAligned="false">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardPerformance"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal"
-                    android:padding="@dimen/card_padding_standard">
+                    android:layout_weight="1"
+                    android:layout_marginEnd="@dimen/card_gap_horizontal_half"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+                    app:cardCornerRadius="@dimen/card_radius_standard"
+                    app:cardElevation="0dp">
 
-                    <ImageView
-                        android:layout_width="@dimen/card_icon_standard"
-                        android:layout_height="@dimen/card_icon_standard"
-                        android:contentDescription="@null"
-                        android:src="@drawable/ic_settings"
-                        app:tint="?attr/colorOnSurfaceVariant" />
-
-                    <TextView
-                        android:layout_width="0dp"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="12dp"
-                        android:layout_weight="1"
-                        android:text="@string/rail_settings"
-                        android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
-                        android:textColor="?attr/colorOnSurface" />
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:padding="@dimen/card_padding_standard">
+
+                        <ImageView
+                            android:layout_width="@dimen/card_icon_standard"
+                            android:layout_height="@dimen/card_icon_standard"
+                            android:contentDescription="@null"
+                            android:src="@drawable/ic_diagnostics"
+                            app:tint="?attr/colorOnSurfaceVariant" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:layout_weight="1"
+                            android:text="@string/diagnostics_section_performance"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+                            android:textColor="?attr/colorOnSurface" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardSettingsShortcut"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="@dimen/card_gap_horizontal_half"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+                    app:cardCornerRadius="@dimen/card_radius_standard"
+                    app:cardElevation="0dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:padding="@dimen/card_padding_standard">
+
+                        <ImageView
+                            android:layout_width="@dimen/card_icon_standard"
+                            android:layout_height="@dimen/card_icon_standard"
+                            android:contentDescription="@null"
+                            android:src="@drawable/ic_settings"
+                            app:tint="?attr/colorOnSurfaceVariant" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:layout_weight="1"
+                            android:text="@string/rail_settings"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+                            android:textColor="?attr/colorOnSurface" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
         </LinearLayout>
 
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_diagnostics.xml
+++ b/app/src/main/res/layout/fragment_diagnostics.xml
@@ -5,12 +5,12 @@
   Single column, but tighter and intentional:
     HERO ROW   : "System diagnostics" + status pill ("All clear")
     HEALTH grid: 2×2 health tiles (Network, Storage, Camera, Battery)
-    TOOLS grid : 2×2 outlined tool cards (Traffic, Camera probe, ADB, Battery)
+    TOOLS grid : 2×2 utility cards plus Performance + Settings shortcuts
     LOGS card  : surface-container card hosting LogsPanelFragment, fills
                  remaining vertical space (layout_weight=1).
 
   IDs preserved (DiagnosticsFragment.kt findViewById targets):
-    cardAdb, cardTraffic, cardCameraProbe, cardBattery, logsPanelContainer
+    cardAdb, cardTraffic, cardCameraProbe, cardBattery, cardPerformance, logsPanelContainer
 
   Health-tile IDs (DiagnosticsFragment.kt findViewById targets):
     Network : tvNetworkValue / viewNetworkTunnelDot / tvNetworkTunnelState
@@ -564,9 +564,9 @@
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
 
-    <!-- TOOLS row 3: Settings shortcut. Diagnostics is where power users
-         land for tuning; surfacing Settings here closes the loop without
-         making them hop back to the rail. -->
+    <!-- TOOLS row 3: Performance + Settings shortcuts. Performance lives in
+         the daemon-hosted web dashboard, but exposing it here keeps the car's
+         native diagnostics menu in parity with the mobile diagnostics UI. -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -575,9 +575,49 @@
         android:baselineAligned="false">
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/cardSettingsShortcut"
-            android:layout_width="match_parent"
+            android:id="@+id/cardPerformance"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="@dimen/card_gap_horizontal_half"
+            android:clickable="true"
+            android:focusable="true"
+            android:foreground="?attr/selectableItemBackground"
+            app:cardBackgroundColor="?attr/colorSurfaceContainerHigh"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="@dimen/card_padding_standard">
+
+                <ImageView
+                    android:layout_width="@dimen/card_icon_standard"
+                    android:layout_height="@dimen/card_icon_standard"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_diagnostics"
+                    app:tint="?attr/colorOnSurfaceVariant" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:text="@string/diagnostics_section_performance"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+                    android:textColor="?attr/colorOnSurface" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardSettingsShortcut"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="@dimen/card_gap_horizontal_half"
             android:clickable="true"
             android:focusable="true"
             android:foreground="?attr/selectableItemBackground"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -142,6 +142,20 @@
         android:label="@string/rail_diagnostics"
         tools:layout="@layout/fragment_diagnostics" />
 
+    <!-- Diagnostics → Performance: same daemon-hosted dashboard as mobile
+         web, exposed as a diagnostics child so the car rail stays on
+         Diagnostics instead of highlighting Live. -->
+    <fragment
+        android:id="@+id/performanceFragment"
+        android:name="com.overdrive.app.ui.fragment.WebViewFragment"
+        android:label="@string/diagnostics_section_performance"
+        tools:layout="@layout/fragment_webview">
+        <argument
+            android:name="page_path"
+            app:argType="string"
+            android:defaultValue="/performance" />
+    </fragment>
+
     <fragment
         android:id="@+id/adbConsoleFragment"
         android:name="com.overdrive.app.ui.fragment.AdbConsoleFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,7 @@
     <string name="diagnostics_section_traffic">Traffic monitor</string>
     <string name="diagnostics_section_camera_probe">Camera probe</string>
     <string name="diagnostics_section_battery">Battery health</string>
+    <string name="diagnostics_section_performance">Performance</string>
     <!-- Sub-label used on diagnostics utility cards in landscape (hint to tap). -->
 
     <!-- SOTA Diagnostics dashboard -->


### PR DESCRIPTION
This is cherry-picked from or part of the branch that fixes this app to work on 2026 BYD Seal 5 DM-i Premium

apk release for testing: https://github.com/andrewloable/Overdrive/releases/tag/2026-seal-5-dmi-phev-fix

## Summary
This branch adds a new Performance entry in the native Diagnostics screen and routes it to the existing daemon-hosted `/performance` dashboard. It also tightens up the performance page layout for smaller screens and improves chart gradient compatibility on older Android WebView/Chrome versions.

## What changed
- Added a new `Performance` card to the Diagnostics UI in both portrait and landscape layouts.
- Wired the card to open the `WebViewFragment` at `/performance` through the navigation graph.
- Added the new `diagnostics_section_performance` string resource.
- Updated the mobile performance dashboard layout to better handle SOH/capacity content on phones.
- Reworked chart gradient fills in `performance.js` to use RGBA instead of 8-digit hex, which keeps gradients working on older Android WebView versions.

## Notes
- Performance is now accessible directly from Diagnostics instead of only from the mobile web UI.
- The layout changes are focused on readability and responsiveness, especially for smaller screens.