### PR TITLE
HA discovery: re-announce late-populating fields, and keep them sticky on reconnect

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/HomeAssistantDiscovery.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/HomeAssistantDiscovery.java
@@ -59,7 +59,8 @@ public final class HomeAssistantDiscovery {
      *                 so PHEV-only / model-specific fields don't create dead entities.
      */
     public static String buildBundle(String deviceId, String vin, String model, String swVersion,
-                                     String baseTopic, JSONObject snapshot, boolean includeControls) {
+                                     String baseTopic, JSONObject snapshot,
+                                     java.util.Set<String> stickyKeys, boolean includeControls) {
         String node = nodeId(deviceId);
         String availabilityTopic = baseTopic + "/availability";
 
@@ -105,6 +106,24 @@ public final class HomeAssistantDiscovery {
                 if (!TelemetryFieldCatalog.isDiscoverable(key)) continue;
                 if (snapshot.opt(key) instanceof JSONArray) continue; // arrays aren't single entities
                 cmps.put(key, component(node, baseTopic, TelemetryFieldCatalog.get(key)));
+            }
+
+            // Sticky keys: a discoverable field that populates intermittently (e.g. hv_pack_v,
+            // derived from cell data + pack capacity) can be ABSENT from this particular snapshot.
+            // The caller's announcedKeys set is monotonic, so once a field has been announced we
+            // keep its component here even when it's momentarily missing. Otherwise a re-announce
+            // fired while it's absent would drop it from the bundle, and the re-announce trigger
+            // (which only fires for keys NOT yet announced) would never re-add it — leaving the
+            // entity orphaned/Unavailable in HA until a full reset (notably after an HA restart).
+            // The component is built from the static catalog (no live value needed), and the
+            // field's retained state already lives on its own state_topic, so HA rebinds it on the
+            // next connect/restart.
+            if (stickyKeys != null) {
+                for (String key : stickyKeys) {
+                    if (cmps.has(key)) continue;
+                    if (!TelemetryFieldCatalog.isDiscoverable(key)) continue;
+                    cmps.put(key, component(node, baseTopic, TelemetryFieldCatalog.get(key)));
+                }
             }
 
             // device_tracker for GPS (attributes carry lat/lon; map dot in HA)

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
@@ -62,6 +62,10 @@ public class MqttPublisherService implements MqttCallback {
     private final TelemetryDiffer differ = new TelemetryDiffer();
     private volatile boolean forceFullResend = false;
     private volatile boolean discoveryAnnounced = false;
+    // Discoverable keys already covered by the announced bundle. Grows as fields appear so a
+    // late-populating field (e.g. hv_pack_v, which needs cells + pack capacity, so it shows up
+    // after the first publish) triggers a re-announce instead of never getting a component.
+    private final java.util.Set<String> announcedKeys = new java.util.HashSet<>();
     private volatile MqttCommandRouter commandRouter;
     private volatile String haVin = null;
     private volatile String haModel = null;
@@ -361,6 +365,11 @@ public class MqttPublisherService implements MqttCallback {
 
         if (config.isHomeAssistant()) {
             if (!ensureConnected()) return false;
+            // Re-announce if a discoverable field has appeared that the last bundle didn't cover
+            // (fields populate at different times; the first publish doesn't have them all yet).
+            if (discoveryAnnounced && !announcedKeys.containsAll(discoverableKeys(snapshot))) {
+                discoveryAnnounced = false;
+            }
             if (!discoveryAnnounced) announceDiscovery(snapshot);
 
             boolean sendAll = first || heartbeat || !config.changeOnly;
@@ -501,7 +510,9 @@ public class MqttPublisherService implements MqttCallback {
                     config.topic, snapshot, config.isControlEnabled());
             if (publishString(topic, bundle, true, 1)) {
                 discoveryAnnounced = true;
-                logger.info("Published HA discovery bundle to " + topic);
+                announcedKeys.addAll(discoverableKeys(snapshot));
+                logger.info("Published HA discovery bundle to " + topic
+                        + " (" + announcedKeys.size() + " keys)");
             }
         } catch (Exception e) {
             logger.warn("HA discovery announce failed: " + e.getMessage());

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
@@ -506,8 +506,11 @@ public class MqttPublisherService implements MqttCallback {
     private void announceDiscovery(JSONObject snapshot) {
         try {
             String topic = HomeAssistantDiscovery.deviceConfigTopic(config.discoveryPrefix, deviceId);
+            // Pass announcedKeys as sticky so a field that's momentarily absent from this snapshot
+            // (e.g. the derived hv_pack_v) isn't dropped from the bundle on a re-announce — that
+            // drop is what left fields Unavailable in HA after a restart.
             String bundle = HomeAssistantDiscovery.buildBundle(deviceId, haVin, haModel, haSwVersion,
-                    config.topic, snapshot, config.isControlEnabled());
+                    config.topic, snapshot, announcedKeys, config.isControlEnabled());
             if (publishString(topic, bundle, true, 1)) {
                 discoveryAnnounced = true;
                 announcedKeys.addAll(discoverableKeys(snapshot));


### PR DESCRIPTION
Re-opens the work from #128 (which GitHub wouldn't let me reopen) with a follow-up fix. Two commits:

**1. Re-announce when a late-populating field first appears** (`1022b1c`, the original #128)

The device discovery bundle is built once on the first publish, from the keys present in that snapshot, and only re-announced on an HA birth message. A field that populates later never gets a component, so HA never creates an entity for it. `hv_pack_v` is the case that hit me: it needs cell voltages + pack capacity, so it shows up after the first publish and was missing from the bundle. Fix: track the discoverable keys the announced bundle already covers, and re-announce when a new one shows up.

**2. Keep previously-announced fields in the bundle** (`756a27f`, the new fix)

The re-announce above rebuilt the bundle from the current snapshot only, but `announcedKeys` is monotonic. A field momentarily absent when a re-announce fires (e.g. right after an HA restart / birth message) gets dropped from the bundle, and since the trigger only fires for keys *not yet* announced, it never returns. The entity ends up stuck Unavailable until a full reset. Fix: keep any already-announced discoverable key in the bundle even when it's absent from the current snapshot, rebuilt from the static catalog; its retained state lives on its own `state_topic`, so HA rebinds on reconnect.

Supersedes #128.