### PR TITLE
Fix requests through tailscale proxy

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/ProxyHelper.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/ProxyHelper.java
@@ -124,7 +124,7 @@ public class ProxyHelper {
      */
     public static Proxy getHttpProxy() {
         if (isProxyAvailable()) {
-            return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(PROXY_HOST, proxyPort));
+            return new Proxy(Proxy.Type.SOCKS, new InetSocketAddress(PROXY_HOST, proxyPort));
         }
         return Proxy.NO_PROXY;
     }


### PR DESCRIPTION
## What does this PR do?
Fixes request errors which go through the Tailscale proxy. This PR is currently a draft PR as it needs to be tested with Singbox.

## Why is this change needed?
The Tailscale proxy is a SOCKS proxy. When doing requests with the proxy type as HTTP, Tailscale errors due to the format of the request being incorrect.

## How to test
Enable the Tailscale proxy and click the check for updates button in Overdrive. This will fail before this change.