### PR TITLE
Publish SoC with decimal precision

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -466,13 +466,18 @@ public class MqttConnectionManager {
             // utc
             payload.put("utc", now / 1000);
 
-            // soc
+            // soc — prefer the decimal monitor source. BatterySocMonitor reads
+            // getElecPercentageValue() as a Double + the onElecPercentageChanged(double)
+            // event, so it carries 1-decimal precision (same source the trip chart uses).
+            // vd.socPercent comes from the STATISTIC poll, which is integer-valued on this
+            // trim, so it's only a fallback. Rounded to 1 decimal to match the 0.1 deadband.
             double soc = -1;
-            if (vd != null && !Double.isNaN(vd.socPercent)) {
+            BatterySocData socData = vehicleDataMonitor.getBatterySoc();
+            if (socData != null && !Double.isNaN(socData.socPercent)
+                    && socData.socPercent >= 0 && socData.socPercent <= 100) {
+                soc = Math.round(socData.socPercent * 10.0) / 10.0;
+            } else if (vd != null && !Double.isNaN(vd.socPercent)) {
                 soc = vd.socPercent;
-            } else {
-                BatterySocData socData = vehicleDataMonitor.getBatterySoc();
-                if (socData != null) soc = socData.socPercent;
             }
             if (soc >= 0) payload.put("soc", soc);
 


### PR DESCRIPTION
## What does this PR do?
Sources the MQTT `soc` field from `BatterySocMonitor.getBatterySoc()` (1-decimal, same source the trip chart uses), with the integer `vd.socPercent` as fallback. Rounded to 1 decimal.

## Why is this change needed?
`vd.socPercent` comes from the STATISTIC poll and is integer-valued on this trim, so HA only saw whole percent steps. The monitor reads `getElecPercentageValue()` as a double and carries real tenths — nicer charge curves, and the 0.1 change-detection deadband actually means something.

## How to test
- Charge or drive: HA `soc` shows tenths (e.g. 82.4) instead of jumping 82 → 83.
- Values match the trip chart's SoC trace.
- `./gradlew assembleDebug` passes. Verified over several charges on my Seal.