### PR TITLE
Fix PWA orientation

### DIFF
--- a/app/src/main/assets/web/local/manifest.json
+++ b/app/src/main/assets/web/local/manifest.json
@@ -5,7 +5,6 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "orientation": "any",
   "background_color": "#000000",
   "theme_color": "#00876C",
   "icons": [


### PR DESCRIPTION
## What does this PR do?
Fixes PWA orientation on Android Chrome.

## Why is this change needed?
When installed as a PWA, Overdrive ignores the rotation lock. Setting this to the default value by removing `any` still allows rotation but still respects the rotation lock.
See https://www.w3.org/TR/screen-orientation/#screen-orientation-types

## How to test
Lock the screen rotation and turn your phone to landscape or portrait. Before this PR, it rotates even when locked. After, it will only rotate when not locked.