### PR TITLE
Fix HV pack voltage reading too low (derive from cell voltage × series count)

### DIFF
--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -1798,8 +1798,31 @@ public class BydDataCollector {
             collectStatTemp(b, BydFeatureIds.STAT_AVERAGE_BATTERY_TEMP, "avg");
 
             // Cell voltages via get() — intValue / 1000.0 = V
-            collectStatVoltage(b, BydFeatureIds.STAT_HIGHEST_BATTERY_VOLTAGE, "high");
-            collectStatVoltage(b, BydFeatureIds.STAT_LOWEST_BATTERY_VOLTAGE, "low");
+            double cellHi = collectStatVoltage(b, BydFeatureIds.STAT_HIGHEST_BATTERY_VOLTAGE, "high");
+            double cellLo = collectStatVoltage(b, BydFeatureIds.STAT_LOWEST_BATTERY_VOLTAGE, "low");
+
+            // HV pack voltage, derived from the (accurate) per-cell voltage × series cell count.
+            // The statistic-device event 1151336480 (formerly read as pack voltage in decivolts)
+            // under-reports on some trims — e.g. on the Seal 82.5 kWh it tracks only ~149 cells'
+            // worth (~494 V) while the true pack is ~570 V (verified vs an OBD2 reading of 567 V at
+            // 3.294 V/cell). The per-cell voltages read correctly, so pack = avg_cell × N, where N
+            // is the pack's series cell count from its nominal capacity (cellCountForCapacity, e.g.
+            // 82.5 kWh → 172s) — so this stays correct across BYD models. If capacity isn't known
+            // yet (cellCount == 0) we skip the override rather than publish a wrong value.
+            if (!Double.isNaN(cellHi) && !Double.isNaN(cellLo)) {
+                int cellCount = 0;
+                try {
+                    com.overdrive.app.abrp.SohEstimator soh =
+                        com.overdrive.app.monitor.SocHistoryDatabase.getInstance().getSohEstimator();
+                    if (soh != null) {
+                        cellCount = com.overdrive.app.abrp.SohEstimator
+                            .cellCountForCapacity(soh.getNominalCapacityKwh());
+                    }
+                } catch (Throwable ignored) {}
+                if (cellCount > 0) {
+                    b.hvPackVoltage(((cellHi + cellLo) / 2.0) * cellCount);
+                }
+            }
         } catch (Exception e) {
             logger.debug("collectStatistic error: " + e.getMessage());
         }
@@ -1821,19 +1844,21 @@ public class BydDataCollector {
         }
     }
 
