### PR TITLE
Localize BYD Seagull as Dolphin Mini for pt-BR

### DIFF
--- a/app/src/main/assets/web/i18n/en.json
+++ b/app/src/main/assets/web/i18n/en.json
@@ -2030,6 +2030,7 @@
     "copy_code": "Copy code"
   },
   "vehicle": {
+    "model_name_seagull": "BYD Seagull",
     "car_locked": "Car locked",
     "car_unlocked": "Car unlocked",
     "lock_failed": "Lock failed",

--- a/app/src/main/assets/web/i18n/pt-BR.json
+++ b/app/src/main/assets/web/i18n/pt-BR.json
@@ -2030,6 +2030,7 @@
     "copy_code": "Copiar código"
   },
   "vehicle": {
+    "model_name_seagull": "BYD Dolphin Mini",
     "car_locked": "Carro travado",
     "car_unlocked": "Carro destravado",
     "lock_failed": "Falha ao travar",

--- a/app/src/main/assets/web/local/performance.html
+++ b/app/src/main/assets/web/local/performance.html
@@ -1002,9 +1002,9 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js"></script>
+    <script src="../shared/core.js?v=14"></script>
     <script src="../shared/update-flow.js"></script>
-    <script src="../shared/performance.js?v=5"></script>
+    <script src="../shared/performance.js?v=6"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -524,14 +524,14 @@
     <!-- core.js polls /status every 5s and populates the sidebar status card
          (12V, ACC, SOC, range, SOH, fuel, network). Without it those values
          all stay at "--" since vehicle-control.js only manages the 3D scene. -->
-    <script src="../shared/core.js?v=13"></script>
+    <script src="../shared/core.js?v=14"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/vendor/three.min.js?v=12"></script>
     <script src="../shared/vendor/DRACOLoader.js?v=12"></script>
     <script src="../shared/vendor/GLTFLoader.js?v=12"></script>
     <script src="../shared/vendor/OrbitControls.js?v=12"></script>
     <script src="../shared/vendor/gsap.min.js?v=12"></script>
-    <script src="../shared/vehicle-control.js?v=18"></script>
+    <script src="../shared/vehicle-control.js?v=19"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/shared/core.js
+++ b/app/src/main/assets/web/shared/core.js
@@ -196,6 +196,22 @@ BYD.i18n = (function () {
         return interpolate(val, vars);
     }
 
+    /**
+     * Resolve a manifest model name through the active locale when a market
+     * uses a different badge. The manifest id remains canonical, so persisted
+     * selections and downloaded GLBs are unaffected by localized branding.
+     */
+    function modelName(modelId, fallback) {
+        var rawId = modelId == null ? '' : String(modelId);
+        var normalized = rawId.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+        if (normalized) {
+            var key = 'vehicle.model_name_' + normalized;
+            var translated = t(key);
+            if (translated != null && translated !== key) return translated;
+        }
+        return fallback || rawId;
+    }
+
     function plural(key, count, vars) {
         var val = lookup(state.catalog, key);
         if (val == null) return key;
@@ -461,6 +477,7 @@ BYD.i18n = (function () {
         setLang: setLang,
         onChange: onChange,
         getLang: function () { return state.lang; },
+        modelName: modelName,
         getDisplayName: function (lang) { return DISPLAY_NAMES[lang] || lang; },
         supported: function () { return SUPPORTED.slice(); },
         // True when the app's server-side locale should override the local

--- a/app/src/main/assets/web/shared/performance.js
+++ b/app/src/main/assets/web/shared/performance.js
@@ -148,6 +148,9 @@ BYD.performance = {
         // — when a click hits an already-open tab, sw.js navigates the
         // existing window which only updates location.hash, no reload.
         var self = this;
+        if (BYD.i18n && typeof BYD.i18n.onChange === 'function') {
+            BYD.i18n.onChange(function() { self.fetchSohStatus(); });
+        }
         if (window.location.hash === '#soh-fix') {
             this._scrollToSohFixBanner();
         }
@@ -2490,7 +2493,8 @@ BYD.performance = {
         // Best-effort: capitalize first letter. Manifest titles aren't cached
         // here; the modal has the full list when the user opens it.
         if (!id) return '';
-        return id.charAt(0).toUpperCase() + id.slice(1);
+        var fallback = id.charAt(0).toUpperCase() + id.slice(1);
+        return BYD.i18n.modelName(id, fallback);
     },
 
     // ==================== SOH Capacity Modal ====================
@@ -2575,7 +2579,8 @@ BYD.performance = {
             opt.value = m.id || '';
             // Manifest's canonical user-facing string is "name"; older
             // copies used "title". Fall back to id when neither is set.
-            opt.textContent = m.name || m.title || m.id || '';
+            var canonicalName = m.name || m.title || m.id || '';
+            opt.textContent = BYD.i18n.modelName(m.id, canonicalName);
             modelSel.appendChild(opt);
             // Gross nameplate for every drivetrain. PHEV remainKwh is corrected
             // to the gross frame at the HAL read boundary (the BYD HAL reports

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -76,6 +76,12 @@ var VC = {
 
     init: function() {
         var self = this;
+        // Model ids are global, but their badges can be market-specific
+        // (for example, Seagull is sold as Dolphin Mini in Brazil). Refresh
+        // the already-built picker when the user changes the web locale.
+        if (BYD.i18n && typeof BYD.i18n.onChange === 'function') {
+            BYD.i18n.onChange(function() { self.refreshModelPickerNames(); });
+        }
         // Default: Aurora White (converted to linear so it matches the rest
         // of the colour pipeline; see applyColor() for the rationale).
         this.baseColor = new THREE.Color(0xE8E8EC).convertSRGBToLinear();
@@ -1132,7 +1138,9 @@ var VC = {
 
         _download: function(id, entry, url, onDone, onProgress) {
             var self = this;
-            if (onProgress) onProgress(BYD.i18n.t('vehicle.downloading_model', {name: entry.name, pct: 0}));
+            if (onProgress) onProgress(BYD.i18n.t('vehicle.downloading_model', {
+                name: BYD.i18n.modelName(entry.id, entry.name), pct: 0
+            }));
 
             var xhr = new XMLHttpRequest();
             xhr.open('POST', '/api/models/download?id=' + encodeURIComponent(id), true);
@@ -1181,7 +1189,9 @@ var VC = {
                     }
                     if (onProgress) {
                         var pct = typeof s.percent === 'number' ? s.percent : 0;
-                        onProgress(BYD.i18n.t('vehicle.downloading_model', {name: entry.name, pct: pct}));
+                        onProgress(BYD.i18n.t('vehicle.downloading_model', {
+                            name: BYD.i18n.modelName(entry.id, entry.name), pct: pct
+                        }));
                     }
                     setTimeout(tick, 250);
                 };
@@ -1205,7 +1215,7 @@ var VC = {
             var m = this.manifest.models[i];
             var opt = document.createElement('option');
             opt.value = m.id;
-            opt.textContent = m.name;
+            opt.textContent = BYD.i18n.modelName(m.id, m.name);
             sel.appendChild(opt);
         }
 
@@ -1225,6 +1235,18 @@ var VC = {
             self._lastStaleRetryMs = now;
             self._kickManifestRefresh();
         });
+    },
+
+    /** Re-label the existing options without rebuilding listeners/selection. */
+    refreshModelPickerNames: function() {
+        var sel = document.getElementById('modelPicker');
+        if (!sel || !this.manifest || !this.manifest.models) return;
+        for (var i = 0; i < this.manifest.models.length; i++) {
+            var m = this.manifest.models[i];
+            if (sel.options[i]) {
+                sel.options[i].textContent = BYD.i18n.modelName(m.id, m.name);
+            }
+        }
     },
 
     setModel: function(id) {

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -3059,7 +3059,7 @@ class MainActivity : AppCompatActivity() {
             "song" -> "BYD Song"
             "qin" -> "BYD Qin"
             "dolphin" -> "BYD Dolphin"
-            "seagull" -> "BYD Seagull"
+            "seagull" -> getString(R.string.vehicle_model_seagull)
             "sealion6" -> "BYD Sealion 6"
             "sealion7" -> "BYD Sealion 7"
             "sealu", "seal-u" -> "BYD Seal U"

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
@@ -914,7 +914,7 @@ class DashboardFragment : Fragment() {
                 if (!isAdded || view == null) return@post
                 if (nominalKwh > 0) {
                     tile.text = if (modelId != null) {
-                        getString(R.string.dashboard_vehicle_summary, nominalKwh, modelId.replaceFirstChar { it.uppercase() })
+                        getString(R.string.dashboard_vehicle_summary, nominalKwh, modelDisplayName(modelId))
                     } else {
                         String.format("%.1f kWh", nominalKwh)
                     }
@@ -1041,10 +1041,15 @@ class DashboardFragment : Fragment() {
                             // The previous version read "title" first which never
                             // existed in our manifest, so models showed as the
                             // id text. Ordering: name → title → id.
-                            val title = when {
+                            val canonicalTitle = when {
                                 m.optString("name", "").isNotEmpty() -> m.optString("name")
                                 m.optString("title", "").isNotEmpty() -> m.optString("title")
                                 else -> id
+                            }
+                            val title = if (id.equals("seagull", ignoreCase = true)) {
+                                ctx.getString(R.string.vehicle_model_seagull)
+                            } else {
+                                canonicalTitle
                             }
                             // nominalKwh is the manifest's canonical pack
                             // capacity for this model. 0 means the manifest
@@ -1231,7 +1236,7 @@ class DashboardFragment : Fragment() {
             "song" -> "BYD Song"
             "qin" -> "BYD Qin"
             "dolphin" -> "BYD Dolphin"
-            "seagull" -> "BYD Seagull"
+            "seagull" -> getString(R.string.vehicle_model_seagull)
             "sealion6" -> "BYD Sealion 6"
             "sealion7" -> "BYD Sealion 7"
             "sealu", "seal-u" -> "BYD Seal U"

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -922,6 +922,7 @@
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
     <string name="vehicle_dialog_capacity_helper">15 a 120 kWh. Deixe em branco para usar o padrão do modelo.</string>
     <string name="vehicle_dialog_model_label">Modelo</string>
+    <string name="vehicle_model_seagull">BYD Dolphin Mini</string>
     <string name="vehicle_dialog_save">Salvar</string>
     <string name="vehicle_dialog_reset">Redefinir para detecção automática</string>
     <string name="vehicle_dialog_invalid_capacity">A capacidade deve ser de 15 a 120 kWh</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1063,6 +1063,7 @@
     <string name="vehicle_dialog_capacity_suffix">kWh</string>
     <string name="vehicle_dialog_capacity_helper">15 to 120 kWh. Leave to use the model default.</string>
     <string name="vehicle_dialog_model_label">Model</string>
+    <string name="vehicle_model_seagull">BYD Seagull</string>
     <string name="vehicle_dialog_save">Save</string>
     <string name="vehicle_dialog_reset">Reset to auto-detect</string>
     <string name="vehicle_dialog_invalid_capacity">Capacity must be 15 - 120 kWh</string>


### PR DESCRIPTION
## Summary

- Show the Seagull model as **BYD Dolphin Mini** when the app or web locale is `pt-BR`.
- Keep the canonical `seagull` model ID and **BYD Seagull** name for every other locale.
- Apply the localized name consistently across the vehicle picker, dashboard, battery/SOH views, and model download progress.

## Why

The BYD Seagull is marketed in Brazil as the BYD Dolphin Mini. Brazilian Portuguese users should see the regional model name without creating a duplicate vehicle entry or changing persisted selections.

## Impact

This is display-only localization. Existing selections, model downloads, battery data, and the `seagull.glb` asset continue using the same canonical model ID.

## Validation

- Checked JavaScript syntax with `node --check`.
- Validated the English and pt-BR JSON catalogs.
- Verified `pt-BR` resolves to **BYD Dolphin Mini** and English resolves to **BYD Seagull**.
- Ran `git diff --check`.
- Android compilation was not run because the local environment does not include the Android SDK.
