### PR TITLE
seperate recording layout profile for sentry

### DIFF
--- a/app/src/main/assets/web/local/events.html
+++ b/app/src/main/assets/web/local/events.html
@@ -1485,6 +1485,14 @@
            on the inactive cells for a glance-readable map. */
         .quadrant-bar .qcell { fill: rgba(255, 255, 255, 0.45); }
         .quadrant-bar .qcell.lit { fill: #FFFFFF; }
+        /* Two icon variants per button: q2x2 (standard mosaic map) and qdash
+           (dashcam map — full-width front band over three lower thirds). Show
+           the dashcam variant only when the open clip is a dashcam clip
+           (videoPlayerWrap gets .dashcam), so the glyph matches the layout-aware
+           zoom regions and each button maps to the right camera. */
+        .quadrant-bar .qdash { display: none; }
+        .video-player.dashcam .quadrant-bar .q2x2 { display: none; }
+        .video-player.dashcam .quadrant-bar .qdash { display: inline; }
         
         .video-details {
             padding: 12px 16px;
@@ -2074,19 +2082,19 @@
                      button restores the full mosaic view. -->
                 <div class="quadrant-bar" id="quadrantBar" role="group" data-i18n-attr="aria-label:events.quadrant_group" aria-label="Camera selector">
                     <button type="button" data-quadrant="all" class="active" data-i18n-attr="title:events.quadrant_all;aria-label:events.quadrant_all" title="Show all cameras" aria-label="Show all cameras">
-                        <svg viewBox="0 0 24 24"><rect class="qcell lit" x="3" y="3" width="8" height="8"/><rect class="qcell lit" x="13" y="3" width="8" height="8"/><rect class="qcell lit" x="3" y="13" width="8" height="8"/><rect class="qcell lit" x="13" y="13" width="8" height="8"/></svg>
+                        <svg viewBox="0 0 24 24"><g class="q2x2"><rect class="qcell lit" x="3" y="3" width="8" height="8"/><rect class="qcell lit" x="13" y="3" width="8" height="8"/><rect class="qcell lit" x="3" y="13" width="8" height="8"/><rect class="qcell lit" x="13" y="13" width="8" height="8"/></g><g class="qdash"><rect class="qcell lit" x="3" y="3" width="18" height="9"/><rect class="qcell lit" x="3" y="14" width="5" height="7"/><rect class="qcell lit" x="9.5" y="14" width="5" height="7"/><rect class="qcell lit" x="16" y="14" width="5" height="7"/></g></svg>
                     </button>
                     <button type="button" data-quadrant="front" data-i18n-attr="title:events.quadrant_front;aria-label:events.quadrant_front" title="Show front camera" aria-label="Show front camera">
-                        <svg viewBox="0 0 24 24"><rect class="qcell lit" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></svg>
+                        <svg viewBox="0 0 24 24"><g class="q2x2"><rect class="qcell lit" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></g><g class="qdash"><rect class="qcell lit" x="3" y="3" width="18" height="9"/><rect class="qcell" x="3" y="14" width="5" height="7"/><rect class="qcell" x="9.5" y="14" width="5" height="7"/><rect class="qcell" x="16" y="14" width="5" height="7"/></g></svg>
                     </button>
                     <button type="button" data-quadrant="right" data-i18n-attr="title:events.quadrant_right;aria-label:events.quadrant_right" title="Show right camera" aria-label="Show right camera">
-                        <svg viewBox="0 0 24 24"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell lit" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></svg>
+                        <svg viewBox="0 0 24 24"><g class="q2x2"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell lit" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></g><g class="qdash"><rect class="qcell" x="3" y="3" width="18" height="9"/><rect class="qcell" x="3" y="14" width="5" height="7"/><rect class="qcell" x="9.5" y="14" width="5" height="7"/><rect class="qcell lit" x="16" y="14" width="5" height="7"/></g></svg>
                     </button>
                     <button type="button" data-quadrant="rear" data-i18n-attr="title:events.quadrant_rear;aria-label:events.quadrant_rear" title="Show rear camera" aria-label="Show rear camera">
-                        <svg viewBox="0 0 24 24"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell lit" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></svg>
+                        <svg viewBox="0 0 24 24"><g class="q2x2"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell lit" x="3" y="13" width="8" height="8"/><rect class="qcell" x="13" y="13" width="8" height="8"/></g><g class="qdash"><rect class="qcell" x="3" y="3" width="18" height="9"/><rect class="qcell" x="3" y="14" width="5" height="7"/><rect class="qcell lit" x="9.5" y="14" width="5" height="7"/><rect class="qcell" x="16" y="14" width="5" height="7"/></g></svg>
                     </button>
                     <button type="button" data-quadrant="left" data-i18n-attr="title:events.quadrant_left;aria-label:events.quadrant_left" title="Show left camera" aria-label="Show left camera">
-                        <svg viewBox="0 0 24 24"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell lit" x="13" y="13" width="8" height="8"/></svg>
+                        <svg viewBox="0 0 24 24"><g class="q2x2"><rect class="qcell" x="3" y="3" width="8" height="8"/><rect class="qcell" x="13" y="3" width="8" height="8"/><rect class="qcell" x="3" y="13" width="8" height="8"/><rect class="qcell lit" x="13" y="13" width="8" height="8"/></g><g class="qdash"><rect class="qcell" x="3" y="3" width="18" height="9"/><rect class="qcell lit" x="3" y="14" width="5" height="7"/><rect class="qcell" x="9.5" y="14" width="5" height="7"/><rect class="qcell" x="16" y="14" width="5" height="7"/></g></svg>
                     </button>
                 </div>
             </div>

--- a/app/src/main/assets/web/local/surveillance.html
+++ b/app/src/main/assets/web/local/surveillance.html
@@ -861,6 +861,56 @@
                     </div>
                 </div>
 
+                <!-- Sentry Recording Layout — the independent counterpart to
+                     the dashcam layout on the recording page. Saves
+                     immediately (not via the Apply button), mirroring the
+                     dashcam layout card. Reuses the recording.layout_* i18n
+                     strings (already translated everywhere). -->
+                <div class="card" data-tab="recording">
+                    <div class="card-header">
+                        <div class="card-title">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/>
+                            </svg>
+                            <span data-i18n="recording.layout_title">Recording Layout</span>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-name">
+                                    <span data-i18n="recording.layout_label">Camera Layout</span>
+                                    <span class="setting-badge" data-i18n="recording.applies_live">Applies live</span>
+                                </div>
+                                <div class="setting-desc" data-i18n="recording.layout_desc">Standard records the four 360 cameras as a 2×2 grid. Dashcam puts the forward road view across the top with the 360 left, rear and right cameras along the bottom. Telemetry overlay is preserved either way.</div>
+                            </div>
+                            <div class="setting-control">
+                                <div class="btn-group btn-group-vertical" id="survLayoutBtns">
+                                    <button class="btn-toggle active" data-value="standard" onclick="SurvSettings.setSurveillanceLayout('standard')">
+                                        <span class="tier-name" data-i18n="recording.layout_standard">Standard (360 grid)</span>
+                                    </button>
+                                    <button class="btn-toggle" data-value="dashcam" onclick="SurvSettings.setSurveillanceLayout('dashcam')">
+                                        <span class="tier-name" data-i18n="recording.layout_dashcam">Dashcam (forward + sides)</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="setting-row" style="border-bottom:none;" id="survWindshieldRow">
+                            <div class="setting-info">
+                                <div class="setting-name" data-i18n="recording.layout_use_windshield_label">Use Windshield Camera in Dashcam Layout</div>
+                                <div class="setting-desc" data-i18n="recording.layout_use_windshield_desc">When available, use the dedicated windshield camera for the top dashcam view. Falls back to the 360 front camera if the stream cannot be opened.</div>
+                                <div class="setting-desc" id="survWindshieldCameraInfo" style="display:none;"></div>
+                            </div>
+                            <div class="setting-control">
+                                <label class="toggle-switch">
+                                    <input type="checkbox" id="survUseWindshield" onchange="SurvSettings.toggleSurveillanceWindshield()">
+                                    <span class="toggle-slider"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Fisheye Correction (Fitzgibbon division-model rectifier).
                      SHARED with the recording page — same unified-config key
                      (recording.rectifyStrength). Editing on either page

--- a/app/src/main/assets/web/shared/surveillance.js
+++ b/app/src/main/assets/web/shared/surveillance.js
@@ -135,6 +135,8 @@ BYD.surveillance = {
         await this.loadStorageStats();
         await this.loadCameraFps();
         await this.loadGeocoding();
+        // Sentry's own composition layout (independent of the dashcam layout).
+        await this.loadSurveillanceLayout();
         // Dedicated OEM Dashcam tab — load the mode picker, telemetry
         // toggle, status badge, and native DVR control on init so the
         // user can land directly on the OEM tab and find populated state.
@@ -242,6 +244,9 @@ BYD.surveillance = {
         // the cards re-evaluate without a page reload.
         this.loadOemDashcam();
         this.loadOemNativeDvr();
+        // Re-read sentry's layout so a change made elsewhere (or on another
+        // device) reflects without a full page reload.
+        this.loadSurveillanceLayout();
         // Lens-dewarp slider lives in unified-config recording.* (shared
         // with the dashcam page). /api/surveillance/config doesn't surface
         // it, so re-read it here so a change made on the recording page
@@ -3345,6 +3350,106 @@ BYD.surveillance = {
             }
         } finally {
             btn.disabled = false;
+        }
+    },
+
+    // ==================== Sentry Recording Layout ====================
+    //
+    // Sentry's OWN composition layout, independent of the dashcam recording
+    // layout on the recording page. Standard = 2x2 360 mosaic (default).
+    // Dashcam = forward road view on top with the 360 left/rear/right cameras
+    // along the bottom. Saves immediately (not via the Apply button), mirroring
+    // the dashcam layout card in recording.js. Hits
+    // /api/settings/surveillance-layout and reuses the recording.layout_* i18n
+    // strings (already translated in every language).
+
+    async loadSurveillanceLayout() {
+        try {
+            const resp = await fetch('/api/settings/surveillance-layout');
+            const data = await resp.json();
+            if (data.success) {
+                this._applySurveillanceLayoutButtons(data.layout || 'standard');
+
+                const wsToggle = document.getElementById('survUseWindshield');
+                if (wsToggle) {
+                    wsToggle.checked = data.dashcamUseWindshield || false;
+                    wsToggle.disabled = !data.windshieldAvailable;
+                }
+
+                const infoLine = document.getElementById('survWindshieldCameraInfo');
+                if (infoLine) {
+                    if (!data.windshieldAvailable) {
+                        infoLine.textContent = BYD.i18n.t('recording.layout_windshield_unavailable');
+                        infoLine.style.display = 'block';
+                    } else {
+                        infoLine.style.display = 'none';
+                    }
+                }
+
+                this._updateSurveillanceWindshieldVisibility(data.layout || 'standard');
+            }
+        } catch (e) {
+            console.warn('Failed to load surveillance layout:', e);
+        }
+    },
+
+    _updateSurveillanceWindshieldVisibility(layout) {
+        const subSetting = document.getElementById('survWindshieldRow');
+        if (subSetting) {
+            subSetting.style.display = layout === 'dashcam' ? 'flex' : 'none';
+        }
+    },
+
+    _applySurveillanceLayoutButtons(layout) {
+        const group = document.getElementById('survLayoutBtns');
+        if (!group) return;
+        group.querySelectorAll('.btn-toggle').forEach(btn =>
+            btn.classList.toggle('active', btn.dataset.value === layout));
+    },
+
+    async setSurveillanceLayout(layout) {
+        this._applySurveillanceLayoutButtons(layout);
+        this._updateSurveillanceWindshieldVisibility(layout);
+        await this._saveSurveillanceLayout();
+    },
+
+    async toggleSurveillanceWindshield() {
+        await this._saveSurveillanceLayout();
+    },
+
+    async _saveSurveillanceLayout() {
+        const group = document.getElementById('survLayoutBtns');
+        const active = group ? group.querySelector('.btn-toggle.active') : null;
+        const layout = active ? active.dataset.value : 'standard';
+
+        const wsToggle = document.getElementById('survUseWindshield');
+        const dashcamUseWindshield = wsToggle ? wsToggle.checked : false;
+
+        try {
+            const resp = await fetch('/api/settings/surveillance-layout', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ layout, dashcamUseWindshield })
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this._applySurveillanceLayoutButtons(data.layout);
+                this._updateSurveillanceWindshieldVisibility(data.layout);
+
+                if (wsToggle) {
+                    wsToggle.checked = data.dashcamUseWindshield;
+                    wsToggle.disabled = !data.windshieldAvailable;
+                }
+
+                if (BYD.utils && BYD.utils.toast) {
+                    const key = data.layout === 'dashcam' ? 'recording.layout_dashcam_toast' : 'recording.layout_standard_toast';
+                    BYD.utils.toast(BYD.i18n.t(key), 'success');
+                }
+            } else if (BYD.utils && BYD.utils.toast) {
+                BYD.utils.toast(BYD.i18n.t('recording.layout_update_failed'), 'error');
+            }
+        } catch (e) {
+            if (BYD.utils && BYD.utils.toast) BYD.utils.toast(BYD.i18n.t('recording.layout_update_failed'), 'error');
         }
     }
 };

