### PR TITLE
Update Thai language label in lang-picker.js

### DIFF
--- a/app/src/main/assets/web/shared/lang-picker.js
+++ b/app/src/main/assets/web/shared/lang-picker.js
@@ -23,7 +23,7 @@
     var SHORT_LABELS = {
         'en': 'EN', 'zh-CN': '中', 'zh-TW': '繁', 'pt-BR': 'PT', 'es': 'ES',
         'de': 'DE', 'fr': 'FR', 'it': 'IT', 'nb': 'NO', 'nl': 'NL',
-        'ja': '日', 'ko': '한', 'th': 'ไ', 'vi': 'VI', 'hi': 'हि', 'tr': 'TR',
+        'ja': '日', 'ko': '한', 'th': 'ไทย', 'vi': 'VI', 'hi': 'हि', 'tr': 'TR',
         'ru': 'РУ'
     };
 


### PR DESCRIPTION
<img width="248" height="83" alt="Screenshot 2026-06-05 at 16 21 26" src="https://github.com/user-attachments/assets/a1420877-5f66-4354-8865-e511da6bf4f5" />

I want it to be corrected because it shows the wrong word; it must show the word "ไทย"