-    private void collectStatVoltage(BydVehicleData.Builder b, int featureId, String which) {
+    /** @return the cell voltage in V, or NaN if unavailable/out-of-range. */
+    private double collectStatVoltage(BydVehicleData.Builder b, int featureId, String which) {
         Object val = BydDeviceHelper.callGet(statisticDevice, featureId, Integer.TYPE);
         if (val == null) val = BydDeviceHelper.callGet(statisticDevice, featureId, Integer.class);
-        if (val == null) return;
+        if (val == null) return Double.NaN;
         int raw = BydDeviceHelper.getIntValue(val);
         if (raw == BydFeatureIds.BMS_UNAVAILABLE || raw == BydFeatureIds.INVALID_VALUE
-            || raw == BydFeatureIds.INVALID_VALUE_2 || raw == Integer.MIN_VALUE || raw <= 0) return;
+            || raw == BydFeatureIds.INVALID_VALUE_2 || raw == Integer.MIN_VALUE || raw <= 0) return Double.NaN;
         double volts = raw / 1000.0;
-        if (volts < 1.0 || volts > 5.0) return;
+        if (volts < 1.0 || volts > 5.0) return Double.NaN;
         switch (which) {
             case "high": b.highCellVoltage(volts); break;
             case "low": b.lowCellVoltage(volts); break;
         }
+        return volts;
     }
 
     private void collectCharging(BydVehicleData.Builder b) {
@@ -3809,9 +3834,6 @@ public class BydDataCollector {
         // Actual data is read on-demand via collectAllFull().
     }
 
-    // Throttle for generic listener callbacks (StatisticDevice fires at ~10Hz on CAN bus)
-    private volatile long lastGenericCallbackTime = 0;
-
     private void onGenericCallback(String method, Object[] args) {
         // Typed callbacks for real-time updates
         if ("onElecPercentageChanged".equals(method) && args != null && args.length > 0) {
@@ -3897,42 +3919,10 @@ public class BydDataCollector {
             return;
         }
 
-        // Capture HV pack voltage from statistic device event.
-        // BYD CAN bus fires StatisticDevice events at ~10Hz — throttle to 1Hz max.
-        if ("onDataEventChanged".equals(method) && args != null && args.length >= 2) {
-            long now = System.currentTimeMillis();
-            if (now - lastGenericCallbackTime < 1000) return;
-            lastGenericCallbackTime = now;
-
-            try {
-                int eventId = ((Number) args[0]).intValue();
-                Object eventValue = args[1];
-                int iVal = BydDeviceHelper.getIntValue(eventValue);
-                
-                // Event 1151336480: HV pack voltage in decivolts (e.g., 4955 = 495.5V)
-                if (eventId == 1151336480 && iVal > 2000 && iVal < 9000) {
-                    BydVehicleData current = snapshot.get();
-                    if (current != null) {
-                        double volts = iVal / 10.0;
-                        boolean isFirst = Double.isNaN(current.hvPackVoltage);
-                        if (isFirst || Math.abs(current.hvPackVoltage - volts) > 0.5) {
-                            snapshot.set(current.toBuilder().hvPackVoltage(volts).build());
-                            
-                            if (isFirst) {
-                                logger.info("HV pack voltage: " + String.format("%.1f", volts) + "V");
-                                try {
-                                    com.overdrive.app.abrp.SohEstimator soh = 
-                                        com.overdrive.app.monitor.SocHistoryDatabase.getInstance().getSohEstimator();
-                                    if (soh != null) {
-                                        soh.autoDetectFromPackVoltage(volts, current);
-                                    }
-                                } catch (Exception ignored) {}
-                            }
-                        }
-                    }
-                }
-            } catch (Exception ignored) {}
-        }
+        // HV pack voltage is NOT read from the onDataEventChanged stream anymore.
+        // Event 1151336480 (formerly parsed as pack voltage in decivolts) under-reports on the
+        // Seal 82.5 kWh trim — it tracks only ~149 cells' worth (~494 V vs the true ~570 V).
+        // Pack voltage is now derived from per-cell voltage × series count in collectStatistic().
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?
`hv_pack_voltage` reads too low on the BYD Seal. This derives it from the per-cell voltages instead of event `1151336480`.

Pack voltage now comes from `avg_cell × series_cell_count`, where the series count is looked up from the pack's nominal capacity via the existing `SohEstimator.cellCountForCapacity()` (82.5 kWh gives 172s). If the capacity isn't known yet, it leaves the value unpublished rather than guessing.

Closes #124.

## Why is this change needed?
On the Seal 82.5 kWh, event `1151336480` reports ~494 V while the real pack sits around 570 V. An OBD2 scanner on the same car reads 567 V at 3.294 V/cell, which is 172 series cells (567 / 3.294). The event tracks only ~149 cells worth, so it's the wrong signal, not a scaling bug. The per-cell voltages are correct, so deriving from them gives the right number. Using `cellCountForCapacity()` keeps it right on other BYD models too, instead of hardcoding 172.

The full investigation is in #124 (event-stream capture, a `get()` feature-ID sweep, and getter probing all came up empty for a correct total-voltage signal).

## How to test
- Seal 82.5 kWh: `hv_pack_voltage` reads ~570 V instead of ~494 V, and pack / avg_cell lands on 172.
- Other models: pack = avg_cell × that model's `cellCountForCapacity(nominalCapacityKwh)`.
- Capacity unknown: nothing is published, so no wrong value.
- `./gradlew assembleDebug` passes. Tested live on a Seal: 570.9 V, 172 cells.

## Notes
`collectStatVoltage` now returns the cell voltage. The old `onDataEventChanged` handler for `1151336480` and its throttle field are gone, since pack voltage no longer comes from that event.