--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -2541,6 +2541,20 @@ public class CameraDaemon {
                     gpuPipeline.setDashcamUseWindshield(dashcamUseWindshield);
                     log("Recording layout: " + recLayout);
 
+                    // Apply persisted sentry (surveillance) layout — the
+                    // independent counterpart to the dashcam layout above.
+                    // Falls back to the dashcam values when the sentry keys are
+                    // unset so existing installs keep their current look.
+                    org.json.JSONObject survLayoutCfg =
+                        com.overdrive.app.config.UnifiedConfigManager.getSurveillance();
+                    String survLayout = survLayoutCfg.optString("recordingLayout", recLayout);
+                    gpuPipeline.setSurveillanceRecordingLayout("dashcam".equals(survLayout) ? 1 : 0);
+                    boolean survUseWindshield = survLayoutCfg.has("useWindshield")
+                        ? survLayoutCfg.optBoolean("useWindshield", false)
+                        : dashcamUseWindshield;
+                    gpuPipeline.setSurveillanceUseWindshield(survUseWindshield);
+                    log("Sentry layout: " + survLayout);
+
                     // Late-bind TelemetryDataCollector to TripAnalyticsManager
                     // (it was null when TripAnalytics was initialized before the 45s GPU delay)
                     if (tripAnalyticsManager != null) {

--- a/app/src/main/java/com/overdrive/app/server/QualitySettingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/QualitySettingsApiHandler.java
@@ -107,6 +107,16 @@ public class QualitySettingsApiHandler {
             handleRecordingLayoutPost(out, body);
             return true;
         }
+        // Sentry (surveillance) composition layout — independent of the
+        // dashcam layout above so sentry and dashcam can use different layouts.
+        if (path.equals("/api/settings/surveillance-layout") && method.equals("GET")) {
+            sendSurveillanceLayoutSettings(out);
+            return true;
+        }
+        if (path.equals("/api/settings/surveillance-layout") && method.equals("POST")) {
+            handleSurveillanceLayoutPost(out, body);
+            return true;
+        }
         // Web-shell appearance (theme picker shipped on every page).
         // Same UnifiedConfigManager-backed pattern as the rest of /api/settings.
         if (path.equals("/api/settings/appearance") && method.equals("GET")) {
@@ -1467,6 +1477,80 @@ public class QualitySettingsApiHandler {
             HttpResponse.sendJson(out, response.toString());
         } catch (Exception e) {
             CameraDaemon.log("Error setting recording layout: " + e.getMessage());
+            HttpResponse.sendJsonError(out, e.getMessage());
+        }
+    }
+
+    /**
+     * GET /api/settings/surveillance-layout — read the SENTRY composition
+     * layout ("standard" 360 mosaic, default, or "dashcam"). Independent of the
+     * dashcam recording-layout. When the sentry keys are unset we fall back to
+     * the dashcam values so existing installs keep their current sentry
+     * appearance until the user explicitly diverges.
+     */
+    private static void sendSurveillanceLayoutSettings(OutputStream out) throws Exception {
+        JSONObject surveillance = com.overdrive.app.config.UnifiedConfigManager.getSurveillance();
+        JSONObject recording = com.overdrive.app.config.UnifiedConfigManager.getRecording();
+        com.overdrive.app.camera.ResolvedCameraConfig camera =
+            com.overdrive.app.camera.CameraConfigResolver.resolve();
+        int windshieldCameraId = camera.getDirectCameraIdForRole(
+            com.overdrive.app.camera.CameraRole.WINDSHIELD);
+        String layout = surveillance.optString("recordingLayout",
+            recording.optString("recordingLayout", "standard"));
+        boolean useWindshield = surveillance.has("useWindshield")
+            ? surveillance.optBoolean("useWindshield", false)
+            : recording.optBoolean("dashcamUseWindshield", false);
+        JSONObject response = new JSONObject();
+        response.put("success", true);
+        response.put("layout", layout);
+        response.put("dashcamUseWindshield", useWindshield);
+        response.put("windshieldAvailable", windshieldCameraId >= 0);
+        response.put("windshieldCameraId", windshieldCameraId);
+        HttpResponse.sendJson(out, response.toString());
+    }
+
+    /**
+     * POST /api/settings/surveillance-layout — set the sentry layout. Hot-
+     * applies to the live recorder (only while in surveillance mode) via the
+     * pipeline and persists under surveillance.* for daemon restarts / later
+     * recorders. Mirrors {@link #handleRecordingLayoutPost} for the dashcam
+     * flow; the request/response use the same {@code dashcamUseWindshield}
+     * key so the web layer can reuse the recording-layout client code.
+     */
+    private static void handleSurveillanceLayoutPost(OutputStream out, String body) throws Exception {
+        try {
+            JSONObject settings = new JSONObject(body);
+            String layout = "dashcam".equals(settings.optString("layout", "standard"))
+                ? "dashcam" : "standard";
+            com.overdrive.app.camera.ResolvedCameraConfig camera =
+                com.overdrive.app.camera.CameraConfigResolver.resolve();
+            int windshieldCameraId = camera.getDirectCameraIdForRole(
+                com.overdrive.app.camera.CameraRole.WINDSHIELD);
+            boolean windshieldAvailable = windshieldCameraId >= 0;
+            boolean useWindshield = settings.optBoolean("dashcamUseWindshield", false)
+                && windshieldAvailable;
+
+            JSONObject delta = new JSONObject();
+            delta.put("recordingLayout", layout);
+            delta.put("useWindshield", useWindshield);
+            com.overdrive.app.config.UnifiedConfigManager.setSurveillance(delta);
+
+            com.overdrive.app.surveillance.GpuSurveillancePipeline pipeline =
+                CameraDaemon.getGpuPipeline();
+            if (pipeline != null) {
+                pipeline.setSurveillanceRecordingLayout("dashcam".equals(layout) ? 1 : 0);
+                pipeline.setSurveillanceUseWindshield(useWindshield);
+            }
+
+            JSONObject response = new JSONObject();
+            response.put("success", true);
+            response.put("layout", layout);
+            response.put("dashcamUseWindshield", useWindshield);
+            response.put("windshieldAvailable", windshieldAvailable);
+            response.put("windshieldCameraId", windshieldCameraId);
+            HttpResponse.sendJson(out, response.toString());
+        } catch (Exception e) {
+            CameraDaemon.log("Error setting surveillance layout: " + e.getMessage());
             HttpResponse.sendJsonError(out, e.getMessage());
         }
     }

--- a/app/src/main/java/com/overdrive/app/surveillance/EventTimelineCollector.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/EventTimelineCollector.java
@@ -751,15 +751,18 @@ public class EventTimelineCollector {
             JSONObject root = new JSONObject();
             root.put("version", 3);
             root.put("durationMs", durationMs);
-            // Composition layout (dashcam clips only) so the player picks the
-            // right per-camera zoom regions. Sentry events share the dashcam
-            // recorder, so they honour the same layout. Read at write time;
-            // omitted for the default standard layout to keep legacy sidecars
-            // byte-identical.
+            // Composition layout so the player picks the right per-camera zoom
+            // regions. Sentry events are composited under the SENTRY layout
+            // profile (surveillance.recordingLayout), independent of the
+            // dashcam layout; fall back to the dashcam value when the sentry
+            // key is unset. Read at write time; omitted for the default
+            // standard layout to keep legacy sidecars byte-identical.
             try {
-                String recLayout = com.overdrive.app.config.UnifiedConfigManager
-                        .getRecording().optString("recordingLayout", "standard");
-                if ("dashcam".equals(recLayout)) {
+                String survLayout = com.overdrive.app.config.UnifiedConfigManager
+                        .getSurveillance().optString("recordingLayout",
+                            com.overdrive.app.config.UnifiedConfigManager
+                                .getRecording().optString("recordingLayout", "standard"));
+                if ("dashcam".equals(survLayout)) {
                     root.put("layout", "dashcam");
                 }
             } catch (Throwable ignored) { /* default standard */ }

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuSurveillancePipeline.java
@@ -137,6 +137,15 @@ public class GpuSurveillancePipeline {
     private volatile boolean dashcamUseWindshieldConfig = false;
     private volatile int windshieldCameraIdConfig = -1;
 
+    // Sentry (surveillance) layout profile — the independent counterpart to
+    // recordingLayoutConfig / dashcamUseWindshieldConfig above. Persisted in
+    // surveillance.recordingLayout / surveillance.useWindshield. Selected over
+    // the dashcam profile by applyActiveLayoutProfile() whenever the pipeline
+    // is in SURVEILLANCE mode, so sentry and dashcam can use different layouts
+    // on the one shared recorder (the two modes are mutually exclusive).
+    private volatile int surveillanceLayoutConfig = 0;
+    private volatile boolean surveillanceUseWindshieldConfig = false;
+
     // Mode tracking
     private enum Mode {
         IDLE,           // Nothing active
@@ -1386,8 +1395,10 @@ public class GpuSurveillancePipeline {
         }
         // Apply persisted overlay enabled state to new recorder
         recorder.setOverlayEnabled(overlayEnabledConfig);
-        // Apply persisted recording composition layout (standard / dashcam).
-        recorder.setRecordingLayout(recordingLayoutConfig);
+        // Apply the layout profile that matches the current mode (dashcam vs
+        // sentry) to the freshly-created recorder. IDLE/normal-recording use
+        // the dashcam profile; surveillance uses its own.
+        applyActiveLayoutProfile();
 
         // 3. Create GPU downscaler with profile-driven offsets
         downscaler = new GpuDownscaler(quadrantStripOffsetX);
@@ -1447,8 +1458,10 @@ public class GpuSurveillancePipeline {
         camera = new PanoramicCameraGpu(cameraWidth, cameraHeight,
             quadrantStripOffsetX, quadrantCornerOffsetsXY);
         camera.setConsumers(recorder, downscaler, sentry);
-        // Apply persisted dashcam windshield-source preference to the new camera.
-        applyWindshieldToCamera();
+        // Apply the active layout profile's windshield-source preference to the
+        // new camera (dashcam profile at startup/IDLE; the surveillance profile
+        // is re-applied when enableSurveillance() runs).
+        applyActiveLayoutProfile();
 
         // Camera FPS config — must match the encoder FPS used above (loadTargetFps())
         // so that camera frame delivery rate matches the encoder's KEY_FRAME_RATE.
@@ -3001,8 +3014,14 @@ public class GpuSurveillancePipeline {
             telemetryCollector.setOverlayRecordingActive(false);
             telemetryCollector.stopPolling();
         }
+
+        // Now that the mode is SURVEILLANCE, switch the recorder + windshield
+        // to sentry's own layout profile. applyActiveLayoutProfile() reads
+        // currentMode, so if sentry was null (mode unchanged) this harmlessly
+        // re-applies the dashcam profile instead.
+        applyActiveLayoutProfile();
     }
-    
+
     /**
      * Disables surveillance mode.
      */
@@ -3011,6 +3030,10 @@ public class GpuSurveillancePipeline {
             sentry.disable();
             currentMode = Mode.IDLE;
             logger.info( "Surveillance mode disabled");
+            // Back to IDLE → restore the dashcam layout profile so the next
+            // normal/continuous recording uses the dashcam setting, not the
+            // sentry one we may have switched to in enableSurveillance().
+            applyActiveLayoutProfile();
         }
     }
     
@@ -5093,40 +5116,87 @@ public class GpuSurveillancePipeline {
     private boolean overlayPollingHeld = false;
 
     /**
-     * Select the recording composition layout (0 = standard 360 mosaic,
-     * 1 = dashcam: 360 front slice on top, 360 left/rear/right below).
-     * Persisted in recording.recordingLayout; hot-applied to the live
-     * recorder and re-applied to recorders created later. Called from the
-     * daemon at startup and from the settings API on change.
+     * Select the DASHCAM recording composition layout (0 = standard 360
+     * mosaic, 1 = dashcam: 360 front slice on top, 360 left/rear/right below).
+     * Persisted in recording.recordingLayout. Stored here and pushed to the
+     * recorder only while the pipeline is NOT in surveillance mode — sentry
+     * owns its own layout profile (see {@link #setSurveillanceRecordingLayout}).
+     * Called from the daemon at startup and from the settings API on change.
      */
     public void setRecordingLayout(int layout) {
         this.recordingLayoutConfig = (layout == 1) ? 1 : 0;
-        if (recorder != null) {
-            recorder.setRecordingLayout(this.recordingLayoutConfig);
-        }
+        applyActiveLayoutProfile();
     }
 
     /**
-     * Record the user's preference for sourcing the dashcam top band from a
-     * dedicated windshield camera. The windshield is captured by
-     * PanoramicCameraGpu and composited into the recorder's dashcam top band
-     * when available; the dashcam layout falls back to the 360 front-camera
-     * slice (the documented graceful fallback) when it isn't. Storing the
-     * flag keeps the setting persisted and the API/daemon callers resolved.
+     * Record the user's preference for sourcing the DASHCAM top band from a
+     * dedicated windshield camera (recording.dashcamUseWindshield). Pushed to
+     * the producer only while NOT in surveillance mode. The windshield is
+     * captured by PanoramicCameraGpu and composited into the recorder's dashcam
+     * top band when available; the dashcam layout falls back to the 360
+     * front-camera slice (the documented graceful fallback) when it isn't.
      */
     public void setDashcamUseWindshield(boolean useWindshield) {
         this.dashcamUseWindshieldConfig = useWindshield;
-        applyWindshieldToCamera();
+        applyActiveLayoutProfile();
     }
 
     /**
-     * Push the windshield-source preference to the producer: resolve the
-     * windshield camera id for this vehicle and enable/disable the dedicated
-     * windshield capture accordingly. No-op until the camera exists (reapplied
-     * on camera creation). PanoramicCameraGpu opens/closes the camera on its GL
-     * thread and falls back to the 360 front slice if it can't open it.
+     * Select the SENTRY (surveillance) recording composition layout — the
+     * independent counterpart to {@link #setRecordingLayout}. Persisted in
+     * surveillance.recordingLayout. Stored here and pushed to the recorder
+     * only while the pipeline IS in surveillance mode, so dashcam and sentry
+     * recordings can use two different layouts on the one shared recorder.
+     * Called from the daemon at startup and from the settings API on change.
      */
-    private void applyWindshieldToCamera() {
+    public void setSurveillanceRecordingLayout(int layout) {
+        this.surveillanceLayoutConfig = (layout == 1) ? 1 : 0;
+        applyActiveLayoutProfile();
+    }
+
+    /**
+     * SENTRY counterpart to {@link #setDashcamUseWindshield}: sentry's own
+     * "use the dedicated windshield camera for the dashcam top band"
+     * preference (surveillance.useWindshield). Pushed to the producer only
+     * while in surveillance mode.
+     */
+    public void setSurveillanceUseWindshield(boolean useWindshield) {
+        this.surveillanceUseWindshieldConfig = useWindshield;
+        applyActiveLayoutProfile();
+    }
+
+    /**
+     * Push the layout profile that matches the CURRENT pipeline mode to the
+     * shared recorder + windshield camera. Surveillance mode uses the
+     * surveillance.* profile; every other mode (normal recording / idle) uses
+     * the dashcam recording.* profile. The two modes are mutually exclusive,
+     * so a single recorder serves both by re-applying the right profile on each
+     * mode transition, recorder (re)creation, and config change. A change to
+     * the INACTIVE profile is stored but not shown until that mode is entered.
+     */
+    private void applyActiveLayoutProfile() {
+        boolean surveillance = currentMode == Mode.SURVEILLANCE;
+        int layout = surveillance ? surveillanceLayoutConfig : recordingLayoutConfig;
+        boolean useWindshield = surveillance
+            ? surveillanceUseWindshieldConfig : dashcamUseWindshieldConfig;
+        if (recorder != null) {
+            // GpuMosaicRecorder.setRecordingLayout early-returns when unchanged.
+            recorder.setRecordingLayout(layout);
+        }
+        applyWindshieldToCamera(useWindshield);
+    }
+
+    /**
+     * Push the given windshield-source preference to the producer: resolve the
+     * windshield camera id for this vehicle and enable/disable the dedicated
+     * windshield capture accordingly. No-op until the camera exists (re-applied
+     * on the next mode transition / recorder creation). PanoramicCameraGpu
+     * opens/closes the camera on its GL thread and falls back to the 360 front
+     * slice if it can't open it. Callers (config setters + mode transitions on
+     * ACC events) are infrequent, so re-resolving + pushing here is never on a
+     * hot path.
+     */
+    private void applyWindshieldToCamera(boolean useWindshield) {
         PanoramicCameraGpu cam = this.camera;
         if (cam == null) return;
         int windshieldCameraId = -1;
@@ -5139,7 +5209,7 @@ public class GpuSurveillancePipeline {
         }
         this.windshieldCameraIdConfig = windshieldCameraId;
         cam.setDashcamWindshieldCamera(
-            dashcamUseWindshieldConfig && windshieldCameraId >= 0, windshieldCameraId);
+            useWindshield && windshieldCameraId >= 0, windshieldCameraId);
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/ui/fragment/VideoPlayerFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/VideoPlayerFragment.kt
@@ -392,6 +392,29 @@ class VideoPlayerFragment : Fragment() {
     }
 
     /**
+     * Swap the quadrant-selector glyphs to match the clip's composition
+     * layout. STANDARD clips use the 2x2 mosaic-map icons; DASHCAM clips use
+     * the dashcam-map icons (full-width front band over three lower thirds) so
+     * each button visually maps to where its camera actually sits in the
+     * frame. The zoom REGIONS are already layout-aware (see
+     * ZoomableVideoView.regionFor); this keeps the icons honest about which
+     * camera each button selects. Called wherever videoView.setLayout() runs.
+     */
+    private fun applyQuadrantLayoutIcons(layout: ZoomableVideoView.Layout) {
+        val dashcam = layout == ZoomableVideoView.Layout.DASHCAM
+        btnQuadrantAll?.setImageResource(
+            if (dashcam) R.drawable.ic_dashcam_all else R.drawable.ic_quadrant_all)
+        btnQuadrantFront?.setImageResource(
+            if (dashcam) R.drawable.ic_dashcam_front else R.drawable.ic_quadrant_front)
+        btnQuadrantRight?.setImageResource(
+            if (dashcam) R.drawable.ic_dashcam_right else R.drawable.ic_quadrant_right)
+        btnQuadrantRear?.setImageResource(
+            if (dashcam) R.drawable.ic_dashcam_rear else R.drawable.ic_quadrant_rear)
+        btnQuadrantLeft?.setImageResource(
+            if (dashcam) R.drawable.ic_dashcam_left else R.drawable.ic_quadrant_left)
+    }
+
+    /**
      * Read the recording.audioEnabled flag from UnifiedConfigManager so the
      * mute default for first-ever playback can mirror whether the user has
      * audio recording on. Best-effort: any exception or missing section
@@ -654,6 +677,7 @@ class VideoPlayerFragment : Fragment() {
                         // a dashcam clip followed by a sidecar-less standard
                         // clip must drop back to the 2x2 zoom regions.
                         videoView.setLayout(ZoomableVideoView.Layout.STANDARD)
+                        applyQuadrantLayoutIcons(ZoomableVideoView.Layout.STANDARD)
                         eventTimeline.setEvents(emptyList(), 0L)
                         tvEventInfo.text = getString(R.string.video_player_no_events)
                     }
@@ -666,7 +690,10 @@ class VideoPlayerFragment : Fragment() {
                 // so read + apply it BEFORE the events null-check below.
                 val clipLayout = if ("dashcam" == json.optString("layout", "standard"))
                     ZoomableVideoView.Layout.DASHCAM else ZoomableVideoView.Layout.STANDARD
-                activity?.runOnUiThread { videoView.setLayout(clipLayout) }
+                activity?.runOnUiThread {
+                    videoView.setLayout(clipLayout)
+                    applyQuadrantLayoutIcons(clipLayout)
+                }
                 val durationMs = json.optLong("durationMs", 0)
                 val eventsArray = json.optJSONArray("events")
                 if (eventsArray == null) {

--- a/app/src/main/res/drawable/ic_dashcam_all.xml
+++ b/app/src/main/res/drawable/ic_dashcam_all.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dashcam layout map: full-width front band over three lower thirds
+     (Left / Rear / Right), all regions solid. "All cameras" affordance
+     shown on the video player's quadrant selector for dashcam clips. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,3h18v9h-18z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,14h5v7h-5z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9.5,14h5v7h-5z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,14h5v7h-5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_dashcam_front.xml
+++ b/app/src/main/res/drawable/ic_dashcam_front.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dashcam layout map with the full-width front band solid (Front camera =
+     top band in the dashcam composition). Lower thirds (Left / Rear / Right)
+     outlined to map where this camera sits in the frame. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,3h18v9h-18z" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,14h5v7h-5zM4,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M9.5,14h5v7h-5zM10.5,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M16,14h5v7h-5zM17,15v5h3v-5z"
+        android:fillType="evenOdd" />
+</vector>

--- a/app/src/main/res/drawable/ic_dashcam_left.xml
+++ b/app/src/main/res/drawable/ic_dashcam_left.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dashcam layout map with the bottom-left third solid (Left camera =
+     lower-left third in the dashcam composition). Front band + other two
+     thirds outlined. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,3h18v9h-18zM4,4v7h16v-7z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3,14h5v7h-5z" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M9.5,14h5v7h-5zM10.5,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M16,14h5v7h-5zM17,15v5h3v-5z"
+        android:fillType="evenOdd" />
+</vector>

--- a/app/src/main/res/drawable/ic_dashcam_rear.xml
+++ b/app/src/main/res/drawable/ic_dashcam_rear.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dashcam layout map with the bottom-middle third solid (Rear camera =
+     lower-middle third in the dashcam composition). Front band + other two
+     thirds outlined. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,3h18v9h-18zM4,4v7h16v-7z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,14h5v7h-5zM4,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9.5,14h5v7h-5z" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M16,14h5v7h-5zM17,15v5h3v-5z"
+        android:fillType="evenOdd" />
+</vector>

--- a/app/src/main/res/drawable/ic_dashcam_right.xml
+++ b/app/src/main/res/drawable/ic_dashcam_right.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dashcam layout map with the bottom-right third solid (Right camera =
+     lower-right third in the dashcam composition). Front band + other two
+     thirds outlined. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,3h18v9h-18zM4,4v7h16v-7z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M3,14h5v7h-5zM4,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#66FFFFFF"
+        android:pathData="M9.5,14h5v7h-5zM10.5,15v5h3v-5z"
+        android:fillType="evenOdd" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,14h5v7h-5z" />
+</vector>


### PR DESCRIPTION
Sentry and dashcam both record through a **single shared** `GpuMosaicRecorder` in `GpuSurveillancePipeline`, and the composition layout was one global setting (`recording.recordingLayout` + `recording.dashcamUseWindshield`) applied unconditionally. So sentry-event clips simply inherited whatever the dashcam layout was — no way to differ.

## What I changed

Sentry now owns an **independent layout profile** stored under `surveillance.*`, and the pipeline selects the right profile by mode. Because `NORMAL_RECORDING` (dashcam) and `SURVEILLANCE` (sentry) are mutually exclusive, the one recorder serves both — a new `applyActiveLayoutProfile()` re-applies the correct layout + windshield source on each mode transition, recorder/camera creation, and config change.