### PR TITLE
Fix dialog buttons being cut off

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,324 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+
+# Keep line numbers for debugging
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
+
+# ==================== BYD SDK Stubs (reflection) ====================
+# These are compile-time stubs - real classes come from system at runtime
+-keep class android.hardware.bydauto.** { *; }
+-keep class android.hardware.BmmCamera** { *; }
+
+# ==================== Daemon Entry Points (app_process) ====================
+# ONLY keep class names and main() - everything else gets obfuscated
+# This hides internal method names like whitelistViaBruteForce -> a()
+
+-keep class com.overdrive.app.daemon.CameraDaemon {
+    public static void main(java.lang.String[]);
+}
+-keep class com.overdrive.app.daemon.SentryDaemon {
+    public static void main(java.lang.String[]);
+}
+-keep class com.overdrive.app.daemon.AccSentryDaemon {
+    public static void main(java.lang.String[]);
+}
+-keep class com.overdrive.app.daemon.TelegramBotDaemon {
+    public static void main(java.lang.String[]);
+}
+-keep class com.overdrive.app.daemon.GlobalProxyDaemon {
+    public static void main(java.lang.String[]);
+}
+-keep class com.overdrive.app.byd.BydEventDaemon {
+    public static void main(java.lang.String[]);
+}
+
+# Keep listener classes that extend BYD SDK (method names must match parent)
+-keep class com.overdrive.app.daemon.AccSentryDaemon$AccListener {
+    <methods>;
+}
+
+# ==================== Static Watchdog Builders (cross-process callers) ====================
+# These companion-object static helpers are called from daemon processes
+# (AccSentryDaemon, TelegramBotDaemon) to build the SAME shell-watchdog
+# script the UI deploys. Without `-keep` here, R8 may rename
+# `buildTelegramWatchdogScript` etc., the runtime call from
+# AccSentryDaemon.launchTelegramDaemon would NoSuchMethodError, and the
+# code falls back to the bare-nohup unsupervised launch — silently
+# regressing the H2 watchdog work.
+-keep class com.overdrive.app.launcher.DaemonLauncher$Companion {
+    public *;
+}
+-keep class com.overdrive.app.launcher.ZrokLauncher$Companion {
+    public *;
+}
+
+# ==================== Daemon Support Classes ====================
+# These are used by daemons but don't need full preservation
+
+# Safe - Pure Java AES decryption (replaced native NativeSecrets)
+-keep class com.overdrive.app.daemon.proxy.Safe {
+    public static java.lang.String s(java.lang.String);
+}
+
+# S - Short alias for string decryption (used throughout daemon code)
+-keep class com.overdrive.app.daemon.proxy.S {
+    public static java.lang.String d(java.lang.String);
+}
+
+# Enc - holds decrypted constants accessed via reflection from
+# DaemonBootstrap.verifySafeWorking() (Class.forName + getDeclaredField).
+# Without this, R8 renames APP_PACKAGE to a single-letter name and the
+# bootstrap aborts before the daemon ever loads.
+-keep class com.overdrive.app.daemon.proxy.Enc {
+    public static java.lang.String APP_PACKAGE;
+    *;
+}
+
+# CameraDaemon.getAppContext() — called reflectively by ScreenDeterrent.resolveContext()
+# (surveillance package can't compile-time depend on daemon package). The
+# main()-only -keep above doesn't preserve this, so R8 renames it to a()
+# and ScreenDeterrent silently falls through to DaemonBootstrap.
+-keepclassmembers class com.overdrive.app.daemon.CameraDaemon {
+    public static android.content.Context getAppContext();
+}
+
+# DaemonBootstrap.getContext() — fallback path for the same reflection above.
+-keepclassmembers class com.overdrive.app.daemon.DaemonBootstrap {
+    public static android.content.Context getContext();
+}
+
+# Messages.get(String, String) and Messages.get(String) — called
+# reflectively by SrtWriter.lookupCatalog() so subtitle generation can
+# pull localized strings without a compile-time dependency from
+# surveillance → server.
+-keepclassmembers class com.overdrive.app.server.Messages {
+    public static java.lang.String get(java.lang.String, java.lang.String);
+    public static java.lang.String get(java.lang.String);
+}
+
+# LocaleManager.get() — called reflectively by SrtWriter.resolveCurrentLocale()
+-keepclassmembers class com.overdrive.app.server.LocaleManager {
+    public static java.lang.String get();
+}
+
+# Keep class names for daemon subpackages (for Class.forName if used internally)
+# but allow method/field renaming
+-keepnames class com.overdrive.app.daemon.** { }
+-keepnames class com.overdrive.app.byd.** { }
+-keepnames class com.overdrive.app.camera.** { }
+-keepnames class com.overdrive.app.server.** { }
+-keepnames class com.overdrive.app.encoding.** { }
+-keepnames class com.overdrive.app.stream.** { }
+-keepnames class com.overdrive.app.monitor.** { }
+
+# ==================== Logging (keep class names + DaemonLogConfig for runtime control) ====================
+-keepnames class com.overdrive.app.logging.** { }
+-keep class com.overdrive.app.logging.DaemonLogConfig { *; }
+
+# ==================== Native Methods (all classes) ====================
+# JNI method names must match native function signatures exactly
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# ==================== Dadb (ADB client) ====================
+-keep class dadb.** { *; }
+-dontwarn dadb.**
+
+# ==================== ZXing (QR codes) ====================
+-keep class com.google.zxing.** { *; }
+
+# ==================== Eclipse Paho MQTT ====================
+# Paho uses java.util.logging internally and loads logging resource bundles
+# by class name via reflection. ProGuard strips these, causing
+# MissingResourceException at connect time.
+-keep class org.eclipse.paho.client.mqttv3.** { *; }
+-keep class org.eclipse.paho.client.mqttv3.logging.** { *; }
+-dontwarn org.eclipse.paho.client.mqttv3.**
+# v5 client used by BydCloudMqttSubscriber for BYD's EMQ broker — same
+# reflection-based logging-bundle loader as v3. The package roots differ
+# from v3 (mqttv5 sits directly under org.eclipse.paho, no .client. prefix
+# in the package after that), so the v3 rules above don't cover it.
+-keep class org.eclipse.paho.mqttv5.** { *; }
+-keep class org.eclipse.paho.mqttv5.client.logging.** { *; }
+-dontwarn org.eclipse.paho.mqttv5.**
+
+# ==================== RTMP client ====================
+-keep class com.pedro.** { *; }
+-dontwarn com.pedro.**
+
+# ==================== TensorFlow Lite ====================
+# CPU-only (XNNPACK). The GPU delegate dependency was removed because on
+# Adreno 610 (unified-memory SoC) concurrent OpenCL inference and the H.265
+# encoder share one DDR bus, producing visible eglSwap stalls during
+# recording. See YoloDetector.kt class doc.
+-keep class org.tensorflow.lite.** { *; }
+-keep interface org.tensorflow.lite.** { *; }
+-keepclassmembers class org.tensorflow.lite.** { *; }
+-keep class org.tensorflow.lite.support.** { *; }
+-keep class com.google.auto.value.** { *; }
+-dontwarn com.google.auto.value.**
+
+# AI detection classes - keep class names but allow method obfuscation
+# Detection data class needs field names for any serialization
+-keep class com.overdrive.app.ai.Detection { *; }
+-keepnames class com.overdrive.app.ai.** { }
+
+# ==================== Kotlin & AndroidX ====================
+-dontwarn kotlin.**
+-keep class kotlin.Metadata { *; }
+# AndroidX - only keep what's needed, not everything
+-keep class androidx.core.content.FileProvider { *; }
+-keep class androidx.work.** { *; }
+-keep class androidx.navigation.** { *; }
+-keepnames class androidx.** { }
+-dontwarn androidx.**
+
+# ==================== App Components (declared in AndroidManifest) ====================
+# R8 auto-keeps these, but explicit rules for safety
+-keep class com.overdrive.app.OverdriveApplication { *; }
+-keep class com.overdrive.app.ui.MainActivity { *; }
+-keep class com.overdrive.app.ui.LocationStarterActivity { *; }
+-keep class com.overdrive.app.BlockerActivity { *; }
+-keep class com.overdrive.app.receiver.BootReceiver { *; }
+-keep class com.overdrive.app.receiver.LocationBootReceiver { *; }
+-keep class com.overdrive.app.services.LocationSidecarService { *; }
+# RoadSense IMU sidecar — launched by the daemon via a STRING-LITERAL `am
+# start-foreground-service -n .../RoadSenseImuSidecarService` (R8 can't see that
+# reference), so its class name must not be renamed/stripped. Same rationale as
+# LocationSidecarService above. The daemon→app bridge (CameraDaemon.getRoadSense,
+# RoadSenseController, RoadSenseApiHandler) is reached by typed calls so R8 tracks
+# those automatically; only the am-launched component needs an explicit keep.
+-keep class com.overdrive.app.roadsense.sidecar.RoadSenseImuSidecarService { *; }
+-keep class com.overdrive.app.roadsense.overlay.RoadSenseOverlayService { *; }
+
+# ==================== App Packages (allow obfuscation) ====================
+# Keep class names for debugging but obfuscate methods/fields
+-keepnames class com.overdrive.app.auth.** { }
+-keepnames class com.overdrive.app.bridge.** { }
+-keepnames class com.overdrive.app.byd.** { }
+-keepnames class com.overdrive.app.client.** { }
+-keepnames class com.overdrive.app.config.** { }
+-keepnames class com.overdrive.app.launcher.** { }
+-keepnames class com.overdrive.app.manager.** { }
+-keepnames class com.overdrive.app.proximity.** { }
+-keepnames class com.overdrive.app.recording.** { }
+-keepnames class com.overdrive.app.service.** { }
+-keepnames class com.overdrive.app.shell.** { }
+-keepnames class com.overdrive.app.storage.** { }
+-keepnames class com.overdrive.app.streaming.** { }
+-keepnames class com.overdrive.app.surveillance.** { }
+-keepnames class com.overdrive.app.telemetry.** { }
+# TelemetrySnapshot fields accessed by overlay renderer — keep from renaming
+-keepclassmembers class com.overdrive.app.telemetry.TelemetrySnapshot { public *; }
+-keepnames class com.overdrive.app.abrp.** { }
+-keepnames class com.overdrive.app.telegram.** { }
+-keepnames class com.overdrive.app.ui.** { }
+-keepnames class com.overdrive.app.util.** { }
+-keepnames class com.overdrive.app.webrtc.** { }
+
+# ==================== Serialization & Parcelable ====================
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final android.os.Parcelable$Creator *;
+}
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+# ==================== H2 Database & JDBC Fixes (COMPLETE) ====================
+
+# 1. Ignore Desktop UI (AWT/Swing)
+-dontwarn java.awt.**
+-dontwarn java.beans.**
+
+# 2. Ignore Java Management Extensions (JMX)
+-dontwarn java.lang.management.**
+-dontwarn javax.management.**
+
+# 3. Ignore Servlets (Web Server features) - MISSING IN PREVIOUS
+-dontwarn javax.servlet.**
+-dontwarn jakarta.servlet.**
+
+# 4. Ignore OSGi (Module System) - MISSING IN PREVIOUS
+-dontwarn org.osgi.**
+
+# 5. Ignore Advanced SQL/Transaction APIs (XA/JDBCType)
+-dontwarn java.sql.**
+-dontwarn javax.sql.**
+-dontwarn javax.transaction.**
+-dontwarn javax.naming.**
+-dontwarn javax.security.**
+
+# 6. Ignore GIS/Geometry Support (JTS)
+-dontwarn org.locationtech.jts.**
+
+# 7. Ignore Lucene (Full Text Search)
+-dontwarn org.apache.lucene.**
+
+# 8. Ignore other missing standard Java extensions
+-dontwarn javax.xml.stream.**
+-dontwarn javax.xml.transform.**
+-dontwarn javax.tools.**
+-dontwarn javax.script.**
+
+# 9. Keep H2 functional
+-keep class org.h2.** { *; }
+
+# ==================== Log Stripping (Release Builds) ====================
+#
+# CONTROLLED BY: com.overdrive.app.logging.DaemonLogConfig
+#
+# DaemonLogger stripping is in a SEPARATE file: proguard-rules-strip-logs.pro
+# build.gradle.kts auto-detects DaemonLogConfig flags:
+#   - All flags false (default) → includes strip-logs → DaemonLogger calls stripped
+#   - Any flag true            → excludes strip-logs → DaemonLogger calls kept
+#
+# Console/stdout stripping below is ALWAYS active (even in debug-logging builds).
+# ====================================================================
+
+# Always strip android.util.Log (logcat) — security: no log strings in production
+-assumenosideeffects class android.util.Log {
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+    public static int w(...);
+    public static int e(...);
+    public static int wtf(...);
+    public static boolean isLoggable(...);
+    public static String getStackTraceString(...);
+    public static int println(...);
+}
+
+# Always strip System.out/err (daemon stdout)
+-assumenosideeffects class java.io.PrintStream {
+    public void println(...);
+    public void print(...);
+    public void printf(...);
+}
+
+# Keep DaemonLogConfig (R8 needs it for runtime checks when logging is enabled)
+-keep class com.overdrive.app.logging.DaemonLogConfig { *; }
+
+# Keep DaemonLogger class structure
+-keep class com.overdrive.app.logging.DaemonLogger { *; }
+-keep class com.overdrive.app.logging.DaemonLogger$Config { *; }
+-keep class com.overdrive.app.logging.DaemonLogger$Level { *; }
+
+# Strip Kotlin null checks (minor optimization — always safe to strip)
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    public static void checkParameterIsNotNull(...);
+    public static void checkNotNullParameter(...);
+    public static void checkNotNullExpressionValue(...);
+}
+
+# ==================== General Safety ====================
+-dontwarn sun.misc.Unsafe
+-dontwarn java.nio.file.**
+-dontwarn java.util.spi.ToolProvider

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
@@ -145,7 +145,6 @@ class DaemonsFragment : Fragment() {
                 val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(context, R.style.Theme_Overdrive_M3_Dialog)
                     .setIcon(R.drawable.ic_link)
                     .setTitle(getString(R.string.dialog_zrok_token_title))
-                    .setMessage(getString(R.string.dialog_zrok_token_message))
                     .setView(dialogView)
                     .setPositiveButton(getString(R.string.dialog_save)) { _, _ ->
                         val token = editToken.text.toString().trim()
@@ -227,7 +226,6 @@ class DaemonsFragment : Fragment() {
             val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(context, R.style.Theme_Overdrive_M3_Dialog)
                 .setIcon(R.drawable.ic_mqtt)
                 .setTitle(getString(R.string.dialog_tailscale_settings_title))
-                .setMessage(getString(R.string.dialog_tailscale_settings_message))
                 .setView(dialogView)
                 .setPositiveButton(getString(R.string.dialog_save)) { _, _ ->
                     val enableProxy = proxySwitch.isChecked

--- a/app/src/main/res/layout/dialog_tailscale_settings.xml
+++ b/app/src/main/res/layout/dialog_tailscale_settings.xml
@@ -13,6 +13,14 @@
         android:orientation="vertical"
         android:padding="24dp">
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:text="@string/dialog_tailscale_settings_message"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_zrok_token.xml
+++ b/app/src/main/res/layout/dialog_zrok_token.xml
@@ -1,68 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/colorSurfaceContainerHigh"
-    android:orientation="vertical"
-    android:padding="24dp">
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:fillViewport="true">
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/zrok_enable_token_hint">
+        android:background="?attr/colorSurfaceContainerHigh"
+        android:orientation="vertical"
+        android:padding="24dp">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editZrokToken"
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fontFamily="monospace"
-            android:imeOptions="actionDone"
-            android:inputType="textVisiblePassword"
-            android:maxLines="1"
-            android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+            android:layout_marginBottom="12dp"
+            android:text="@string/dialog_zrok_token_message"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            android:textColor="?attr/colorOnSurfaceVariant" />
 
-    </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/zrok_enable_token_hint">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:text="@string/zrok_token_storage_note"
-        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-        android:textColor="?attr/colorOnSurfaceVariant" />
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editZrokToken"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="monospace"
+                android:imeOptions="actionDone"
+                android:inputType="textVisiblePassword"
+                android:maxLines="1"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginTop="20dp"
-        android:background="?attr/colorOutlineVariant" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <!-- Reset Environment — proper M3 outlined button so it reads as a real
-         destructive action. Error-tinted stroke + label. -->
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnResetZrokEnvironment"
-        style="?attr/materialButtonOutlinedStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:minHeight="48dp"
-        android:text="@string/zrok_reset_environment"
-        android:textAllCaps="false"
-        android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
-        android:textColor="?attr/colorError"
-        app:cornerRadius="20dp"
-        app:strokeColor="?attr/colorError"
-        app:rippleColor="?attr/colorError" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/zrok_token_storage_note"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:layout_marginStart="4dp"
-        android:text="@string/zrok_reset_environment_desc"
-        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-        android:textColor="?attr/colorOnSurfaceVariant" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="20dp"
+            android:background="?attr/colorOutlineVariant" />
 
-</LinearLayout>
+        <!-- Reset Environment — proper M3 outlined button so it reads as a real
+             destructive action. Error-tinted stroke + label. -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnResetZrokEnvironment"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:minHeight="48dp"
+            android:text="@string/zrok_reset_environment"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
+            android:textColor="?attr/colorError"
+            app:cornerRadius="20dp"
+            app:strokeColor="?attr/colorError"
+            app:rippleColor="?attr/colorError" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginStart="4dp"
+            android:text="@string/zrok_reset_environment_desc"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</ScrollView>


### PR DESCRIPTION
## What does this PR do?
Fixes the dialog buttons for Zrok and Tailscale settings being cut off. This was due to setMessage and setView being called on the dialogs at the same time. I moved the message to inside the view to fix this which makes it styled a little differently.
I have also added the proguard rules back in as it fails to build without them.

## Why is this change needed?
Allow users to save Tailscale and Zrok settings even on smaller screens without rotating to portrait mode.

## How to test
Add more text to the dialog layouts forcing them to require scrolling and see if the buttons are still available.

## Screenshots (if applicable) 
Zrok Before:
<img width="621" height="356" alt="ZrokBefore" src="https://github.com/user-attachments/assets/b17cdf21-40c9-4201-a22f-8bd37a0dabd6" />
Zrok After:
<img width="614" height="347" alt="ZrokAfter" src="https://github.com/user-attachments/assets/9a520453-5173-41a5-9630-f0bdab2160e2" />

Tailscale Before:
<img width="617" height="350" alt="TailscaleBefore" src="https://github.com/user-attachments/assets/010fc522-dfdc-4e90-ab47-123181f7c0d0" />
Tailscale After:
<img width="614" height="349" alt="TailscaleAfter" src="https://github.com/user-attachments/assets/3e0ec9a6-0fec-447f-929e-85df95ab12e4" />
