### PR TITLE
Source gear and is_parked from the 5Hz GearMonitor

### DIFF
--- a/app/src/main/java/com/overdrive/app/monitor/GearMonitor.java
+++ b/app/src/main/java/com/overdrive/app/monitor/GearMonitor.java
@@ -43,6 +43,10 @@ public class GearMonitor {
     private volatile boolean isRunning = false;
     private volatile int currentGear = GEAR_P;
     private long lastUpdateTime = 0;
+
+    /** Whether the 200ms poll thread is active — i.e. getCurrentGear() is fresh
+     *  to within ~POLL_INTERVAL_MS rather than a cold initial value. */
+    public boolean isActive() { return isRunning; }
     
     // TelemetryDataCollector reference — when set, read gear from its cached snapshot
     // instead of polling the BYD device directly (avoids duplicate CAN bus reads)

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -559,8 +559,13 @@ public class MqttConnectionManager {
             // isn't actively polled and carries forward its last value (e.g. R after backing into
             // a spot), so gear alone would wrongly report not-parked while the car sits switched
             // off. A powered-off car is always parked.
+            // Gear source preference: the 5Hz GearMonitor poller (fresh within ~200ms) over the
+            // 5s/90s collector snapshot — via the snapshot a P→D shift took 10-14s to reach
+            // consumers. Snapshot stays as the fallback when the monitor isn't running.
             boolean isParked = false;
-            if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
+            if (gearMonitor.isActive()) {
+                isParked = gearMonitor.getCurrentGear() == GearMonitor.GEAR_P;
+            } else if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 isParked = vd.gearMode == GearMonitor.GEAR_P;
             } else {
                 isParked = gearMonitor.getCurrentGear() == GearMonitor.GEAR_P;
@@ -613,7 +618,13 @@ public class MqttConnectionManager {
             }
 
             // gear (extra field not in ABRP — useful for MQTT consumers)
-            if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
+            // Prefer the 5Hz GearMonitor poller (fresh within ~200ms) over the 5s/90s
+            // collector snapshot: via the snapshot a P→D shift took 10-14s to reach HA,
+            // and the gearbox SDK listener can't be used (crashes as uid 2000). The
+            // snapshot stays as the fallback when the monitor isn't running.
+            if (gearMonitor.isActive()) {
+                payload.put("gear", GearMonitor.gearToString(gearMonitor.getCurrentGear()));
+            } else if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 payload.put("gear", GearMonitor.gearToString(vd.gearMode));
             } else {
                 payload.put("gear", GearMonitor.gearToString(gearMonitor.getCurrentGear()));


### PR DESCRIPTION
## What does this PR do?
`gear` and `is_parked` now prefer the running `GearMonitor` (200 ms poll) over the collector snapshot, keeping the snapshot as fallback when the monitor isn't active. Adds an `isActive()` accessor to `GearMonitor`.

## Why is this change needed?
The snapshot updates every 5 s driving / 90 s parked, so a P→D shift took 10-14 s to reach MQTT consumers. The trip recorder already trusts the GearMonitor for exactly this reason (the gearbox SDK listener can't be used — it crashes under uid 2000, hence the poll). With this change HA sees a gear change in a second or two.

## How to test
- Shift P→D with HA open: `gear` flips in ~1-2 s instead of 10+.
- Kill the monitor (or early startup): values still arrive via the snapshot path.
- `./gradlew assembleDebug` passes. Drive-verified on my Seal.