### PR TITLE
Report is_parked when the car is powered off

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -543,12 +543,19 @@ public class MqttConnectionManager {
                 if (vd.chargingGunState == 4) payload.put("is_charging", 0); // V2L
             }
 
-            // is_parked
+            // is_parked — gear==P, OR the car is powered off. When ACC is off the gear signal
+            // isn't actively polled and carries forward its last value (e.g. R after backing into
+            // a spot), so gear alone would wrongly report not-parked while the car sits switched
+            // off. A powered-off car is always parked.
             boolean isParked = false;
             if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 isParked = vd.gearMode == GearMonitor.GEAR_P;
             } else {
                 isParked = gearMonitor.getCurrentGear() == GearMonitor.GEAR_P;
+            }
+            if (!isParked) {
+                try { if (!com.overdrive.app.monitor.AccMonitor.isAccOn()) isParked = true; }
+                catch (Throwable ignored) {}
             }
             payload.put("is_parked", isParked ? 1 : 0);
 


### PR DESCRIPTION
## What does this PR do?
`is_parked` now reports parked when the car is switched off, regardless of the last gear.

## Why is this change needed?
`is_parked` was derived from `gear == P` only. When the car is off, the gear signal isn't polled and carries forward its last value, so parking in anything but P (e.g. backing into a spot, ending in R) left `is_parked` at 0 while the car sat switched off. Anything keyed off it (trip tracking, automations) never saw the car as parked.

## How to test
- Park ending in R or D, switch off: `is_parked` reads 1 (was 0).
- Park in P, switch off: still 1.
- Stopped in D at a light with the car on: still 0 (not parked).
- `./gradlew assembleDebug` passes. Verified on a BYD Seal: `is_parked` toggled off while driving and back on when parked, even with gear stuck at R.
