### PR TITLE
GPS at its real 1Hz instead of 0.25Hz

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionManager.java
@@ -444,6 +444,34 @@ public class MqttConnectionManager {
     // ==================== TELEMETRY COLLECTION ====================
 
     /**
+     * Return a shallow copy of {@code base} with the position fields refreshed to the current GPS
+     * fix. Used on a telemetry-cache hit so the GPS track publishes at the publish-cycle rate
+     * (e.g. 1Hz) instead of being frozen to the 2s telemetry cache, while the expensive BYD SDK
+     * fields stay cached. Mirrors the lat/lon/elevation/heading block in {@link #collectTelemetry()}.
+     * Copies rather than mutating {@code base} because the cached object is shared across connections.
+     */
+    private JSONObject withLiveGps(JSONObject base) {
+        try {
+            JSONObject copy = new JSONObject();
+            for (java.util.Iterator<String> it = base.keys(); it.hasNext(); ) {
+                String k = it.next();
+                copy.put(k, base.opt(k));
+            }
+            if (gpsMonitor != null && gpsMonitor.hasLocation()) {
+                copy.put("lat", gpsMonitor.getLatitude());
+                copy.put("lon", gpsMonitor.getLongitude());
+                double alt = gpsMonitor.getAltitude();
+                if (alt != 0) copy.put("elevation", alt);
+                float heading = gpsMonitor.getHeading();
+                if (heading > 0) copy.put("heading", heading);
+            }
+            return copy;
+        } catch (Exception e) {
+            return base; // on any failure, fall back to the cached snapshot unchanged
+        }
+    }
+
+    /**
      * Collect telemetry from all data sources.
      * Same fields as ABRP Gold Standard payload for consistency.
      */
@@ -452,8 +480,15 @@ public class MqttConnectionManager {
 
         // If we collected data less than 2 seconds ago, return the cached copy immediately.
         // This protects the BYD hardware from being spammed by multiple MQTT threads.
+        //
+        // BUT position must not be frozen to that 2s cache: GPS comes from the in-memory GpsMonitor
+        // (~1Hz, cheap to read — no BYD SDK hit), and serving the cached snapshot capped the
+        // published track at ~0.5Hz and lagged the position (visible as corner-cutting + start/stop
+        // gaps in HA). Refresh just the position fields onto a COPY of the cached snapshot so the
+        // track publishes at the full publish-cycle rate. Copy, not mutate: the cached object is
+        // shared with other connections that read it concurrently.
         if (lastCachedTelemetry != null && (now - lastCollectionTimeMs) < TELEMETRY_CACHE_TTL_MS) {
-            return lastCachedTelemetry;
+            return withLiveGps(lastCachedTelemetry);
         }
 
         JSONObject payload = new JSONObject();

--- a/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
+++ b/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
@@ -282,7 +282,18 @@ public class LocationSidecarService extends Service implements LocationListener 
             // IPC/disk spam happens downstream in onLocationChanged (the
             // distance/time gate), NOT at the provider — coarsening the
             // provider here would starve hazard approach detection.
-            if (locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)) {
+            //
+            // Register UNCONDITIONALLY — never gate on isProviderEnabled().
+            // The head unit disables location (location_mode=0) whenever the
+            // car is off, and app (re)starts almost always happen parked, so
+            // an isProviderEnabled gate here meant the listener was NEVER
+            // registered for that app instance and the callback path never
+            // delivered — fixes then only arrived via the periodic
+            // getLastKnownLocation poll, riding on the factory nav's own GPS
+            // request while driving. Android accepts registration while a
+            // provider is disabled and starts delivering the moment it comes
+            // on (ACC-on) — exactly the behavior we want.
+            try {
                 locationManager.requestLocationUpdates(
                     LocationManager.GPS_PROVIDER,
                     1000,  // 1 second
@@ -290,12 +301,15 @@ public class LocationSidecarService extends Service implements LocationListener 
                     this,
                     workerThread.getLooper()  // deliver off the UI thread
                 );
-                Log.i(TAG, "GPS provider started (1s/0m)");
+                Log.i(TAG, "GPS provider registered (1s/0m), enabled="
+                        + locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER));
+            } catch (Exception e) {
+                Log.e(TAG, "GPS provider registration failed: " + e.getMessage());
             }
 
             // Also use network provider as fallback. 5s cadence is fine; keep
             // min-distance 0 so it doesn't pre-filter fixes the gate wants.
-            if (locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+            try {
                 locationManager.requestLocationUpdates(
                     LocationManager.NETWORK_PROVIDER,
                     5000,  // 5 seconds
@@ -303,7 +317,10 @@ public class LocationSidecarService extends Service implements LocationListener 
                     this,
                     workerThread.getLooper()  // deliver off the UI thread
                 );
-                Log.i(TAG, "Network provider started (5s/0m)");
+                Log.i(TAG, "Network provider registered (5s/0m), enabled="
+                        + locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER));
+            } catch (Exception e) {
+                Log.e(TAG, "Network provider registration failed: " + e.getMessage());
             }
             
             // Get last known location immediately

--- a/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
+++ b/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
@@ -191,9 +191,13 @@ public class LocationSidecarService extends Service implements LocationListener 
             @Override
             public void run() {
                 sendGpsViaTcp();
-                
-                // If no fresh GPS fix in 30 seconds, request one explicitly
-                // This handles cases where the provider stopped sending updates
+
+                // Poll the provider's last-known fix and process it. Our own 1s
+                // GPS request (requestLocationUpdates GPS_PROVIDER, 1000ms) keeps
+                // the provider PRODUCING fixes at ~1Hz, so its last-known cache is
+                // fresh at ~1Hz even if the onLocationChanged callback isn't
+                // delivering on this background looper — this poll then picks up a
+                // fresh distinct fix each tick.
                 if (permissionGranted && locationManager != null) {
                     try {
                         Location lastGps = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
@@ -201,7 +205,7 @@ public class LocationSidecarService extends Service implements LocationListener 
                             long fixAge = System.currentTimeMillis() - lastGps.getTime();
                             if (fixAge < 10000) {
                                 // Fresh fix available that we might have missed
-                                onLocationChanged(lastGps);
+                                processFix(lastGps);
                             }
                         }
                     } catch (SecurityException e) {
@@ -210,13 +214,15 @@ public class LocationSidecarService extends Service implements LocationListener 
                         // Ignore
                     }
                 }
-                
-                // Periodic keep-alive / daemon-restart recovery. Kept at 4s
-                // (down from the original 2s for CPU/IPC savings, but well
-                // under RoadSense's 5s fix-staleness cutoff) so that when the
-                // car is truly stationary and the provider emits no callbacks,
-                // GpsMonitor.lastUpdate never ages past the consumer threshold.
-                handler.postDelayed(this, 4000);
+
+                // Periodic keep-alive / poll / daemon-restart recovery. Dropped
+                // from 4000ms -> 1000ms: at 4s this poll was the ONLY thing
+                // advancing GpsMonitor (the provider callback wasn't delivering),
+                // capping GPS at ~0.25Hz across both the MQTT feed AND the internal
+                // trip track. 1s makes GpsMonitor ~1Hz. Still well under RoadSense's
+                // 5s fix-staleness cutoff; CPU/IPC cost of a localhost write + one
+                // file cache per second is negligible (was 2s originally).
+                handler.postDelayed(this, 1000);
             }
         };
         handler.postDelayed(periodicSender, 5000);
