### PR TITLE
Append to ssc_whitelist instead of overwriting it

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/ServiceLauncher.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/ServiceLauncher.kt
@@ -209,9 +209,13 @@ class ServiceLauncher(
             "appops set $packageName WAKE_LOCK allow 2>/dev/null",
             // Method 4: Disable battery optimization
             "dumpsys deviceidle whitelist +$packageName 2>/dev/null",
-            // Method 5: BYD Start Control whitelist
-            "settings put global ssc_whitelist '$packageName' 2>/dev/null",
-            "settings put secure ssc_whitelist '$packageName' 2>/dev/null",
+            // Method 5: BYD Start Control whitelist — APPEND (merge), never
+            // overwrite. The old `settings put ... '$packageName'` clobbered the
+            // whole list to just OverDrive, wiping any co-installed app (e.g. the
+            // standalone head-unit keep-alive) that had added itself. Read
+            // current, add ourselves only if absent, preserve the rest.
+            "CUR=\$(settings get global ssc_whitelist 2>/dev/null); [ \"\$CUR\" = null ] && CUR=; case \",\$CUR,\" in *,$packageName,*) ;; *) settings put global ssc_whitelist \"\${CUR:+\$CUR,}$packageName\" 2>/dev/null;; esac",
+            "CUR=\$(settings get secure ssc_whitelist 2>/dev/null); [ \"\$CUR\" = null ] && CUR=; case \",\$CUR,\" in *,$packageName,*) ;; *) settings put secure ssc_whitelist \"\${CUR:+\$CUR,}$packageName\" 2>/dev/null;; esac",
             // Method 6: BYD app startup manager
             "content call --uri content://com.byd.appstartup/whitelist --method add --arg '$packageName' 2>/dev/null",
             "cmd appops set $packageName AUTO_START allow 2>/dev/null",


### PR DESCRIPTION
## What does this PR do?
`injectAccWhitelist` now reads the current `ssc_whitelist` value and adds `com.overdrive.app` only if absent, preserving whatever else is in the list. Same for the `secure` copy. It used to write the whole setting to just our package.

## Why is this change needed?
The whitelist is a shared system list. Overwriting it wipes any other app the user has added (I hit this with a second sideloaded app that adds itself to the same list — every OverDrive launch clobbered it). Append keeps OverDrive working and leaves the rest of the list alone. Idempotent, so repeated launches don't grow it.

## How to test
- `settings put global ssc_whitelist some.other.app`, launch OverDrive, then `settings get global ssc_whitelist` → `some.other.app,com.overdrive.app`.
- Relaunch a few times → no duplicates.
- Verified live on my Seal with both apps coexisting.