### PR TITLE
Report motor power correctly and add a charge_power field

### DIFF
--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -2050,6 +2050,18 @@ public class BydDataCollector {
             // Anything above 50 from a getter that's supposed to be kW is the
             // hectowatt scale — divide. Below 50, trust the value as-is.
             // The 104857.5 BYD sentinel falls cleanly above the 50000 cap.
+
+            // Charge power into the pack (kW), direct from the instrument cluster.
+            // getChargePower() reads the real DC charge rate (e.g. 2.9 kW on a 15 A/230 V AC
+            // charge, matches the BYD app / cloud battery_power), unlike getExternalChargingPower()
+            // which returns the 104857.5 sentinel on this trim. Returns 0 / sentinel when idle —
+            // bound to a plausible kW range so a sentinel can't leak.
+            Object chgPower = BydDeviceHelper.callGetter(instrumentDevice, "getChargePower");
+            if (chgPower instanceof Number) {
+                double kw = ((Number) chgPower).doubleValue();
+                if (kw >= 0 && kw <= 500) b.chargePowerKw(kw);
+            }
+
             Object extPower = BydDeviceHelper.callGetter(instrumentDevice, "getExternalChargingPower");
             if (extPower instanceof Number) {
                 double raw = ((Number) extPower).doubleValue();

--- a/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydVehicleData.java
@@ -72,6 +72,7 @@ public class BydVehicleData {
     public final int chargingMode;        // SDK getChargingMode() raw (AC vs DC vs wireless — model-specific)
     public final double chargingPowerKw;
     public final double externalChargingPowerKw;
+    public final double chargePowerKw;    // DC charge power into pack (kW), InstrumentDevice.getChargePower()
     public final double hvPackVoltage;    // HV battery pack voltage (V), from CAN event
 
     // ==================== GEAR ====================
@@ -237,6 +238,7 @@ public class BydVehicleData {
         this.chargingMode = b.chargingMode;
         this.chargingPowerKw = b.chargingPowerKw;
         this.externalChargingPowerKw = b.externalChargingPowerKw;
+        this.chargePowerKw = b.chargePowerKw;
         this.hvPackVoltage = b.hvPackVoltage;
         this.gearMode = b.gearMode;
         this.tyrePressure = b.tyrePressure;
@@ -639,6 +641,7 @@ public class BydVehicleData {
         b.chargingGunState = chargingGunState; b.chargerWorkState = chargerWorkState;
         b.chargingMode = chargingMode;
         b.chargingPowerKw = chargingPowerKw; b.externalChargingPowerKw = externalChargingPowerKw;
+        b.chargePowerKw = chargePowerKw;
         b.hvPackVoltage = hvPackVoltage;
         b.gearMode = gearMode; b.tyrePressure = tyrePressure;
         b.tyrePressureState = tyrePressureState; b.tyreAirLeakState = tyreAirLeakState;
@@ -703,7 +706,7 @@ public class BydVehicleData {
         int totalMileageKm = UNAVAILABLE, evMileageKm = UNAVAILABLE;
         int chargingState = UNAVAILABLE, chargingGunState = UNAVAILABLE, chargerWorkState = UNAVAILABLE;
         int chargingMode = UNAVAILABLE;
-        double chargingPowerKw = NaN, externalChargingPowerKw = NaN, hvPackVoltage = NaN;
+        double chargingPowerKw = NaN, externalChargingPowerKw = NaN, chargePowerKw = NaN, hvPackVoltage = NaN;
         int gearMode = UNAVAILABLE;
         int[] tyrePressure, doorLockStatus, windowOpenPercent, seatbeltStatus, radarDistances;
         int[] seatHeat, seatCool;
@@ -797,6 +800,7 @@ public class BydVehicleData {
         public Builder chargingMode(int v) { chargingMode = v; return this; }
         public Builder chargingPowerKw(double v) { chargingPowerKw = v; return this; }
         public Builder externalChargingPowerKw(double v) { externalChargingPowerKw = v; return this; }
+        public Builder chargePowerKw(double v) { chargePowerKw = v; return this; }
         public Builder hvPackVoltage(double v) { hvPackVoltage = v; return this; }
         public Builder gearMode(int v) { gearMode = v; return this; }
         public Builder tyrePressure(int[] v) { tyrePressure = v; return this; }

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -476,34 +476,19 @@ public class MqttConnectionManager {
             }
             if (soc >= 0) payload.put("soc", soc);
 
-            // power — sign convention: positive = discharge, negative = charge.
-            // Sources: enginePowerKw while driving, then negated charging power.
+            // power — motor/propulsion power (kW). Positive = consuming, negative = regen.
+            // Only meaningful while the car is on: the motor signal idles at ~-2 kW noise when
+            // parked, so force 0 when ACC is off. Charge power is reported separately as
+            // charge_power — the motor signal does not see the OBC→pack charge path.
             try {
-                boolean powerSet = false;
-                if (vd != null && !Double.isNaN(vd.enginePowerKw)
-                        && Math.abs(vd.enginePowerKw) > 0.1
+                boolean accOn = false;
+                try { accOn = com.overdrive.app.monitor.AccMonitor.isAccOn(); } catch (Throwable ignored) {}
+                double motorKw = 0;
+                if (accOn && vd != null && !Double.isNaN(vd.enginePowerKw)
                         && Math.abs(vd.enginePowerKw) <= 300) {
-                    payload.put("power", vd.enginePowerKw);
-                    powerSet = true;
+                    motorKw = vd.enginePowerKw;
                 }
-                if (!powerSet) {
-                    // Prefer externalChargingPowerKw (InstrumentDevice) — real charger-reported power.
-                    // ChargingDevice.getChargingPower() is broken on most BYD models (returns 0).
-                    // Threshold 0.15 kW filters phantom readings when charger is unplugged.
-                    double chargingPower = 0;
-                    if (vd != null && !Double.isNaN(vd.externalChargingPowerKw) && vd.externalChargingPowerKw > 0.15) {
-                        chargingPower = vd.externalChargingPowerKw;
-                    } else if (vd != null && !Double.isNaN(vd.chargingPowerKw) && vd.chargingPowerKw > 0.15) {
-                        chargingPower = vd.chargingPowerKw;
-                    }
-
-                    ChargingStateData chargingData = vehicleDataMonitor.getChargingState();
-                    boolean isChg = (chargingData != null && chargingData.status == ChargingStateData.ChargingStatus.CHARGING)
-                                    || chargingPower > 0.15;
-                    double monitorPower = chargingPower > 0 ? chargingPower
-                            : (chargingData != null ? chargingData.chargingPowerKW : 0);
-                    payload.put("power", isChg && monitorPower > 0.1 ? -monitorPower : 0);
-                }
+                payload.put("power", motorKw);
             } catch (Exception e) {
                 payload.put("power", 0);
             }
@@ -538,10 +523,22 @@ public class MqttConnectionManager {
             payload.put("is_charging", isCharging ? 1 : 0);
 
             // is_dcfc
+            boolean v2l = false;
             if (vd != null && vd.chargingGunState != BydVehicleData.UNAVAILABLE) {
                 payload.put("is_dcfc", vd.chargingGunState == 3 ? 1 : 0);
-                if (vd.chargingGunState == 4) payload.put("is_charging", 0); // V2L
+                if (vd.chargingGunState == 4) { payload.put("is_charging", 0); v2l = true; } // V2L
             }
+
+            // charge_power — DC charge power into the pack (kW), from InstrumentDevice.getChargePower().
+            // Only meaningful while charging: getChargePower() returns garbage (~359) when idle, so
+            // gate on the charging state and a sane upper bound; 0 otherwise. This is the real charge
+            // rate (matches the BYD app / cloud battery_power, e.g. 2.9 kW on a 15 A AC charge).
+            double chargeKw = 0;
+            if (isCharging && !v2l && vd != null && !Double.isNaN(vd.chargePowerKw)
+                    && vd.chargePowerKw > 0.1 && vd.chargePowerKw <= 300) {
+                chargeKw = vd.chargePowerKw;
+            }
+            payload.put("charge_power", chargeKw);
 
             // is_parked
             boolean isParked = false;

--- a/app/src/main/java/com/overdrive/app/mqtt/TelemetryFieldCatalog.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/TelemetryFieldCatalog.java
@@ -76,6 +76,7 @@ public final class TelemetryFieldCatalog {
         // ---------- Core driving / energy ----------
         add("soc",        "State of Charge", SENSOR, "battery",     MEAS, "%",    "mdi:battery",            false, 0.1);
         add("power",      "Power",           SENSOR, "power",       MEAS, "kW",   "mdi:flash",              false, 0.1);
+        add("charge_power","Charge Power",   SENSOR, "power",       MEAS, "kW",   "mdi:battery-charging",   false, 0.1);
         add("speed",      "Speed",           SENSOR, "speed",       MEAS, "km/h", "mdi:speedometer",        false, 0.1);
         add("lat",        "Latitude",        SENSOR, null,          MEAS, "°",    "mdi:latitude",           true,  0.00001);
         add("lon",        "Longitude",       SENSOR, null,          MEAS, "°",    "mdi:longitude",          true,  0.00001);


### PR DESCRIPTION
## What does this PR do?
Two fixes to the power values published to Home Assistant:
- `power` now reports motor/propulsion power only, and 0 when the car is off (it was publishing the ~−2 kW idle noise as real power).
- Adds `charge_power`, the real DC charge rate into the pack, from `InstrumentDevice.getChargePower()`. 0 when not charging.

## Why is this change needed?
The motor signal idles around −2 kW when parked, so HA showed a bogus "power" on a parked car. It also never sees the OBC→pack charge path, so it read ~0 while the car charged at 2.9 kW. `getChargePower()` reports the real charge rate directly (matches the BYD app and cloud battery_power); `getExternalChargingPower()` returns a 104857.5 sentinel on this trim, which is why charging power was missing before. Splitting the two into separate fields keeps each one meaningful.

## How to test
- Drive: `power` shows motor power (positive accel, negative regen), `charge_power` stays 0.
- Park and switch off: `power` reads 0 (no idle noise).
- Plug in and charge: `charge_power` shows the real kW (~2.9 on a 15 A AC charge), `power` stays 0.
- `./gradlew assembleDebug` passes. Verified on a BYD Seal over real drives and an AC charge.