@@ -348,6 +354,11 @@ public class LocationSidecarService extends Service implements LocationListener 
 
     @Override
     public void onLocationChanged(Location location) {
+        processFix(location);
+    }
+
+    /** Process a fix from either the provider callback or the periodic poll. */
+    private void processFix(Location location) {
         if (location == null) return;
 
         long now = System.currentTimeMillis();


### PR DESCRIPTION
## What does this PR do?
Three related fixes so positions flow at the rate the GNSS actually produces them:
- Register the location listeners unconditionally instead of gating on `isProviderEnabled()` at service start — provider on/off is handled by the provider events themselves.
- Poll `getLastKnownLocation` at 1 s (was 4 s) as the keep-alive/recovery path.
- Publish the position fresh each MQTT cycle instead of through the 2 s telemetry cache.

## Why is this change needed?
If the app (re)starts while location is off — which is every start on a parked car, since the head unit flips location off at key-off — the `isProviderEnabled` gate meant the listeners were never registered. GPS then fed only from the 4 s poll: 0.25 Hz across both the MQTT feed and the internal trip track, on hardware that delivers clean 1 Hz fixes. Measured on my Seal: internal trip tracks went from ~25% distinct points to ~96%, and the HA position cadence from ~4.1 s to ~1.6 s median.

## How to test
- Start the app with location off, then drive: positions update ~1 Hz.
- `/api/trips` track for the drive has ~one distinct point per second (was one per 4 s).
- `./gradlew assembleDebug` passes. Drive-verified over multiple trips.