### PR TITLE
Force speed=0 and gear=P when ACC is off

### DIFF
--- a/app/src/main/java/com/overdrive/app/monitor/GearMonitor.java
+++ b/app/src/main/java/com/overdrive/app/monitor/GearMonitor.java
@@ -43,6 +43,10 @@ public class GearMonitor {
     private volatile boolean isRunning = false;
     private volatile int currentGear = GEAR_P;
     private long lastUpdateTime = 0;
+
+    /** Whether the 200ms poll thread is active — i.e. getCurrentGear() is fresh
+     *  to within ~POLL_INTERVAL_MS rather than a cold initial value. */
+    public boolean isActive() { return isRunning; }
     
     // TelemetryDataCollector reference — when set, read gear from its cached snapshot
     // instead of polling the BYD device directly (avoids duplicate CAN bus reads)

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -559,8 +559,13 @@ public class MqttConnectionManager {
             // isn't actively polled and carries forward its last value (e.g. R after backing into
             // a spot), so gear alone would wrongly report not-parked while the car sits switched
             // off. A powered-off car is always parked.
+            // Gear source preference: the 5Hz GearMonitor poller (fresh within ~200ms) over the
+            // 5s/90s collector snapshot — via the snapshot a P→D shift took 10-14s to reach
+            // consumers. Snapshot stays as the fallback when the monitor isn't running.
             boolean isParked = false;
-            if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
+            if (gearMonitor.isActive()) {
+                isParked = gearMonitor.getCurrentGear() == GearMonitor.GEAR_P;
+            } else if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 isParked = vd.gearMode == GearMonitor.GEAR_P;
             } else {
                 isParked = gearMonitor.getCurrentGear() == GearMonitor.GEAR_P;
@@ -613,7 +618,13 @@ public class MqttConnectionManager {
             }
 
             // gear (extra field not in ABRP — useful for MQTT consumers)
-            if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
+            // Prefer the 5Hz GearMonitor poller (fresh within ~200ms) over the 5s/90s
+            // collector snapshot: via the snapshot a P→D shift took 10-14s to reach HA,
+            // and the gearbox SDK listener can't be used (crashes as uid 2000). The
+            // snapshot stays as the fallback when the monitor isn't running.
+            if (gearMonitor.isActive()) {
+                payload.put("gear", GearMonitor.gearToString(gearMonitor.getCurrentGear()));
+            } else if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 payload.put("gear", GearMonitor.gearToString(vd.gearMode));
             } else {
                 payload.put("gear", GearMonitor.gearToString(gearMonitor.getCurrentGear()));

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -626,11 +626,21 @@ public class MqttConnectionManager {
             }
 
             // gear (extra field not in ABRP — useful for MQTT consumers)
-            // Prefer the 5Hz GearMonitor poller (fresh within ~200ms) over the 5s/90s
-            // collector snapshot: via the snapshot a P→D shift took 10-14s to reach HA,
-            // and the gearbox SDK listener can't be used (crashes as uid 2000). The
-            // snapshot stays as the fallback when the monitor isn't running.
-            if (gearMonitor.isActive()) {
+            // ACC off → force P: the bus gear signal (and GearMonitor's poll) FREEZES at
+            // the last driven gear when the car powers off (e.g. R after backing into a
+            // spot), but the car physically auto-shifts to P at shutdown — it cannot sit
+            // powered-off in R. Same stale-signal handling as speed→0 and power→0 above;
+            // the ACC-edge flush ships the P within a couple of seconds of key-off.
+            // While ACC is on: prefer the 5Hz GearMonitor poller (fresh within ~200ms)
+            // over the 5s/90s collector snapshot — via the snapshot a P→D shift took
+            // 10-14s to reach HA, and the gearbox SDK listener can't be used (crashes
+            // as uid 2000). The snapshot stays as the fallback when the monitor isn't
+            // running.
+            boolean accOnGear = false;
+            try { accOnGear = com.overdrive.app.monitor.AccMonitor.isAccOn(); } catch (Throwable ignored) {}
+            if (!accOnGear) {
+                payload.put("gear", GearMonitor.gearToString(GearMonitor.GEAR_P));
+            } else if (gearMonitor.isActive()) {
                 payload.put("gear", GearMonitor.gearToString(gearMonitor.getCurrentGear()));
             } else if (vd != null && vd.gearMode != BydVehicleData.UNAVAILABLE) {
                 payload.put("gear", GearMonitor.gearToString(vd.gearMode));

--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -493,8 +493,16 @@ public class MqttConnectionManager {
                 payload.put("power", 0);
             }
 
-            // speed
-            if (vd != null && !Double.isNaN(vd.speedKmh)) {
+            // speed — the bus speed signal freezes at its last sample when ACC is off
+            // (BydDataCollector drops to a 90s poll and the speed listener stops firing), so a
+            // stale non-zero value would keep publishing after parking and HA would think the car
+            // is still moving. The car is parked when ACC is off, so force 0 — same handling as
+            // power above. GPS stays a driving-only fallback for a momentary NaN bus speed.
+            boolean accOnSpeed = false;
+            try { accOnSpeed = com.overdrive.app.monitor.AccMonitor.isAccOn(); } catch (Throwable ignored) {}
+            if (!accOnSpeed) {
+                payload.put("speed", 0);
+            } else if (vd != null && !Double.isNaN(vd.speedKmh)) {
                 payload.put("speed", vd.speedKmh);
             } else if (gpsMonitor.hasLocation()) {
                 payload.put("speed", gpsMonitor.getSpeed() * 3.6);


### PR DESCRIPTION
## What does this PR do?
When ACC is off, `speed` publishes 0 and `gear` publishes P, mirroring the existing ACC-off guard on `power`.

Stacked on #138 (gear source) since both touch the same block — merge that first, this branch includes its commit.

## Why is this change needed?
The bus signals freeze at their last driven value when the car powers off — the collector drops to its 90 s parked poll and just re-reads the stale sample. I had a parked car publishing `speed: 1.0` for 16 minutes and `gear: R` all night after backing into a spot. The car physically auto-shifts to P at shutdown, so P is the true state, and a powered-off car isn't moving. Same reasoning as the `power` guard that's already there.

## How to test
- Drive, park, switch off: `speed` goes 0 and `gear` goes P within a couple of seconds (the ACC-edge flush ships it).
- While driving nothing changes.
- `./gradlew assembleDebug` passes. Drive-verified on my Seal.