### PR TITLE
Fix MQTT connection updates not applying + ABRP presence stuck on "foreground"

### DIFF
--- a/app/src/main/java/com/overdrive/app/abrp/AbrpAppPresence.java
+++ b/app/src/main/java/com/overdrive/app/abrp/AbrpAppPresence.java
@@ -14,6 +14,11 @@ import java.io.InputStreamReader;
  *                  (survives quick app-switches; pauses shortly after leaving ABRP).
  *   - running    : the ABRP process is alive at all (better for background navigation).
  *
+ * The grace window only smooths the telemetry *gate* ({@link #isActive()}) so a quick
+ * app-switch doesn't tear the stream down. The status string ({@link #describe()})
+ * reports the *current* observed state instead, so closing ABRP flips it away from
+ * "foreground" on the next poll rather than lingering for the whole grace window.
+ *
  * No installed-check — if ABRP isn't on the device it simply won't appear as
  * foreground or running, so the gate naturally returns false without extra logic.
  *
@@ -32,17 +37,24 @@ public class AbrpAppPresence {
 
     private volatile long lastCheckMs = 0;
     private volatile long lastForegroundSeenMs = 0;
+    private volatile boolean lastForegroundNow = false;
     private volatile boolean lastProcessAlive = false;
 
     public AbrpAppPresence(AbrpConfig config) {
         this.config = config;
     }
 
-    /** Human-readable presence for the status panel: "foreground" / "running" / "not running". */
+    /**
+     * Human-readable presence for the status panel: "foreground" / "background" / "not running".
+     *
+     * Reflects the most recent observation, NOT the grace window — so when the user leaves
+     * ABRP the panel stops saying "foreground" within one check cycle ({@link #CHECK_TTL_MS}),
+     * even though {@link #isActive()} may keep the stream alive through the grace period.
+     */
     public String describe() {
         refreshIfStale();
-        if (isForegroundWithinGrace()) return "foreground";
-        if (lastProcessAlive) return "running";
+        if (lastForegroundNow) return "foreground";
+        if (lastProcessAlive) return "background";
         return "not running";
     }
 
@@ -67,10 +79,12 @@ public class AbrpAppPresence {
         if (pkg == null || pkg.isEmpty()) pkg = "com.iternio.abrpapp";
 
         String top = readForegroundPackage();
-        if (top != null && top.contains(pkg)) {
+        boolean foregroundNow = top != null && top.contains(pkg);
+        lastForegroundNow = foregroundNow;
+        if (foregroundNow) {
             lastForegroundSeenMs = now;
         }
-        lastProcessAlive = (top != null && top.contains(pkg)) || isProcessAlive(pkg);
+        lastProcessAlive = foregroundNow || isProcessAlive(pkg);
     }
 
     /** Parse the resumed/top activity package from dumpsys. */

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -16,7 +16,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +48,16 @@ public class MqttConnectionManager {
     // Per-connection schedulers: connectionId → scheduler
     private final ConcurrentHashMap<String, ScheduledExecutorService> schedulers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    // Serial executor for connection lifecycle (connect/disconnect). Paho's connect blocks up to
+    // ~10s and disconnect up to 5s; running them on the caller's thread would blow the IPC socket's
+    // 3s read timeout (MqttApiHandler) and make add/update/delete look like they failed. Offloading
+    // here lets the IPC call return immediately while the broker is (re)connected in the background.
+    private final ExecutorService controlExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "MQTT-control");
+        t.setDaemon(true);
+        return t;
+    });
 
     // Data sources (set during init)
     private VehicleDataMonitor vehicleDataMonitor;
@@ -186,7 +198,7 @@ public class MqttConnectionManager {
         schedulers.put(config.id, scheduler);
 
         // Schedule publish loop at the min-interval floor.
-        scheduleNext(config.id, Math.max(1, config.minIntervalSeconds));
+        scheduleNext(config.id, scheduler, Math.max(1, config.minIntervalSeconds));
     }
 
     /**
@@ -204,21 +216,33 @@ public class MqttConnectionManager {
     }
 
     /**
-     * Schedule the next publish for a connection.
+     * Schedule the next publish for a connection on its own scheduler.
+     *
+     * The scheduler is passed in (not looked up) so a trailing cycle from a scheduler that has
+     * since been replaced by a restart can't queue work onto the new one — it simply no-ops.
      */
-    private void scheduleNext(String connectionId, long delaySeconds) {
-        ScheduledExecutorService scheduler = schedulers.get(connectionId);
+    private void scheduleNext(String connectionId, ScheduledExecutorService scheduler, long delaySeconds) {
         if (scheduler == null || scheduler.isShutdown()) return;
+        // This scheduler was swapped out by a restart — drop the reschedule.
+        if (schedulers.get(connectionId) != scheduler) return;
 
-        ScheduledFuture<?> task = scheduler.schedule(() -> runPublishCycle(connectionId),
-                delaySeconds, TimeUnit.SECONDS);
-        scheduledTasks.put(connectionId, task);
+        try {
+            ScheduledFuture<?> task = scheduler.schedule(() -> runPublishCycle(connectionId, scheduler),
+                    delaySeconds, TimeUnit.SECONDS);
+            scheduledTasks.put(connectionId, task);
+        } catch (RejectedExecutionException ignored) {
+            // Scheduler was shut down between the guard above and schedule() — connection is
+            // being torn down; nothing to do.
+        }
     }
 
     /**
      * Execute one publish cycle for a connection.
      */
-    private void runPublishCycle(String connectionId) {
+    private void runPublishCycle(String connectionId, ScheduledExecutorService scheduler) {
+        // Bail if this connection was restarted/stopped — our scheduler is no longer the live one.
+        if (schedulers.get(connectionId) != scheduler) return;
+
         MqttPublisherService publisher = publishers.get(connectionId);
         if (publisher == null || !publisher.isRunning()) return;
 
@@ -252,8 +276,8 @@ public class MqttConnectionManager {
             nextInterval = backoff;
         }
 
-        // Schedule next
-        scheduleNext(connectionId, nextInterval);
+        // Schedule next on the same scheduler this cycle ran on.
+        scheduleNext(connectionId, scheduler, nextInterval);
     }
 
     // ==================== CRUD OPERATIONS (called from IPC) ====================
@@ -270,9 +294,9 @@ public class MqttConnectionManager {
         MqttConnectionConfig added = store.add(config);
         if (added == null) return null;
 
-        // Auto-start if enabled
+        // Auto-start if enabled — off the caller's thread (connect() blocks).
         if (added.enabled && added.isConfigured()) {
-            startConnection(added);
+            controlExecutor.execute(() -> startConnection(added));
         }
 
         return added;
@@ -291,18 +315,24 @@ public class MqttConnectionManager {
         boolean updated = store.update(id, updates);
         if (!updated) return false;
 
-        // Restart the connection to apply changes
-        MqttConnectionConfig config = store.getById(id);
+        // Apply the change by tearing the live connection down and rebuilding it from the updated
+        // config (host/port/topic/auth/TLS can't be changed on a live Paho client). The store has
+        // already been written, so the IPC reply is correct the instant it returns; the actual
+        // disconnect/reconnect runs on the control executor to keep network I/O off the IPC thread.
+        final MqttConnectionConfig config = store.getById(id);
         if (config != null) {
-            // If HA discovery was just turned off, retract the device while still connected.
-            if (wasHa && !config.homeAssistantDiscovery) {
-                MqttPublisherService pub = publishers.get(id);
-                if (pub != null) pub.removeDiscovery(oldPrefix);
-            }
-            stopConnection(id);
-            if (config.enabled && config.isConfigured()) {
-                startConnection(config);
-            }
+            final boolean retractHa = wasHa && !config.homeAssistantDiscovery;
+            controlExecutor.execute(() -> {
+                // If HA discovery was just turned off, retract the device while still connected.
+                if (retractHa) {
+                    MqttPublisherService pub = publishers.get(id);
+                    if (pub != null) pub.removeDiscovery(oldPrefix);
+                }
+                stopConnection(id);
+                if (config.enabled && config.isConfigured()) {
+                    startConnection(config);
+                }
+            });
         }
 
         return true;
@@ -313,14 +343,19 @@ public class MqttConnectionManager {
      * @return true if deleted
      */
     public boolean deleteConnection(String id) {
-        // Retract HA discovery (while the client is still connected) so deleting a
-        // connection doesn't leave orphaned entities in Home Assistant.
+        // Retract HA discovery (while the client is still connected) so deleting a connection
+        // doesn't leave orphaned entities in Home Assistant, then tear the connection down —
+        // both on the control executor so disconnect() doesn't block the IPC caller.
         MqttConnectionConfig cfg = store.getById(id);
-        MqttPublisherService pub = publishers.get(id);
-        if (pub != null && cfg != null && cfg.isHomeAssistant()) {
-            pub.removeDiscovery(cfg.discoveryPrefix);
-        }
-        stopConnection(id);
+        final boolean ha = cfg != null && cfg.isHomeAssistant();
+        final String prefix = cfg != null ? cfg.discoveryPrefix : "homeassistant";
+        controlExecutor.execute(() -> {
+            MqttPublisherService pub = publishers.get(id);
+            if (pub != null && ha) {
+                pub.removeDiscovery(prefix);
+            }
+            stopConnection(id);
+        });
         return store.delete(id);
     }
 

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
@@ -88,6 +88,16 @@ public class MqttPublisherService implements MqttCallback {
 
         String effectiveClientId = config.getEffectiveClientId(deviceId);
 
+        // Tear down any stale client before opening a new one. Without this, a reconnect after a
+        // dropped/half-open connection leaves the old Paho client (same clientId) abandoned but not
+        // closed — the broker then sees two clients with the same id and the new connect can fail
+        // with "Client is connected" (Paho reason 32100). Closing it first releases the clientId.
+        if (client != null) {
+            try { if (client.isConnected()) client.disconnect(1000); } catch (Exception ignored) {}
+            try { client.close(); } catch (Exception ignored) {}
+            client = null;
+        }
+
         MqttClient newClient = null;
         try {
             // Create client with in-memory persistence (no filesystem needed)


### PR DESCRIPTION
After more testing I found two things not working properly; 

### MQTT: updates now reliably reconnect
Editing a connection already tore down and rebuilt the client, but it ran on the IPC handler thread — `disconnect()`/`connect()` can block ~5–10s while the HTTP→IPC socket times out at 3s, so saves against a slow/unreachable broker surfaced as "IPC communication failed" and left the restart half-applied.

- `add`/`update`/`delete` now persist the config synchronously and offload the disconnect/reconnect to a dedicated serial executor, so the UI gets an immediate reply and the broker reconnects in the background.
- Threaded the live scheduler through the publish loop so a trailing cycle from a connection being restarted can't queue work onto the fresh one.

### ABRP: presence status reflects the live state
`describe()` reported `foreground` for the whole grace window (default 90s), so closing ABRP left the status stuck on `foreground`.

- Track the current foreground observation separately; `describe()` now returns `foreground` / `background` / `not running` based on the latest check, flipping within one cycle (~8s) when you leave ABRP.
- The send gate (`isActive()`) is unchanged — it still honors the grace window, so telemetry behavior is identical. During grace you'll now see `background ✓`.