### PR TITLE
Back off the adb auth polling instead of hammering adbd every 3s

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
@@ -374,9 +374,18 @@ class AdbShellExecutor(private val context: Context) {
             
             while (isAuthPending.get() && attempts < maxAttempts) {
                 attempts++
-                
+
                 try {
-                    Thread.sleep(3000)
+                    // [local] Back off so a STUCK connection doesn't hammer adbd every 3s. Each
+                    // poll re-opens a TCP + dadb connect to 127.0.0.1:5555; at a 3s cadence that
+                    // churns adbd and flaps any external adb-over-wifi session (observed 2026-07-01:
+                    // laptop adb cycling device->offline while OverDrive was stuck relaunching
+                    // daemons post-reboot). Quick first tries still catch a transient blip / a
+                    // first-time auth grant; then stretch to a 30s ceiling so a persistently-stuck
+                    // OverDrive polls at most every 30s and stops interrupting adb.
+                    val backoffMs = if (attempts <= 3) 3000L
+                                    else minOf(3000L * (1L shl minOf(attempts - 3, 4)), 30000L)
+                    Thread.sleep(backoffMs)
                 } catch (e: InterruptedException) {
                     logger.debug(TAG, "Polling interrupted")
                     break


### PR DESCRIPTION
## What does this PR do?
Adds exponential backoff to the daemon-launch auth polling: 3 s for the first three attempts, then doubling up to a 30 s ceiling. Resets once a shell is authorized.

## Why is this change needed?
When the app can't launch its daemons (RSA prompt unanswered, adbd busy), it retried every 3 s forever. That churns adbd and can flap an external wireless-adb session that's connected to the same port. With backoff the stuck state settles to a poll every 30 s, and recovery is still quick when auth arrives early.

## How to test
- Fresh install, don't accept the RSA prompt: logcat shows the poll interval growing 3 s → 30 s.
- Accept the prompt: daemons launch on the next poll, interval resets.
- `./gradlew assembleDebug` passes. Running on my Seal since early July.