### PR TITLE
Localize Telegram bot in Brazilian Portuguese

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -416,6 +416,8 @@ dependencies {
     implementation("org.eclipse.paho:org.eclipse.paho.mqttv5.client:1.2.5")
 
     testImplementation(libs.junit)
+    // Android's mockable org.json stubs throw in local JVM tests.
+    testImplementation("org.json:json:20231013")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/main/assets/server-i18n/en.json
+++ b/app/src/main/assets/server-i18n/en.json
@@ -116,6 +116,31 @@
     "charging_complete": "Charging complete",
     "charging_fault": "Charging fault",
     "battery_ready_to_unplug": "Battery at {0}% — ready to unplug",
+    "charging_state": {
+      "ready": "Ready",
+      "charging": "Charging",
+      "finished": "Charge finished",
+      "discharging": "Discharging",
+      "terminated": "Charge terminated",
+      "fault_c10": "Breakdown: C10",
+      "fault_gun": "Breakdown: charging gun",
+      "fault_ac": "Breakdown: AC",
+      "fault_charger": "Breakdown: charger",
+      "scheduled": "Scheduled",
+      "timeout": "Timeout",
+      "discharging_cbu": "Discharging CBU",
+      "discharge_finished": "Discharge finished",
+      "idle": "Idle",
+      "unknown": "Unknown ({0})"
+    },
+    "tyre_no_reading": "no reading",
+    "tyre_critically_low": "Tyre critically low",
+    "tyre_overpressure": "Overpressure",
+    "tyre_underpressure": "Underpressure",
+    "tyre_wheel_reading": "{0} — {1}",
+    "tyre_fast_leak": "Fast leak detected",
+    "tyre_slow_leak": "Slow leak detected",
+    "tyre_wheel_pressure": "{0} ({1} kPa)",
     "door_opened": "{0} door opened",
     "door_closed": "{0} door closed",
     "while_parked": "While parked",
@@ -134,7 +159,306 @@
   "telegram": {
     "recording_caption": "📹 Recording ({0}) - {1}s",
     "recording_caption_no_label": "📹 Recording - {0}s",
-    "proximity_alert": "🚨 Proximity Alert\nTime: {0}\nTrigger: {1} ({2})\nRecording started..."
+    "recording_label": {
+      "person": "person",
+      "bike": "bike",
+      "vehicle": "vehicle",
+      "animal": "animal",
+      "motion": "motion"
+    },
+    "proximity_alert": "🚨 *Proximity Alert*\nTime: {0}\nTrigger: {1} ({2})\nRecording started…",
+    "proximity": {
+      "trigger": {
+        "red": "Red",
+        "yellow": "Yellow"
+      }
+    },
+    "common": {
+      "cancel_button": "❌ Cancel",
+      "unknown_error": "unknown error"
+    },
+    "error_details": {
+      "app_context_not_ready": "The app is not ready yet.",
+      "timeout": "The operation timed out.",
+      "public_mode": "Updates are disabled in public mode.",
+      "invalid_channel": "The update channel is invalid.",
+      "channel_save_failed": "The update channel could not be saved.",
+      "update_in_progress": "An update is already in progress.",
+      "inactive_channel": "This version is not available on the active channel.",
+      "no_update": "No update is available.",
+      "unavailable_build": "This feature is not available in this build.",
+      "permission_denied": "The device denied permission for this operation.",
+      "storage_full": "The device does not have enough free storage.",
+      "http_status": "The service returned HTTP {0}.",
+      "network": "A network connection could not be established.",
+      "download_failed": "The download failed.",
+      "verification_failed": "Package verification failed.",
+      "install_failed": "The installation failed.",
+      "unknown_daemon": "The requested daemon is unknown.",
+      "generic": "See the device logs for details."
+    },
+    "router": {
+      "unknown_command": "Unknown command. Use /help for available commands."
+    },
+    "daemon_names": {
+      "camera": "Camera",
+      "acc_sentry": "ACC Sentry",
+      "sentry": "Sentry",
+      "telegram": "Telegram",
+      "surveillance": "Surveillance",
+      "cloudflare_tunnel": "Cloudflare Tunnel",
+      "zrok_tunnel": "Zrok Tunnel",
+      "tailscale_tunnel": "Tailscale Tunnel",
+      "sing_box": "Sing-Box"
+    },
+    "buttons": {
+      "stop_named": "⛔ Stop {0}",
+      "start_named": "✅ Start {0}",
+      "refresh": "🔄 Refresh",
+      "status": "📊 Status",
+      "events": "📹 Events",
+      "start_surveillance": "✅ Start Surveillance",
+      "stop_surveillance": "⛔ Stop Surveillance",
+      "daemons": "🤖 Daemons",
+      "tunnel_url": "🌐 Tunnel URL",
+      "check_update": "⬆️ Check Update",
+      "backup": "💾 Backup",
+      "stop": "⛔ Stop",
+      "start": "✅ Start"
+    },
+    "daemons": {
+      "title": "🤖 *Daemons*\n\n"
+    },
+    "url": {
+      "none_running": "⚠️ No tunnel running\n\nStart one with:\n`/daemon cloudflared start`\n`/daemon zrok start`\n`/daemon tailscale start`",
+      "title": "🌐 *Tunnel URLs*\n\n",
+      "resolved_line": "• *{0}:* {1}\n",
+      "pending_line": "• *{0}:* _starting, URL not available yet_\n",
+      "last_known": "\n_Last known:_ {0}\n",
+      "retry_pending": "\n_Try again in a few seconds for pending URLs._",
+      "error": "⚠️ Error: {0}"
+    },
+    "help": {
+      "text": "📖 *Commands*\n_OverDrive {0}_\n\n*Surveillance*\n`/start` - Start surveillance\n`/stop` - Stop surveillance\n`/status` - System status\n\n*Events*\n`/events [hours] [page]` - List recordings\n`/download <file>` - Download video\n\n*Daemons*\n`/daemons` - List all daemons\n`/daemon <name> start|stop`\n\n*System*\n`/url` - Tunnel URL\n`/update` - Check for app update\n`/backup` - Export settings backup\n`/backup trips` - Backup incl. trip history\n`/help` - This message"
+    },
+    "surveillance": {
+      "started": "✅ Surveillance started",
+      "start_failed": "⚠️ Failed to start surveillance",
+      "stopped": "⛔ Surveillance stopped",
+      "stop_failed": "⚠️ Failed to stop surveillance",
+      "status_title": "📊 *Status*\n\n",
+      "status_active": "*Surveillance:* ✅ Active\n",
+      "status_inactive": "*Surveillance:* ⛔ Inactive\n",
+      "temperature": "*Temp:* {0}\n\n",
+      "daemons_heading": "*Daemons:*\n",
+      "daemon_running": "✅ {0}\n",
+      "no_daemons_running": "_No daemons running_\n",
+      "not_available": "N/A"
+    },
+    "daemon": {
+      "usage": "Usage: /daemon <name> start|stop|status\n\nAvailable: {0}",
+      "unknown": "❌ Unknown daemon: {0}\n\nAvailable: {1}",
+      "cannot_control_telegram": "⚠️ The Telegram daemon cannot be controlled through Telegram.",
+      "already_running": "ℹ️ {0} is already running.",
+      "must_start_from_app": "⚠️ {0} must be started from the app interface.",
+      "started": "✅ {0} started.",
+      "start_failed": "⚠️ Failed to start {0}.",
+      "not_running": "ℹ️ {0} is not running.",
+      "stopped": "⛔ {0} stopped.",
+      "stop_failed": "⚠️ Failed to stop {0}.",
+      "status_running": "{0}: ✅ Running",
+      "status_stopped": "{0}: ⛔ Stopped",
+      "action_usage": "Usage: /daemon {0} start|stop|status",
+      "tunnel_url": "🌐 *Tunnel URL*\n{0}"
+    },
+    "events": {
+      "invalid_hours": "⚠️ Invalid hour value. Usage: `/events [hours] [page]`\nExample: `/events 12 2`",
+      "download_usage": "⚠️ Usage: `/download <filename>`\nExample: `/download event_20260113_143022.mp4`",
+      "directory_missing": "📁 Events directory not found",
+      "none_found": "📭 No event recordings found",
+      "none_recent": "📭 No events in the last {0} hours",
+      "header": "📹 *Events* ({0}h)",
+      "header_paged": "📹 *Events* ({0}h) {1}/{2}",
+      "download_button": "{0} {1} ({2})",
+      "previous_button": "◀️ Previous",
+      "next_button": "Next ▶️",
+      "legend": "⏺️ Recording  ⚠️ >50 MB  📥 Ready",
+      "invalid_filename": "⚠️ Invalid filename. It must match `event_*.mp4`.",
+      "file_not_found": "❌ File not found: `{0}`",
+      "recording_in_progress": "⏳ *Recording in progress*\n\nFile: `{0}`\nCurrent size: {1}\n\nWait 10–15 seconds and try again.",
+      "file_too_large": "❌ *File too large*\n\nFile: `{0}`\nSize: {1}\nLimit: 50 MB",
+      "uploading": "📤 Uploading `{0}` ({1})…",
+      "video_caption": "📹 {0}",
+      "upload_failed": "❌ Failed to upload the video. Try again later.",
+      "size_bytes": "{0} B",
+      "size_kb": "{0} KB",
+      "size_mb": "{0} MB"
+    },
+    "update": {
+      "checking": "🔍 Checking for updates…",
+      "service_unreachable": "⚠️ Could not reach the update service.\n\nThe camera daemon may not be running. Try `/daemon camera start`.",
+      "check_failed": "⚠️ Update check failed: {0}",
+      "switch_alpha_all_button": "📚 Switch to Alpha (all versions)",
+      "up_to_date": "✅ *Up to date*\n_OverDrive {0} · Braveheart_",
+      "available": "⬆️ *Update available* _(Braveheart)_\n\n*Current:* {0}\n*Latest:* {1}\n\n_Installation takes about 2 minutes. The bot will restart and send a new tunnel URL when it finishes._",
+      "available_with_notes": "⬆️ *Update available* _(Braveheart)_\n\n*Current:* {0}\n*Latest:* {1}\n\n*Release notes:*\n{2}\n\n_Installation takes about 2 minutes. The bot will restart and send a new tunnel URL when it finishes._",
+      "install_now_button": "🔄 Install Now",
+      "switch_alpha_button": "📚 Switch to Alpha",
+      "list_service_unreachable": "⚠️ Could not list versions because the update service is unreachable.",
+      "list_failed": "⚠️ Could not list versions: {0}",
+      "no_versions": "ℹ️ No versions have been published yet.",
+      "version_button": "{0}",
+      "version_installed_button": "✅ {0} (installed)",
+      "version_older_button": "⬇️ {0}",
+      "switch_braveheart_button": "🚀 Switch to Braveheart (latest only)",
+      "alpha_list": "📚 *Alpha — choose a version*\n_Installed: {0}_\n\n_Downgrades are allowed._",
+      "alpha_list_truncated": "📚 *Alpha — choose a version*\n_Installed: {0}_\n\n_Showing the newest {1} of {2}. Older builds remain available on GitHub Releases._\n_Downgrades are allowed._",
+      "channel_usage": "Usage: `/update channel alpha` or `/update channel braveheart`",
+      "channel_service_unreachable": "⚠️ Could not switch the update channel because the update service is unreachable.",
+      "channel_switch_failed": "⚠️ Could not switch the update channel: {0}",
+      "channel_set_braveheart": "✅ Update channel set to *Braveheart (latest only)*.\nSend /update to continue.",
+      "channel_set_alpha": "✅ Update channel set to *Alpha (all versions)*.\nSend /update to continue.",
+      "installing": "⏳ *Installing update…*\n\nThe daemons will stop, the APK will be installed, and the device will restart. This bot will be silent for about 2 minutes. A new tunnel URL message will arrive when it is back online.",
+      "install_service_unreachable": "⚠️ Could not start the installation because the camera daemon is unreachable.",
+      "install_rejected": "⚠️ Installation rejected: {0}",
+      "install_failed": "⚠️ *Overdrive update failed*\nThe device is still on the previous version.\nReason: {0}",
+      "unknown_reason": "unknown (see head unit)",
+      "installed": "🔄 *Overdrive updated to {0}*",
+      "installed_new_tunnel": "🔄 *Overdrive updated to {0}*\nNew tunnel URL:\n{1}\n\n_The cloudflared link rotates after every install._",
+      "installed_tunnel_online": "🔄 *Overdrive updated to {0}*\nTunnel back online:\n{1}"
+    },
+    "backup": {
+      "restore_unavailable": "ℹ️ *Restore is not available through Telegram.*\n\nOpen Overdrive on the head unit or in the app, then go to *Settings → Backup & Restore* and select the backup file. Backups can only be restored on the same device and require confirmation there.",
+      "building_with_trips": "💾 Building backup with settings and trip history…",
+      "building_settings": "💾 Building settings backup…",
+      "service_unreachable": "⚠️ Could not reach the backup service.\n\nThe camera daemon may not be running. Try `/daemon camera start`.",
+      "failed": "⚠️ Backup failed: {0}",
+      "no_data": "⚠️ The backup returned no data.",
+      "write_failed": "⚠️ Could not write the backup file: {0}",
+      "document_settings": "💾 Overdrive settings backup\n\n⚠️ This file contains credentials and the device key. Keep it private. Restore it on this same head unit from Settings → Backup & Restore.",
+      "document_settings_version": "💾 Overdrive settings backup · {0}\n\n⚠️ This file contains credentials and the device key. Keep it private. Restore it on this same head unit from Settings → Backup & Restore.",
+      "document_with_trips": "💾 Overdrive backup (settings + trip history: {0})\n\n⚠️ This file contains credentials, the device key, and location history. Keep it private. Restore it on this same head unit from Settings → Backup & Restore.",
+      "document_with_trips_version": "💾 Overdrive backup (settings + trip history: {0}) · {1}\n\n⚠️ This file contains credentials, the device key, and location history. Keep it private. Restore it on this same head unit from Settings → Backup & Restore.",
+      "upload_failed": "⚠️ Could not upload the backup file to Telegram."
+    },
+    "sendlog": {
+      "choose": "📄 *Send a daemon log*\n\nChoose a daemon or use `/sendlog <name>`:",
+      "daemon_button": "{0}",
+      "unknown_daemon": "❌ Unknown daemon `{0}`.\nTry: {1}",
+      "uploading": "⏳ Uploading the *{0}* log…",
+      "service_unreachable": "⚠️ Could not reach the log service. The camera daemon may not be running. Try `/daemon camera start`.",
+      "upload_failed": "⚠️ Log upload failed: {0}",
+      "upload_success": "✅ *{0}* log uploaded.\n\nShare this code with us and include a note describing what went wrong:\n`{1}`\n\nReport it on:\n• Discord: {2}\n• GitHub: {3}\n• WhatsApp: {4}\n\n_Secrets were removed before upload. The log expires automatically._"
+    },
+    "greeting": {
+      "online": "🤖 *Surveillance Bot Online*\n\nBot daemon started and ready.\nUse /help for available commands."
+    },
+    "callback": {
+      "not_authorized": "⚠️ Not authorized",
+      "downloading": "📥 Downloading…",
+      "starting": "⏳ Starting…",
+      "stopping": "⏳ Stopping…",
+      "processing": "⏳ Processing…",
+      "unknown_action": "Unknown action"
+    },
+    "pair": {
+      "no_owner": "⚠️ No owner paired. Use /pair <PIN> to pair.",
+      "already_paired": "❌ Already paired with another owner.",
+      "invalid_format": "❌ Invalid PIN format. Enter the 6-digit PIN from the app.",
+      "no_pin": "❌ No PIN generated. Generate a PIN from the app first.",
+      "expired": "❌ PIN expired. Generate a new PIN from the app.",
+      "invalid": "❌ Invalid PIN. Check the PIN shown in the app.",
+      "storage_error": "⚠️ Pairing could not be saved (storage error). Please try /pair again; if it keeps failing, restart the app.",
+      "success": "✅ Paired successfully!\n\nWelcome, {0}!\nUse /help to see available commands.",
+      "success_no_name": "✅ Paired successfully!\n\nUse /help to see available commands."
+    },
+    "tunnel": {
+      "notification_url": "🌐 *Tunnel URL*\n{0}",
+      "notification_url_changed": "🔄 *Tunnel URL Changed*\n{0}"
+    },
+    "critical": {
+      "message": "⚠️ *Critical Alert*\n{0}",
+      "message_with_details": "⚠️ *Critical Alert*\n{0}\n{1}",
+      "type": {
+        "low_battery": "🔋 Low battery",
+        "storage_full": "💾 Storage full",
+        "daemon_crash": "⚠️ Daemon crashed",
+        "system_error": "❌ System error",
+        "system_reboot": "🔄 System reboot",
+        "unknown": "❓ Unknown critical event"
+      }
+    },
+    "motion": {
+      "tier": {
+        "critical": "CRITICAL",
+        "alert": "Alert"
+      },
+      "actor": {
+        "person": "Person",
+        "bike": "Bike",
+        "vehicle": "Vehicle",
+        "animal": "Animal",
+        "motion": "Motion"
+      },
+      "camera": {
+        "front": "front",
+        "right": "right",
+        "rear": "rear",
+        "left": "left"
+      },
+      "title": {
+        "tier_actor_camera": "{0} *{1} · {2} at {3}*",
+        "tier_actor": "{0} *{1} · {2}*",
+        "tier_camera": "{0} *{1} at {2}*",
+        "tier": "{0} *{1}*",
+        "actor_camera": "{0} *{1} at {2}*",
+        "actor": "{0} *{1}*",
+        "camera": "{0} *Motion at {1}*",
+        "detected": "{0} *Motion detected*"
+      },
+      "proximity": {
+        "very_close": "Very close",
+        "close": "Close",
+        "mid": "Mid range",
+        "far": "Far"
+      },
+      "count": {
+        "person_one": "{0} person",
+        "person_many": "{0} people",
+        "vehicle_one": "{0} vehicle",
+        "vehicle_many": "{0} vehicles",
+        "bike_one": "{0} bike",
+        "bike_many": "{0} bikes",
+        "animal_one": "{0} animal",
+        "animal_many": "{0} animals"
+      },
+      "recording_in_progress": "_Recording in progress_",
+      "detected_at": "🕒 _Detected {0}_",
+      "cleared_no_event": "✅ Motion cleared — no event recorded (filtered as a non-actor false alert)."
+    },
+    "media": {
+      "video_too_large": "📹 *Clip too large to send*\n`{0}` ({1} MB)\nView it on the device — it exceeds the 50 MB Telegram limit.",
+      "document_too_large": "📄 *File too large to send*\n`{0}` ({1} MB) — it exceeds the 50 MB Telegram limit."
+    },
+    "legacy": {
+      "connectivity": {
+        "connected": "📶 Connected via {0}",
+        "disconnected": "📵 Disconnected from {0}"
+      },
+      "critical_with_details": "{0}: {1}",
+      "motion": {
+        "detected_actor": "🚨 {0} detected ({1}%)",
+        "detected": "👁 Motion detected"
+      },
+      "tunnel": {
+        "connected": "🌐 Tunnel connected:\n{0}",
+        "changed": "🔄 Tunnel URL changed:\n{0}"
+      },
+      "video": {
+        "saved_with_detection": "🎬 Recording saved ({0} detected) - {1}s",
+        "saved": "🎬 Recording saved - {0}s"
+      }
+    }
   },
   "vehicle_control": {
     "cloud_required": "Connect a BYD account in Settings to use this control",

--- a/app/src/main/assets/server-i18n/pt-BR.json
+++ b/app/src/main/assets/server-i18n/pt-BR.json
@@ -115,7 +115,32 @@
     "charging_stopped": "Carregamento parado",
     "charging_complete": "Carregamento completo",
     "charging_fault": "Falha de carregamento",
-    "battery_ready_to_unplug": "Bateria em {0}%  pronta para desconectar",
+    "battery_ready_to_unplug": "Bateria em {0}% — pronta para desconectar",
+    "charging_state": {
+      "ready": "Pronto",
+      "charging": "Carregando",
+      "finished": "Carregamento concluído",
+      "discharging": "Descarregando",
+      "terminated": "Carregamento interrompido",
+      "fault_c10": "Falha: C10",
+      "fault_gun": "Falha: conector de carregamento",
+      "fault_ac": "Falha: corrente alternada",
+      "fault_charger": "Falha: carregador",
+      "scheduled": "Agendado",
+      "timeout": "Tempo limite excedido",
+      "discharging_cbu": "Descarregando pela CBU",
+      "discharge_finished": "Descarga concluída",
+      "idle": "Inativo",
+      "unknown": "Desconhecido ({0})"
+    },
+    "tyre_no_reading": "sem leitura",
+    "tyre_critically_low": "Pneu criticamente baixo",
+    "tyre_overpressure": "Pressão excessiva",
+    "tyre_underpressure": "Pressão baixa",
+    "tyre_wheel_reading": "{0} — {1}",
+    "tyre_fast_leak": "Vazamento rápido detectado",
+    "tyre_slow_leak": "Vazamento lento detectado",
+    "tyre_wheel_pressure": "{0} ({1} kPa)",
     "door_opened": "A porta {0} aberta",
     "door_closed": "Porta {0} fechada",
     "while_parked": "Enquanto estacionado",
@@ -132,9 +157,308 @@
     "soh_frame_mismatch_body": "O veículo informa {0} kWh com carga total, mas a capacidade de embalagem é definida para {1} kWh."
   },
   "telegram": {
-    "recording_caption": " Registo ({0}) - {1}s",
-    "recording_caption_no_label": " Registros - {0}s",
-    "proximity_alert": " Tempo de alerta de proximidade: {0} Trigger: {1} ({2}) A gravação começou..."
+    "recording_caption": "📹 Gravação ({0}) — {1}s",
+    "recording_caption_no_label": "📹 Gravação — {0}s",
+    "recording_label": {
+      "person": "pessoa",
+      "bike": "bicicleta",
+      "vehicle": "veículo",
+      "animal": "animal",
+      "motion": "movimento"
+    },
+    "proximity_alert": "🚨 *Alerta de proximidade*\nHorário: {0}\nNível: {1} ({2})\nGravação iniciada…",
+    "proximity": {
+      "trigger": {
+        "red": "Vermelho",
+        "yellow": "Amarelo"
+      }
+    },
+    "common": {
+      "cancel_button": "❌ Cancelar",
+      "unknown_error": "erro desconhecido"
+    },
+    "error_details": {
+      "app_context_not_ready": "O aplicativo ainda não está pronto.",
+      "timeout": "A operação excedeu o tempo limite.",
+      "public_mode": "As atualizações estão desativadas no modo público.",
+      "invalid_channel": "O canal de atualização é inválido.",
+      "channel_save_failed": "Não foi possível salvar o canal de atualização.",
+      "update_in_progress": "Já existe uma atualização em andamento.",
+      "inactive_channel": "Esta versão não está disponível no canal ativo.",
+      "no_update": "Não há atualização disponível.",
+      "unavailable_build": "Este recurso não está disponível nesta versão do aplicativo.",
+      "permission_denied": "O dispositivo negou permissão para esta operação.",
+      "storage_full": "O dispositivo não tem espaço livre suficiente.",
+      "http_status": "O serviço retornou o código HTTP {0}.",
+      "network": "Não foi possível estabelecer uma conexão de rede.",
+      "download_failed": "Falha ao baixar o arquivo.",
+      "verification_failed": "Falha ao verificar o pacote.",
+      "install_failed": "Falha na instalação.",
+      "unknown_daemon": "O daemon solicitado é desconhecido.",
+      "generic": "Consulte os logs do dispositivo para ver os detalhes."
+    },
+    "router": {
+      "unknown_command": "Comando desconhecido. Use /help para ver os comandos disponíveis."
+    },
+    "daemon_names": {
+      "camera": "Câmera",
+      "acc_sentry": "Vigilância ACC",
+      "sentry": "Sentry",
+      "telegram": "Telegram",
+      "surveillance": "Vigilância",
+      "cloudflare_tunnel": "Túnel Cloudflare",
+      "zrok_tunnel": "Túnel Zrok",
+      "tailscale_tunnel": "Túnel Tailscale",
+      "sing_box": "Sing-Box"
+    },
+    "buttons": {
+      "stop_named": "⛔ Parar {0}",
+      "start_named": "✅ Iniciar {0}",
+      "refresh": "🔄 Atualizar",
+      "status": "📊 Status",
+      "events": "📹 Eventos",
+      "start_surveillance": "✅ Iniciar vigilância",
+      "stop_surveillance": "⛔ Parar vigilância",
+      "daemons": "🤖 Serviços",
+      "tunnel_url": "🌐 URL do túnel",
+      "check_update": "⬆️ Verificar atualização",
+      "backup": "💾 Backup",
+      "stop": "⛔ Parar",
+      "start": "✅ Iniciar"
+    },
+    "daemons": {
+      "title": "🤖 *Serviços*\n\n"
+    },
+    "url": {
+      "none_running": "⚠️ Nenhum túnel em execução\n\nInicie um com:\n`/daemon cloudflared start`\n`/daemon zrok start`\n`/daemon tailscale start`",
+      "title": "🌐 *URLs dos túneis*\n\n",
+      "resolved_line": "• *{0}:* {1}\n",
+      "pending_line": "• *{0}:* _iniciando, URL ainda não disponível_\n",
+      "last_known": "\n_Última URL conhecida:_ {0}\n",
+      "retry_pending": "\n_Tente novamente em alguns segundos para consultar as URLs pendentes._",
+      "error": "⚠️ Erro: {0}"
+    },
+    "help": {
+      "text": "📖 *Comandos*\n_OverDrive {0}_\n\n*Vigilância*\n`/start` - Iniciar vigilância\n`/stop` - Parar vigilância\n`/status` - Exibir status do sistema\n\n*Eventos*\n`/events [horas] [página]` - Listar gravações\n`/download <arquivo>` - Baixar vídeo\n\n*Serviços*\n`/daemons` - Listar todos os serviços\n`/daemon <nome> start|stop`\n\n*Sistema*\n`/url` - Exibir URL do túnel\n`/update` - Verificar atualização do app\n`/backup` - Exportar backup das configurações\n`/backup trips` - Incluir histórico de viagens no backup\n`/help` - Exibir esta mensagem"
+    },
+    "surveillance": {
+      "started": "✅ Vigilância iniciada",
+      "start_failed": "⚠️ Não foi possível iniciar a vigilância",
+      "stopped": "⛔ Vigilância encerrada",
+      "stop_failed": "⚠️ Não foi possível encerrar a vigilância",
+      "status_title": "📊 *Status*\n\n",
+      "status_active": "*Vigilância:* ✅ Ativa\n",
+      "status_inactive": "*Vigilância:* ⛔ Inativa\n",
+      "temperature": "*Temperatura:* {0}\n\n",
+      "daemons_heading": "*Serviços:*\n",
+      "daemon_running": "✅ {0}\n",
+      "no_daemons_running": "_Nenhum serviço em execução_\n",
+      "not_available": "N/D"
+    },
+    "daemon": {
+      "usage": "Uso: /daemon <nome> start|stop|status\n\nDisponíveis: {0}",
+      "unknown": "❌ Serviço desconhecido: {0}\n\nDisponíveis: {1}",
+      "cannot_control_telegram": "⚠️ O daemon do Telegram não pode ser controlado pelo próprio Telegram.",
+      "already_running": "ℹ️ {0} já está em execução.",
+      "must_start_from_app": "⚠️ {0} precisa ser iniciado pela interface do aplicativo.",
+      "started": "✅ {0} iniciado.",
+      "start_failed": "⚠️ Não foi possível iniciar {0}.",
+      "not_running": "ℹ️ {0} não está em execução.",
+      "stopped": "⛔ {0} parado.",
+      "stop_failed": "⚠️ Não foi possível parar {0}.",
+      "status_running": "{0}: ✅ Em execução",
+      "status_stopped": "{0}: ⛔ Parado",
+      "action_usage": "Uso: /daemon {0} start|stop|status",
+      "tunnel_url": "🌐 *URL do túnel*\n{0}"
+    },
+    "events": {
+      "invalid_hours": "⚠️ Quantidade de horas inválida. Uso: `/events [horas] [página]`\nExemplo: `/events 12 2`",
+      "download_usage": "⚠️ Uso: `/download <arquivo>`\nExemplo: `/download event_20260113_143022.mp4`",
+      "directory_missing": "📁 Pasta de eventos não encontrada",
+      "none_found": "📭 Nenhuma gravação de evento encontrada",
+      "none_recent": "📭 Nenhum evento nas últimas {0} horas",
+      "header": "📹 *Eventos* ({0} h)",
+      "header_paged": "📹 *Eventos* ({0} h) {1}/{2}",
+      "download_button": "{0} {1} ({2})",
+      "previous_button": "◀️ Anterior",
+      "next_button": "Próxima ▶️",
+      "legend": "⏺️ Em gravação  ⚠️ >50 MB  📥 Disponível",
+      "invalid_filename": "⚠️ Nome de arquivo inválido. Use o formato `event_*.mp4`.",
+      "file_not_found": "❌ Arquivo não encontrado: `{0}`",
+      "recording_in_progress": "⏳ *Gravação em andamento*\n\nArquivo: `{0}`\nTamanho atual: {1}\n\nAguarde de 10 a 15 segundos e tente novamente.",
+      "file_too_large": "❌ *Arquivo muito grande*\n\nArquivo: `{0}`\nTamanho: {1}\nLimite: 50 MB",
+      "uploading": "📤 Enviando `{0}` ({1})…",
+      "video_caption": "📹 {0}",
+      "upload_failed": "❌ Não foi possível enviar o vídeo. Tente novamente mais tarde.",
+      "size_bytes": "{0} B",
+      "size_kb": "{0} KB",
+      "size_mb": "{0} MB"
+    },
+    "update": {
+      "checking": "🔍 Verificando atualizações…",
+      "service_unreachable": "⚠️ Não foi possível acessar o serviço de atualização.\n\nO daemon da câmera pode não estar em execução. Tente `/daemon camera start`.",
+      "check_failed": "⚠️ Falha ao verificar atualizações: {0}",
+      "switch_alpha_all_button": "📚 Mudar para Alpha (todas as versões)",
+      "up_to_date": "✅ *Tudo atualizado*\n_OverDrive {0} · Braveheart_",
+      "available": "⬆️ *Atualização disponível* _(Braveheart)_\n\n*Atual:* {0}\n*Mais recente:* {1}\n\n_A instalação leva cerca de 2 minutos. O bot será reiniciado e enviará uma nova URL do túnel ao concluir._",
+      "available_with_notes": "⬆️ *Atualização disponível* _(Braveheart)_\n\n*Atual:* {0}\n*Mais recente:* {1}\n\n*Notas da versão:*\n{2}\n\n_A instalação leva cerca de 2 minutos. O bot será reiniciado e enviará uma nova URL do túnel ao concluir._",
+      "install_now_button": "🔄 Instalar agora",
+      "switch_alpha_button": "📚 Mudar para Alpha",
+      "list_service_unreachable": "⚠️ Não foi possível listar as versões porque o serviço de atualização está inacessível.",
+      "list_failed": "⚠️ Não foi possível listar as versões: {0}",
+      "no_versions": "ℹ️ Nenhuma versão foi publicada ainda.",
+      "version_button": "{0}",
+      "version_installed_button": "✅ {0} (instalada)",
+      "version_older_button": "⬇️ {0}",
+      "switch_braveheart_button": "🚀 Mudar para Braveheart (somente a mais recente)",
+      "alpha_list": "📚 *Alpha — escolha uma versão*\n_Instalada: {0}_\n\n_É possível instalar versões anteriores._",
+      "alpha_list_truncated": "📚 *Alpha — escolha uma versão*\n_Instalada: {0}_\n\n_Exibindo as {1} mais recentes de {2}. As versões anteriores continuam disponíveis na página de lançamentos do GitHub._\n_É possível instalar versões anteriores._",
+      "channel_usage": "Uso: `/update channel alpha` ou `/update channel braveheart`",
+      "channel_service_unreachable": "⚠️ Não foi possível mudar o canal de atualização porque o serviço está inacessível.",
+      "channel_switch_failed": "⚠️ Não foi possível mudar o canal de atualização: {0}",
+      "channel_set_braveheart": "✅ Canal de atualização definido como *Braveheart (somente a versão mais recente)*.\nEnvie /update para continuar.",
+      "channel_set_alpha": "✅ Canal de atualização definido como *Alpha (todas as versões)*.\nEnvie /update para continuar.",
+      "installing": "⏳ *Instalando atualização…*\n\nOs daemons serão interrompidos, o APK será instalado e o dispositivo será reiniciado. Este bot ficará em silêncio por cerca de 2 minutos. Você receberá uma mensagem com a nova URL do túnel quando ele voltar a ficar online.",
+      "install_service_unreachable": "⚠️ Não foi possível iniciar a instalação porque o daemon da câmera está inacessível.",
+      "install_rejected": "⚠️ Instalação rejeitada: {0}",
+      "install_failed": "⚠️ *A atualização do Overdrive falhou*\nO dispositivo continua na versão anterior.\nMotivo: {0}",
+      "unknown_reason": "motivo desconhecido (consulte a central multimídia)",
+      "installed": "🔄 *Overdrive atualizado para {0}*",
+      "installed_new_tunnel": "🔄 *Overdrive atualizado para {0}*\nNova URL do túnel:\n{1}\n\n_O link do cloudflared muda após cada instalação._",
+      "installed_tunnel_online": "🔄 *Overdrive atualizado para {0}*\nTúnel novamente online:\n{1}"
+    },
+    "backup": {
+      "restore_unavailable": "ℹ️ *A restauração não está disponível pelo Telegram.*\n\nAbra o Overdrive na central multimídia ou no app, acesse *Configurações → Backup e restauração* e selecione o arquivo de backup. O backup só pode ser restaurado no mesmo dispositivo e exige confirmação nessa tela.",
+      "building_with_trips": "💾 Criando backup das configurações e do histórico de viagens…",
+      "building_settings": "💾 Criando backup das configurações…",
+      "service_unreachable": "⚠️ Não foi possível acessar o serviço de backup.\n\nO daemon da câmera pode não estar em execução. Tente `/daemon camera start`.",
+      "failed": "⚠️ Falha ao criar o backup: {0}",
+      "no_data": "⚠️ O backup não retornou dados.",
+      "write_failed": "⚠️ Não foi possível gravar o arquivo de backup: {0}",
+      "document_settings": "💾 Backup das configurações do Overdrive\n\n⚠️ Este arquivo contém credenciais e a chave do dispositivo. Mantenha-o em local seguro. Restaure-o nesta mesma central multimídia em Configurações → Backup e restauração.",
+      "document_settings_version": "💾 Backup das configurações do Overdrive · {0}\n\n⚠️ Este arquivo contém credenciais e a chave do dispositivo. Mantenha-o em local seguro. Restaure-o nesta mesma central multimídia em Configurações → Backup e restauração.",
+      "document_with_trips": "💾 Backup do Overdrive (configurações + histórico de viagens: {0})\n\n⚠️ Este arquivo contém credenciais, a chave do dispositivo e o histórico de localização. Mantenha-o em local seguro. Restaure-o nesta mesma central multimídia em Configurações → Backup e restauração.",
+      "document_with_trips_version": "💾 Backup do Overdrive (configurações + histórico de viagens: {0}) · {1}\n\n⚠️ Este arquivo contém credenciais, a chave do dispositivo e o histórico de localização. Mantenha-o em local seguro. Restaure-o nesta mesma central multimídia em Configurações → Backup e restauração.",
+      "upload_failed": "⚠️ Não foi possível enviar o arquivo de backup pelo Telegram."
+    },
+    "sendlog": {
+      "choose": "📄 *Enviar o log de um daemon*\n\nEscolha um daemon ou use `/sendlog <nome>`:",
+      "daemon_button": "{0}",
+      "unknown_daemon": "❌ Daemon desconhecido: `{0}`.\nTente: {1}",
+      "uploading": "⏳ Enviando o log de *{0}*…",
+      "service_unreachable": "⚠️ Não foi possível acessar o serviço de logs. O daemon da câmera pode não estar em execução. Tente `/daemon camera start`.",
+      "upload_failed": "⚠️ Falha ao enviar o log: {0}",
+      "upload_success": "✅ Log de *{0}* enviado.\n\nCompartilhe este código conosco e inclua uma breve descrição do problema:\n`{1}`\n\nEnvie o relato por:\n• Discord: {2}\n• GitHub: {3}\n• WhatsApp: {4}\n\n_Dados sigilosos foram removidos antes do envio. O log expira automaticamente._"
+    },
+    "greeting": {
+      "online": "🤖 *Bot de vigilância online*\n\nO daemon do bot foi iniciado e está pronto.\nUse /help para ver os comandos disponíveis."
+    },
+    "callback": {
+      "not_authorized": "⚠️ Não autorizado",
+      "downloading": "📥 Baixando…",
+      "starting": "⏳ Iniciando…",
+      "stopping": "⏳ Parando…",
+      "processing": "⏳ Processando…",
+      "unknown_action": "Ação desconhecida"
+    },
+    "pair": {
+      "no_owner": "⚠️ Nenhum proprietário pareado. Use /pair <PIN> para parear.",
+      "already_paired": "❌ O bot já está pareado com outro proprietário.",
+      "invalid_format": "❌ Formato de PIN inválido. Digite o PIN de 6 dígitos exibido no app.",
+      "no_pin": "❌ Nenhum PIN foi gerado. Gere primeiro um PIN no app.",
+      "expired": "❌ O PIN expirou. Gere um novo PIN no app.",
+      "invalid": "❌ PIN inválido. Confira o PIN exibido no app.",
+      "storage_error": "⚠️ Não foi possível salvar o pareamento (erro de armazenamento). Tente /pair novamente; se o problema continuar, reinicie o app.",
+      "success": "✅ Pareamento concluído!\n\nBoas-vindas, {0}!\nUse /help para ver os comandos disponíveis.",
+      "success_no_name": "✅ Pareamento concluído!\n\nUse /help para ver os comandos disponíveis."
+    },
+    "tunnel": {
+      "notification_url": "🌐 *URL do túnel*\n{0}",
+      "notification_url_changed": "🔄 *URL do túnel alterada*\n{0}"
+    },
+    "critical": {
+      "message": "⚠️ *Alerta crítico*\n{0}",
+      "message_with_details": "⚠️ *Alerta crítico*\n{0}\n{1}",
+      "type": {
+        "low_battery": "🔋 Bateria fraca",
+        "storage_full": "💾 Armazenamento cheio",
+        "daemon_crash": "⚠️ Falha em um daemon",
+        "system_error": "❌ Erro do sistema",
+        "system_reboot": "🔄 Reinicialização do sistema",
+        "unknown": "❓ Evento crítico desconhecido"
+      }
+    },
+    "motion": {
+      "tier": {
+        "critical": "CRÍTICO",
+        "alert": "Alerta"
+      },
+      "actor": {
+        "person": "Pessoa",
+        "bike": "Bicicleta",
+        "vehicle": "Veículo",
+        "animal": "Animal",
+        "motion": "Movimento"
+      },
+      "camera": {
+        "front": "dianteira",
+        "right": "direita",
+        "rear": "traseira",
+        "left": "esquerda"
+      },
+      "title": {
+        "tier_actor_camera": "{0} *{1} · {2} na câmera {3}*",
+        "tier_actor": "{0} *{1} · {2}*",
+        "tier_camera": "{0} *{1} na câmera {2}*",
+        "tier": "{0} *{1}*",
+        "actor_camera": "{0} *{1} na câmera {2}*",
+        "actor": "{0} *{1}*",
+        "camera": "{0} *Movimento na câmera {1}*",
+        "detected": "{0} *Movimento detectado*"
+      },
+      "proximity": {
+        "very_close": "Muito perto",
+        "close": "Perto",
+        "mid": "Distância média",
+        "far": "Longe"
+      },
+      "count": {
+        "person_one": "{0} pessoa",
+        "person_many": "{0} pessoas",
+        "vehicle_one": "{0} veículo",
+        "vehicle_many": "{0} veículos",
+        "bike_one": "{0} bicicleta",
+        "bike_many": "{0} bicicletas",
+        "animal_one": "{0} animal",
+        "animal_many": "{0} animais"
+      },
+      "recording_in_progress": "_Gravação em andamento_",
+      "detected_at": "🕒 _Detectado às {0}_",
+      "cleared_no_event": "✅ Movimento descartado — nenhum evento foi gravado (alerta falso sem pessoa, veículo ou animal)."
+    },
+    "media": {
+      "video_too_large": "📹 *Vídeo grande demais para enviar*\n`{0}` ({1} MB)\nVeja o arquivo no dispositivo — ele excede o limite de 50 MB do Telegram.",
+      "document_too_large": "📄 *Arquivo grande demais para enviar*\n`{0}` ({1} MB) — excede o limite de 50 MB do Telegram."
+    },
+    "legacy": {
+      "connectivity": {
+        "connected": "📶 Conectado por {0}",
+        "disconnected": "📵 Desconectado de {0}"
+      },
+      "critical_with_details": "{0}: {1}",
+      "motion": {
+        "detected_actor": "🚨 Detecção: {0} ({1}%)",
+        "detected": "👁 Movimento detectado"
+      },
+      "tunnel": {
+        "connected": "🌐 Túnel conectado:\n{0}",
+        "changed": "🔄 URL do túnel alterada:\n{0}"
+      },
+      "video": {
+        "saved_with_detection": "🎬 Gravação salva (detecção: {0}) — {1}s",
+        "saved": "🎬 Gravação salva — {0}s"
+      }
+    }
   },
   "vehicle_control": {
     "cloud_required": "Conectar uma conta BYD em Configurações para usar este controle",

--- a/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
+++ b/app/src/main/java/com/overdrive/app/byd/BydDataCollector.java
@@ -3,6 +3,7 @@ package com.overdrive.app.byd;
 import android.content.Context;
 
 import com.overdrive.app.logging.DaemonLogger;
+import com.overdrive.app.server.Messages;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -2973,8 +2974,15 @@ public class BydDataCollector {
         logger.info(sb.toString());
     }
 
-    private static final String[] TYRE_WHEEL_LABELS =
-            {"Front-left", "Front-right", "Rear-left", "Rear-right"};
+    private static String tyreWheelLabel(int wheel) {
+        switch (wheel) {
+            case 0: return Messages.get("notifications.area_front_left");
+            case 1: return Messages.get("notifications.area_front_right");
+            case 2: return Messages.get("notifications.area_rear_left");
+            case 3: return Messages.get("notifications.area_rear_right");
+            default: return Messages.get("notifications.area_door_n", wheel + 1);
+        }
+    }
 
     /**
      * Per-corner latched tyre-alarm evaluator. Called on every tyre read (poll
@@ -3080,7 +3088,7 @@ public class BydDataCollector {
                 if (++tyrePressureNormalStreak[i] >= TYRE_ALARM_REARM_STREAK) {
                     tyrePressureLatchedLevel[i] = 0;
                     tyrePressureNormalStreak[i] = 0;
-                    logger.info("Tyre pressure re-armed (normal): " + TYRE_WHEEL_LABELS[i]
+                    logger.info("Tyre pressure re-armed (normal): " + tyreWheelLabel(i)
                             + (kPaValid ? " " + kPa + " kPa" : ""));
                 }
             }
@@ -3119,10 +3127,13 @@ public class BydDataCollector {
         // — stay silent.
         if (fireLevel > tyrePressureLatchedLevel[i]) {
             tyrePressureLatchedLevel[i] = fireLevel;
-            String kPaText = kPaValid ? (kPa + " kPa") : "no reading";
+            String kPaText = kPaValid ? (kPa + " kPa")
+                    : Messages.get("notifications.tyre_no_reading");
             String title = fireLevel >= 2
-                    ? "Tyre critically low"
-                    : (over ? "Overpressure" : "Underpressure");
+                    ? Messages.get("notifications.tyre_critically_low")
+                    : Messages.get(over
+                            ? "notifications.tyre_overpressure"
+                            : "notifications.tyre_underpressure");
             com.overdrive.app.notifications.NotificationEvent.Severity sev = fireLevel >= 2
                     ? com.overdrive.app.notifications.NotificationEvent.Severity.CRITICAL
                     : com.overdrive.app.notifications.NotificationEvent.Severity.WARN;
@@ -3137,7 +3148,8 @@ public class BydDataCollector {
                                 "vehicle.health.tyre.pressure",
                                 sev,
                                 title,
-                                TYRE_WHEEL_LABELS[i] + " — " + kPaText,
+                                Messages.get("notifications.tyre_wheel_reading",
+                                        tyreWheelLabel(i), kPaText),
                                 "tyre-pressure-" + i,
                                 null,
                                 data));
@@ -3159,7 +3171,7 @@ public class BydDataCollector {
                 if (++tyreLeakNormalStreak[i] >= TYRE_ALARM_REARM_STREAK) {
                     tyreLeakLatchedSeverity[i] = 0;
                     tyreLeakNormalStreak[i] = 0;
-                    logger.info("Tyre leak re-armed (normal): " + TYRE_WHEEL_LABELS[i]);
+                    logger.info("Tyre leak re-armed (normal): " + tyreWheelLabel(i));
                 }
             }
             return;
@@ -3183,9 +3195,13 @@ public class BydDataCollector {
                         new com.overdrive.app.notifications.NotificationEvent(
                                 "vehicle.health.tyre.leak",
                                 sev,
-                                leak == 2 ? "Fast leak detected" : "Slow leak detected",
-                                TYRE_WHEEL_LABELS[i]
-                                        + (kPaValid ? " (" + kPa + " kPa)" : ""),
+                                Messages.get(leak == 2
+                                        ? "notifications.tyre_fast_leak"
+                                        : "notifications.tyre_slow_leak"),
+                                kPaValid
+                                        ? Messages.get("notifications.tyre_wheel_pressure",
+                                                tyreWheelLabel(i), kPa)
+                                        : tyreWheelLabel(i),
                                 "tyre-leak-" + i,
                                 null,
                                 data));

--- a/app/src/main/java/com/overdrive/app/daemon/TelegramBotDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/TelegramBotDaemon.java
@@ -5,6 +5,8 @@ import android.os.Looper;
 import com.overdrive.app.daemon.telegram.CommandContext;
 import com.overdrive.app.daemon.telegram.CommandRouter;
 import com.overdrive.app.logging.DaemonLogger;
+import com.overdrive.app.server.LocaleManager;
+import com.overdrive.app.telegram.TelegramMessages;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -42,6 +44,10 @@ public class TelegramBotDaemon {
     
     private static final String TAG = "TelegramBotDaemon";
     private static DaemonLogger logger;
+
+    private static String tr(String key, Object... args) {
+        return TelegramMessages.get(key, args);
+    }
     
     // ==================== ENCRYPTED CONSTANTS (SOTA Java obfuscation) ====================
     // Decrypted at runtime via Safe.s() - AES-256-CBC with stack-based key reconstruction
@@ -1322,9 +1328,8 @@ public class TelegramBotDaemon {
                             // URL. Mirrors the web (toast install_failed) and app
                             // (showError) failure surfaces.
                             if (installFailedReason != null) {
-                                String failMsg = "⚠️ *Overdrive update failed*\n"
-                                        + "The device is still on the previous version.\n"
-                                        + "Reason: " + mdEscape(installFailedReason);
+                                String failMsg = tr("update.install_failed",
+                                        TelegramMessages.technicalDetail(installFailedReason));
                                 boolean failOk = sendMessage(ownerChatId, failMsg);
                                 log("notifyTunnel install-failed message sent: " + failOk);
                             }
@@ -1336,15 +1341,15 @@ public class TelegramBotDaemon {
                                 // named cloudflared tunnels keep the same URL. Only
                                 // call out the rotation when it actually happened.
                                 boolean rotates = url.contains(".trycloudflare.com");
-                                msg = "🔄 *Overdrive updated to " + postUpdateVersion + "*\n" +
-                                      (rotates ? "New tunnel URL:\n" : "Tunnel back online:\n") + url;
-                                if (rotates) {
-                                    msg += "\n\n_The cloudflared link rotates after every install._";
-                                }
+                                msg = rotates
+                                        ? tr("update.installed_new_tunnel",
+                                                mdEscape(postUpdateVersion), url)
+                                        : tr("update.installed_tunnel_online",
+                                                mdEscape(postUpdateVersion), url);
                             } else if (isNew) {
-                                msg = "🌐 *Tunnel URL*\n" + url;
+                                msg = tr("tunnel.notification_url", url);
                             } else {
-                                msg = "🔄 *Tunnel URL Changed*\n" + url;
+                                msg = tr("tunnel.notification_url_changed", url);
                             }
                             boolean ok = sendMessage(ownerChatId, msg);
                             log("notifyTunnel message sent: " + ok +
@@ -1433,8 +1438,11 @@ public class TelegramBotDaemon {
                     String criticalType = cmd.optString("type", "");
                     String details = cmd.optString("details", "");
                     if (ownerChatId > 0) {
-                        String msg = "⚠️ *Critical Alert*\n" + criticalType;
-                        if (!details.isEmpty()) msg += "\n" + details;
+                        String localizedType = criticalTypeLabel(criticalType);
+                        String msg = details.isEmpty()
+                                ? tr("critical.message", localizedType)
+                                : tr("critical.message_with_details", localizedType,
+                                        TelegramMessages.technicalDetail(details));
                         boolean ok = sendMessage(ownerChatId, msg);
                         response.put("status", ok ? "ok" : "error");
                     } else {
@@ -1627,9 +1635,8 @@ public class TelegramBotDaemon {
                 String installFailedReason = consumeInstallFailedHint();
                 if (installFailedReason != null) {
                     if (criticalAlertsEnabled) {
-                        String failMsg = "⚠️ *Overdrive update failed*\n"
-                                + "The device is still on the previous version.\n"
-                                + "Reason: " + mdEscape(installFailedReason);
+                        String failMsg = tr("update.install_failed",
+                                TelegramMessages.technicalDetail(installFailedReason));
                         boolean ok = sendMessage(ownerChatId, failMsg);
                         log("Startup install-failed message sent: " + ok);
                     } else {
@@ -1641,7 +1648,8 @@ public class TelegramBotDaemon {
                 String postUpdateVersion = consumePostUpdateHint();
                 if (postUpdateVersion != null) {
                     if (criticalAlertsEnabled) {
-                        String msg = "🔄 *Overdrive updated to " + mdEscape(postUpdateVersion) + "*";
+                        String msg = tr("update.installed",
+                                mdEscape(postUpdateVersion));
                         boolean ok = sendMessage(ownerChatId, msg);
                         log("Startup update-success message sent: " + ok);
                     } else {
@@ -1905,13 +1913,13 @@ public class TelegramBotDaemon {
         }
 
         try {
-            String greeting = "🤖 *Surveillance Bot Online*\n\n" +
-                    "Bot daemon started and ready.\n" +
-                    "Use /help for available commands.";
+            String greeting = tr("greeting.online");
 
             String[][][] buttons = {
-                {{"📊 Status", "cmd:/status"}, {"🤖 Daemons", "cmd:/daemons"}},
-                {{"📹 Events", "cmd:/events"}, {"🌐 Tunnel URL", "cmd:/url"}}
+                {{tr("buttons.status"), "cmd:/status"},
+                        {tr("buttons.daemons"), "cmd:/daemons"}},
+                {{tr("buttons.events"), "cmd:/events"},
+                        {tr("buttons.tunnel_url"), "cmd:/url"}}
             };
 
             boolean sent = sendMessageWithButtons(ownerChatId, greeting, buttons);
@@ -2056,7 +2064,7 @@ public class TelegramBotDaemon {
             
             // Owner-only commands
             if (ownerChatId <= 0) {
-                sendMessage(chatId, "⚠️ No owner paired. Use /pair <PIN> to pair.");
+                sendMessage(chatId, tr("pair.no_owner"));
                 return;
             }
             
@@ -2090,14 +2098,14 @@ public class TelegramBotDaemon {
             
             // Only allow owner
             if (userId != ownerChatId) {
-                answerCallbackQuery(callbackId, "⚠️ Not authorized");
+                answerCallbackQuery(callbackId, tr("callback.not_authorized"));
                 return;
             }
             
             // Handle download callback: "dl:filename.mp4"
             if (data.startsWith("dl:")) {
                 String filename = data.substring(3);
-                answerCallbackQuery(callbackId, "📥 Downloading...");
+                answerCallbackQuery(callbackId, tr("callback.downloading"));
                 commandRouter.route(ownerChatId, "/download " + filename);
             }
             // Handle events pagination: "ev:hours:page"
@@ -2118,12 +2126,21 @@ public class TelegramBotDaemon {
             else if (data.startsWith("dm:")) {
                 String[] parts = data.substring(3).split(":");
                 if (parts.length == 2) {
-                    answerCallbackQuery(callbackId, "⏳ " + parts[1] + "ing...");
+                    String action = parts[1];
+                    String callbackText;
+                    if ("start".equals(action)) {
+                        callbackText = tr("callback.starting");
+                    } else if ("stop".equals(action)) {
+                        callbackText = tr("callback.stopping");
+                    } else {
+                        callbackText = tr("callback.processing");
+                    }
+                    answerCallbackQuery(callbackId, callbackText);
                     commandRouter.route(ownerChatId, "/daemon " + parts[0] + " " + parts[1]);
                 }
             }
             else {
-                answerCallbackQuery(callbackId, "Unknown action");
+                answerCallbackQuery(callbackId, tr("callback.unknown_action"));
             }
             
         } catch (Exception e) {
@@ -2157,12 +2174,12 @@ public class TelegramBotDaemon {
     
     private static void handlePairCommand(long chatId, String username, String firstName, String pin) {
         if (ownerChatId > 0) {
-            sendMessage(chatId, "❌ Already paired with another owner.");
+            sendMessage(chatId, tr("pair.already_paired"));
             return;
         }
         
         if (pin.length() != 6 || !pin.matches("\\d+")) {
-            sendMessage(chatId, "❌ Invalid PIN format. Enter 6-digit PIN from app.");
+            sendMessage(chatId, tr("pair.invalid_format"));
             return;
         }
         
@@ -2181,19 +2198,19 @@ public class TelegramBotDaemon {
         }
         
         if (expectedPin == null || expectedPin.isEmpty()) {
-            sendMessage(chatId, "❌ No PIN generated. Generate a PIN from the app first.");
+            sendMessage(chatId, tr("pair.no_pin"));
             return;
         }
         
         if (System.currentTimeMillis() > pinExpiry) {
-            sendMessage(chatId, "❌ PIN expired. Generate a new PIN from the app.");
+            sendMessage(chatId, tr("pair.expired"));
             // Clear expired PIN from config
             clearPairPinFromConfig();
             return;
         }
         
         if (!pin.equals(expectedPin)) {
-            sendMessage(chatId, "❌ Invalid PIN. Check the PIN shown in the app.");
+            sendMessage(chatId, tr("pair.invalid"));
             return;
         }
         
@@ -2211,15 +2228,16 @@ public class TelegramBotDaemon {
             // every alert would silently drop. Surface the failure instead of
             // claiming a pairing that won't survive — the user can retry.
             ownerChatId = chatId;  // best-effort for THIS session's reply
-            sendMessage(chatId, "⚠️ Pairing could not be saved (storage error). "
-                    + "Please try /pair again; if it keeps failing, restart the app.");
+            sendMessage(chatId, tr("pair.storage_error"));
             log("handlePairCommand: owner persist FAILED for " + chatId + " — pairing not durable");
             return;
         }
         ownerChatId = chatId;
         clearPairPinFromConfig();
 
-        sendMessage(chatId, "✅ Paired successfully!\n\nWelcome, " + firstName + "!\nUse /help to see available commands.");
+        sendMessage(chatId, firstName == null || firstName.isEmpty()
+                ? tr("pair.success_no_name")
+                : tr("pair.success", mdEscape(firstName)));
     }
     
     private static void clearPairPinFromConfig() {
@@ -2532,31 +2550,41 @@ public class TelegramBotDaemon {
                 : null;
         String tierIcon;
         String tierWord;
-        if ("CRITICAL".equalsIgnoreCase(severity))    { tierIcon = "🚨"; tierWord = "CRITICAL"; }
-        else if ("ALERT".equalsIgnoreCase(severity))  { tierIcon = "⚠️"; tierWord = "Alert"; }
+        if ("CRITICAL".equalsIgnoreCase(severity)) {
+            tierIcon = "🚨";
+            tierWord = tr("motion.tier.critical");
+        }
+        else if ("ALERT".equalsIgnoreCase(severity)) {
+            tierIcon = "⚠️";
+            tierWord = tr("motion.tier.alert");
+        }
         else                                          { tierIcon = "👁"; tierWord = null; }
 
         // Camera is the only free-form interpolation outside backticks. Today
         // it's enum-bounded ("front"/"right"/"rear"/"left") so safe, but
         // mdEscape it defensively so a future user-supplied label can't break
         // Markdown rendering with a stray *, _, `, or [.
-        String safeCamera = camera.isEmpty() ? "" : mdEscape(camera);
-        msg.append(tierIcon).append(" *");
+        String safeCamera = camera.isEmpty() ? "" : mdEscape(cameraLabel(camera));
+        String title;
         if (tierWord != null && haveActorInfo) {
-            msg.append(tierWord).append(" · ").append(primary);
-            if (!safeCamera.isEmpty()) msg.append(" at ").append(safeCamera);
+            title = safeCamera.isEmpty()
+                    ? tr("motion.title.tier_actor", tierIcon, tierWord, primary)
+                    : tr("motion.title.tier_actor_camera", tierIcon, tierWord,
+                            primary, safeCamera);
         } else if (tierWord != null) {
-            msg.append(tierWord);
-            if (!safeCamera.isEmpty()) msg.append(" at ").append(safeCamera);
+            title = safeCamera.isEmpty()
+                    ? tr("motion.title.tier", tierIcon, tierWord)
+                    : tr("motion.title.tier_camera", tierIcon, tierWord, safeCamera);
         } else if (haveActorInfo) {
-            msg.append(primary);
-            if (!safeCamera.isEmpty()) msg.append(" at ").append(safeCamera);
+            title = safeCamera.isEmpty()
+                    ? tr("motion.title.actor", tierIcon, primary)
+                    : tr("motion.title.actor_camera", tierIcon, primary, safeCamera);
         } else if (!safeCamera.isEmpty()) {
-            msg.append("Motion at ").append(safeCamera);
+            title = tr("motion.title.camera", tierIcon, safeCamera);
         } else {
-            msg.append("Motion detected");
+            title = tr("motion.title.detected", tierIcon);
         }
-        msg.append("*\n");
+        msg.append(title).append("\n");
 
         // ---- Body line ----
         if (finalized) {
@@ -2573,7 +2601,7 @@ public class TelegramBotDaemon {
         } else {
             // Start-stage: minimal "in progress" line, mirrors the PWA
             // "Recording in progress" body.
-            msg.append("_Recording in progress_\n");
+            msg.append(tr("motion.recording_in_progress")).append("\n");
         }
 
         // ---- Footer ----
@@ -2594,15 +2622,15 @@ public class TelegramBotDaemon {
             long lagMs = System.currentTimeMillis() - eventTimeMs;
             if (lagMs > STALE_NOTICE_MS) {
                 java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(
-                        "HH:mm:ss", java.util.Locale.US);
+                        "HH:mm:ss", java.util.Locale.forLanguageTag(LocaleManager.get()));
                 // Separate from the preceding line only when there IS one and it
                 // doesn't already end in a newline — avoids a leading blank line
                 // when the body + filename were both empty.
                 if (msg.length() > 0 && msg.charAt(msg.length() - 1) != '\n') {
                     msg.append("\n");
                 }
-                msg.append("🕒 _Detected ").append(sdf.format(new java.util.Date(eventTimeMs)))
-                        .append("_");
+                msg.append(tr("motion.detected_at",
+                        sdf.format(new java.util.Date(eventTimeMs))));
             }
         }
         return msg.toString();
@@ -2632,21 +2660,32 @@ public class TelegramBotDaemon {
         // Match the engine-side classRank: PERSON > BIKE > VEHICLE > ANIMAL.
         // Single-actor case shows just the class word; the body line carries
         // the count breakdown when there's more than one actor.
-        if (p > 0) return "Person";
-        if (b > 0) return "Bike";
-        if (v > 0) return "Vehicle";
-        if (a > 0) return "Animal";
-        return "Motion";
+        if (p > 0) return tr("motion.actor.person");
+        if (b > 0) return tr("motion.actor.bike");
+        if (v > 0) return tr("motion.actor.vehicle");
+        if (a > 0) return tr("motion.actor.animal");
+        return tr("motion.actor.motion");
+    }
+
+    private static String cameraLabel(String camera) {
+        if (camera == null || camera.isEmpty()) return "";
+        switch (camera.toLowerCase(java.util.Locale.ROOT)) {
+            case "front": return tr("motion.camera.front");
+            case "right": return tr("motion.camera.right");
+            case "rear":  return tr("motion.camera.rear");
+            case "left":  return tr("motion.camera.left");
+            default:      return camera;
+        }
     }
 
     /** Capitalised proximity phrase for the body's lead clause. */
     private static String proximityPhraseTelegram(String enumName) {
         if (enumName == null) return "";
         switch (enumName) {
-            case "VERY_CLOSE": return "Very close";
-            case "CLOSE":      return "Close";
-            case "MID":        return "Mid range";
-            case "FAR":        return "Far";
+            case "VERY_CLOSE": return tr("motion.proximity.very_close");
+            case "CLOSE":      return tr("motion.proximity.close");
+            case "MID":        return tr("motion.proximity.mid");
+            case "FAR":        return tr("motion.proximity.far");
             default:           return "";
         }
     }
@@ -2654,11 +2693,28 @@ public class TelegramBotDaemon {
     /** Pluralised count list: "1 person, 2 vehicles" — drops "× n" formatter. */
     private static String formatTelegramCounts(int p, int v, int b, int a) {
         java.util.List<String> parts = new java.util.ArrayList<>(4);
-        if (p > 0) parts.add(p + " " + (p == 1 ? "person"  : "people"));
-        if (v > 0) parts.add(v + " " + (v == 1 ? "vehicle" : "vehicles"));
-        if (b > 0) parts.add(b + " " + (b == 1 ? "bike"    : "bikes"));
-        if (a > 0) parts.add(a + " " + (a == 1 ? "animal"  : "animals"));
+        if (p > 0) parts.add(tr(p == 1 ? "motion.count.person_one" : "motion.count.person_many",
+                String.valueOf(p)));
+        if (v > 0) parts.add(tr(v == 1 ? "motion.count.vehicle_one" : "motion.count.vehicle_many",
+                String.valueOf(v)));
+        if (b > 0) parts.add(tr(b == 1 ? "motion.count.bike_one" : "motion.count.bike_many",
+                String.valueOf(b)));
+        if (a > 0) parts.add(tr(a == 1 ? "motion.count.animal_one" : "motion.count.animal_many",
+                String.valueOf(a)));
         return String.join(", ", parts);
+    }
+
+    private static String criticalTypeLabel(String type) {
+        if (type == null || type.isEmpty()) return tr("critical.type.system_error");
+        switch (type.toUpperCase(java.util.Locale.ROOT)) {
+            case "LOW_BATTERY": return tr("critical.type.low_battery");
+            case "STORAGE_FULL": return tr("critical.type.storage_full");
+            case "DAEMON_CRASH": return tr("critical.type.daemon_crash");
+            case "SYSTEM_REBOOT": return tr("critical.type.system_reboot");
+            case "SYSTEM_ERROR": return tr("critical.type.system_error");
+            default: return TelegramMessages.isPortuguese()
+                    ? tr("critical.type.unknown") : mdEscape(type);
+        }
     }
 
     /** Telegram bot API file-upload ceiling. Above this, sendVideo/sendDocument 400. */
@@ -2684,9 +2740,8 @@ public class TelegramBotDaemon {
                 long mb = len / (1000L * 1000L);
                 log("Video " + videoFile.getName() + " is " + mb
                         + "MB > 50MB Telegram limit; sending text notice instead");
-                String notice = "📹 *Clip too large to send*\n`"
-                        + videoFile.getName() + "` (" + mb + " MB)\n"
-                        + "View it on the device — over Telegram's 50 MB limit.";
+                String notice = tr("media.video_too_large",
+                        videoFile.getName(), String.valueOf(mb));
                 return sendMessage(chatId, notice);
             }
 
@@ -2758,8 +2813,8 @@ public class TelegramBotDaemon {
                 long mb = len / (1000L * 1000L);
                 log("Document " + docFile.getName() + " is " + mb
                         + "MB > 50MB Telegram limit; sending text notice instead");
-                return sendMessage(chatId, "📄 *File too large to send*\n`"
-                        + docFile.getName() + "` (" + mb + " MB) — over Telegram's 50 MB limit.");
+                return sendMessage(chatId, tr("media.document_too_large",
+                        docFile.getName(), String.valueOf(mb)));
             }
 
             String url = TELEGRAM_API_BASE() + botToken + "/sendDocument";

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/BackupCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/BackupCommandHandler.java
@@ -36,11 +36,7 @@ public class BackupCommandHandler implements TelegramCommandHandler {
     @Override
     public void handle(long chatId, String[] args, CommandContext ctx) {
         if (args.length > 1 && "restore".equalsIgnoreCase(args[1])) {
-            ctx.sendMessage(chatId,
-                    "ℹ️ *Restore* isn't available over Telegram.\n\n" +
-                    "Open Overdrive on the head unit (or the app) → *Settings → " +
-                    "Backup & Restore* → choose your backup file. Restore is " +
-                    "same-device only and asks for confirmation there.");
+            ctx.sendMessage(chatId, ctx.tr("backup.restore_unavailable"));
             return;
         }
 
@@ -49,8 +45,8 @@ public class BackupCommandHandler implements TelegramCommandHandler {
         boolean includeTrips = args.length > 1 && "trips".equalsIgnoreCase(args[1]);
 
         ctx.sendMessage(chatId, includeTrips
-                ? "💾 Building backup (settings + trip history)…"
-                : "💾 Building settings backup…");
+                ? ctx.tr("backup.building_with_trips")
+                : ctx.tr("backup.building_settings"));
 
         JSONObject req = new JSONObject();
         try {
@@ -60,17 +56,17 @@ public class BackupCommandHandler implements TelegramCommandHandler {
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, EXPORT_TIMEOUT_MS);
         if (resp == null) {
-            ctx.sendMessage(chatId, "⚠️ Could not reach the backup service.\n\n" +
-                    "The camera daemon may not be running. Try `/daemon camera start`.");
+            ctx.sendMessage(chatId, ctx.tr("backup.service_unreachable"));
             return;
         }
         if (!resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId, "⚠️ Backup failed: " + resp.optString("error", "unknown"));
+            ctx.sendMessage(chatId, ctx.tr("backup.failed",
+                    ctx.technicalDetail(resp.optString("error", ""))));
             return;
         }
         JSONObject bundle = resp.optJSONObject("bundle");
         if (bundle == null) {
-            ctx.sendMessage(chatId, "⚠️ Backup returned no data.");
+            ctx.sendMessage(chatId, ctx.tr("backup.no_data"));
             return;
         }
 
@@ -99,7 +95,8 @@ public class BackupCommandHandler implements TelegramCommandHandler {
             }
         } catch (Exception e) {
             try { tmp.delete(); } catch (Exception ignored) {}
-            ctx.sendMessage(chatId, "⚠️ Could not write the backup file: " + e.getMessage());
+            ctx.sendMessage(chatId, ctx.tr("backup.write_failed",
+                    ctx.technicalDetail(e.getMessage())));
             return;
         }
 
@@ -111,25 +108,26 @@ public class BackupCommandHandler implements TelegramCommandHandler {
         org.json.JSONArray tripsArr = bundle.optJSONArray("trips");
         if (tripsArr != null) tripCount = tripsArr.length();
 
-        String title = (includeTrips
-                ? "💾 Overdrive backup (settings + " + tripCount + " trips)"
-                : "💾 Overdrive settings backup")
-                + (appVer.isEmpty() ? "" : " · " + appVer);
+        String caption;
+        if (includeTrips) {
+            caption = appVer.isEmpty()
+                    ? ctx.tr("backup.document_with_trips", tripCount)
+                    : ctx.tr("backup.document_with_trips_version", tripCount, appVer);
+        } else {
+            caption = appVer.isEmpty()
+                    ? ctx.tr("backup.document_settings")
+                    : ctx.tr("backup.document_settings_version", appVer);
+        }
 
         boolean sent;
         try {
-            sent = ctx.sendDocument(chatId, tmp.getAbsolutePath(),
-                    title +
-                    "\n\n⚠️ This file contains your credentials and device key" +
-                    (includeTrips ? " and your location history" : "") +
-                    " — keep it private. " +
-                    "Restore it on this same head unit via Settings → Backup & Restore.");
+            sent = ctx.sendDocument(chatId, tmp.getAbsolutePath(), caption);
         } finally {
             try { tmp.delete(); } catch (Exception ignored) {}
         }
 
         if (!sent) {
-            ctx.sendMessage(chatId, "⚠️ Could not upload the backup file to Telegram.");
+            ctx.sendMessage(chatId, ctx.tr("backup.upload_failed"));
         }
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/CommandContext.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/CommandContext.java
@@ -1,11 +1,24 @@
 package com.overdrive.app.daemon.telegram;
 
+import com.overdrive.app.telegram.TelegramMessages;
 import org.json.JSONObject;
 
 /**
  * Context for command execution - provides messaging and utility methods.
  */
 public interface CommandContext {
+
+    /**
+     * Resolve user-facing Telegram copy using the app's current locale.
+     */
+    default String tr(String key, Object... args) {
+        return TelegramMessages.get(key, args);
+    }
+
+    /** Localize and Markdown-escape a technical error returned by a backend. */
+    default String technicalDetail(String detail) {
+        return TelegramMessages.technicalDetail(detail);
+    }
     
     /**
      * Send a text message to the chat.

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/CommandRouter.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/CommandRouter.java
@@ -2,6 +2,7 @@ package com.overdrive.app.daemon.telegram;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Routes commands to appropriate handlers.
@@ -36,7 +37,7 @@ public class CommandRouter {
         }
         
         String[] args = text.split("\\s+");
-        String command = args[0].toLowerCase();
+        String command = args[0].toLowerCase(Locale.ROOT);
         
         for (TelegramCommandHandler handler : handlers) {
             if (handler.canHandle(command)) {
@@ -46,7 +47,7 @@ public class CommandRouter {
         }
         
         // Unknown command
-        context.sendMessage(chatId, "Unknown command. Use /help for available commands.");
+        context.sendMessage(chatId, context.tr("router.unknown_command"));
         return true;
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/DaemonCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/DaemonCommandHandler.java
@@ -3,6 +3,7 @@ package com.overdrive.app.daemon.telegram;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -23,17 +24,17 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
     private String lastCommandKey = "";
     private static final long DEBOUNCE_MS = 3000;
     
-    // Daemon definitions: name -> [processName, className, displayName, startable]
+    // Daemon definitions: name -> [processName, className, displayNameKey, startable]
     // startable: "yes" if can be started via app_process or shell, "no" if can't be started remotely
     private static final String[][] DAEMONS = {
-        {"camera", "byd_cam_daemon", "CameraDaemon", "Camera", "yes"},
-        {"acc", "acc_sentry_daemon", "AccSentryDaemon", "ACC Sentry", "yes"},
-        {"sentry", "sentry_daemon", "SentryDaemon", "Sentry", "yes"},
-        {"telegram", "telegram_bot_daemon", "TelegramBotDaemon", "Telegram", "yes"},
-        {"cloudflared", "cloudflared", "shell", "Cloudflare Tunnel", "yes"},
-        {"zrok", "zrok", "shell", "Zrok Tunnel", "yes"},
-        {"tailscale", "tailscaled", "shell", "Tailscale Tunnel", "yes"},
-        {"singbox", "sing-box", "shell", "Sing-Box", "yes"},
+        {"camera", "byd_cam_daemon", "CameraDaemon", "daemon_names.camera", "yes"},
+        {"acc", "acc_sentry_daemon", "AccSentryDaemon", "daemon_names.acc_sentry", "yes"},
+        {"sentry", "sentry_daemon", "SentryDaemon", "daemon_names.sentry", "yes"},
+        {"telegram", "telegram_bot_daemon", "TelegramBotDaemon", "daemon_names.telegram", "yes"},
+        {"cloudflared", "cloudflared", "shell", "daemon_names.cloudflare_tunnel", "yes"},
+        {"zrok", "zrok", "shell", "daemon_names.zrok_tunnel", "yes"},
+        {"tailscale", "tailscaled", "shell", "daemon_names.tailscale_tunnel", "yes"},
+        {"singbox", "sing-box", "shell", "daemon_names.sing_box", "yes"},
     };
     
     private static final String AVAILABLE_DAEMONS = "camera, acc, sentry, cloudflared, zrok, tailscale, singbox";
@@ -46,12 +47,12 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
     @Override
     public void handle(long chatId, String[] args, CommandContext ctx) {
         if (args.length < 3) {
-            ctx.sendMessage(chatId, "Usage: /daemon <name> start|stop|status\n\nAvailable: " + AVAILABLE_DAEMONS);
+            ctx.sendMessage(chatId, ctx.tr("daemon.usage", AVAILABLE_DAEMONS));
             return;
         }
         
-        String name = args[1].toLowerCase();
-        String action = args[2].toLowerCase();
+        String name = args[1].toLowerCase(Locale.ROOT);
+        String action = args[2].toLowerCase(Locale.ROOT);
         
         // Debounce
         String cmdKey = name + ":" + action;
@@ -66,17 +67,17 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
         // Find daemon
         String[] daemon = findDaemon(name);
         if (daemon == null) {
-            ctx.sendMessage(chatId, "❌ Unknown daemon: " + name + "\n\nAvailable: " + AVAILABLE_DAEMONS);
+            ctx.sendMessage(chatId, ctx.tr("daemon.unknown", name, AVAILABLE_DAEMONS));
             return;
         }
         
         String processName = daemon[1];
-        String displayName = daemon[3];
+        String displayName = ctx.tr(daemon[3]);
         boolean isStartable = "yes".equals(daemon[4]);
         
         // Can't control telegram from telegram
         if ("telegram".equals(name)) {
-            ctx.sendMessage(chatId, "⚠️ Cannot control Telegram daemon from Telegram.");
+            ctx.sendMessage(chatId, ctx.tr("daemon.cannot_control_telegram"));
             return;
         }
         
@@ -87,9 +88,9 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
         switch (action) {
             case "start":
                 if (isRunning) {
-                    ctx.sendMessage(chatId, "ℹ️ " + displayName + " is already running.");
+                    ctx.sendMessage(chatId, ctx.tr("daemon.already_running", displayName));
                 } else if (!isStartable) {
-                    ctx.sendMessage(chatId, "⚠️ " + displayName + " must be started from the app UI.");
+                    ctx.sendMessage(chatId, ctx.tr("daemon.must_start_from_app", displayName));
                 } else {
                     // Clear the durable disable sentinel — user is explicitly
                     // starting this daemon, so the watchdog + app health-check
@@ -137,13 +138,13 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
                         // Clear stopped state - daemon was started via Telegram
                         saveDaemonState(name, true, ctx);
                     }
-                    ctx.sendMessage(chatId, ok ? "✅ " + displayName + " started." : "⚠️ Failed to start " + displayName);
+                    ctx.sendMessage(chatId, ctx.tr(ok ? "daemon.started" : "daemon.start_failed", displayName));
                 }
                 break;
                 
             case "stop":
                 if (!isRunning) {
-                    ctx.sendMessage(chatId, "ℹ️ " + displayName + " is not running.");
+                    ctx.sendMessage(chatId, ctx.tr("daemon.not_running", displayName));
                 } else {
                     // Real user stop — plant the durable disable sentinel so the
                     // watchdog + app health-check honor it across restarts.
@@ -152,16 +153,18 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
                         // Mark as stopped via Telegram - health check should NOT auto-restart
                         saveDaemonState(name, false, ctx);
                     }
-                    ctx.sendMessage(chatId, ok ? "⛔ " + displayName + " stopped." : "⚠️ Failed to stop " + displayName);
+                    ctx.sendMessage(chatId, ctx.tr(ok ? "daemon.stopped" : "daemon.stop_failed", displayName));
                 }
                 break;
                 
             case "status":
-                ctx.sendMessage(chatId, displayName + ": " + (isRunning ? "✅ Running" : "⛔ Stopped"));
+                ctx.sendMessage(chatId, ctx.tr(
+                        isRunning ? "daemon.status_running" : "daemon.status_stopped",
+                        displayName));
                 break;
                 
             default:
-                ctx.sendMessage(chatId, "Usage: /daemon " + name + " start|stop|status");
+                ctx.sendMessage(chatId, ctx.tr("daemon.action_usage", name));
         }
     }
     
@@ -891,7 +894,7 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
             // config (single source of truth shared with the app).
             long ownerChatId = com.overdrive.app.telegram.config.UnifiedTelegramConfig.getOwnerChatId();
             if (ownerChatId > 0) {
-                ctx.sendMessage(ownerChatId, "🌐 *Tunnel URL*\n" + url);
+                ctx.sendMessage(ownerChatId, ctx.tr("daemon.tunnel_url", url));
                 ctx.log("Tunnel URL notification sent to owner");
             }
         } catch (Exception e) {

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/EventCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/EventCommandHandler.java
@@ -1,8 +1,10 @@
 package com.overdrive.app.daemon.telegram;
 
+import com.overdrive.app.server.LocaleManager;
 import com.overdrive.app.storage.StorageManager;
 
 import java.io.File;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -49,7 +51,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
     
     @Override
     public void handle(long chatId, String[] args, CommandContext ctx) {
-        String cmd = args[0].toLowerCase();
+        String cmd = args[0].toLowerCase(Locale.ROOT);
         
         switch (cmd) {
             case "/events":
@@ -61,7 +63,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
                         if (hours < 1) hours = 1;
                         if (hours > 168) hours = 168; // Max 7 days
                     } catch (NumberFormatException e) {
-                        ctx.sendMessage(chatId, "⚠️ Invalid hours. Usage: /events [hours] [page]\nExample: /events 12 2");
+                        ctx.sendMessage(chatId, ctx.tr("events.invalid_hours"));
                         return;
                     }
                 }
@@ -78,7 +80,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
                 
             case "/download":
                 if (args.length < 2) {
-                    ctx.sendMessage(chatId, "⚠️ Usage: /download <filename>\nExample: /download event_20260113_143022.mp4");
+                    ctx.sendMessage(chatId, ctx.tr("events.download_usage"));
                     return;
                 }
                 handleDownload(chatId, args[1], ctx);
@@ -92,7 +94,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
         File eventDir = new File(getEventDir());
         
         if (!eventDir.exists() || !eventDir.isDirectory()) {
-            ctx.sendMessage(chatId, "📁 No events directory found");
+            ctx.sendMessage(chatId, ctx.tr("events.directory_missing"));
             return;
         }
         
@@ -100,7 +102,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
             name.startsWith("event_") && name.endsWith(".mp4"));
         
         if (files == null || files.length == 0) {
-            ctx.sendMessage(chatId, "📭 No event recordings found");
+            ctx.sendMessage(chatId, ctx.tr("events.none_found"));
             return;
         }
         
@@ -115,7 +117,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
         }
         
         if (recentFiles.isEmpty()) {
-            ctx.sendMessage(chatId, "📭 No events in the last " + hours + " hours");
+            ctx.sendMessage(chatId, ctx.tr("events.none_recent", formatInteger(hours)));
             return;
         }
         
@@ -131,21 +133,21 @@ public class EventCommandHandler implements TelegramCommandHandler {
         int endIdx = Math.min(startIdx + EVENTS_PER_PAGE, totalEvents);
         
         // Build header
-        StringBuilder sb = new StringBuilder();
-        sb.append("📹 *Events* (").append(hours).append("h)");
-        if (totalPages > 1) {
-            sb.append(" ").append(page).append("/").append(totalPages);
-        }
+        StringBuilder sb = new StringBuilder(totalPages > 1
+                ? ctx.tr("events.header_paged",
+                        formatInteger(hours), formatInteger(page), formatInteger(totalPages))
+                : ctx.tr("events.header", formatInteger(hours)));
         sb.append("\n\n");
         
         // Build buttons - one row per event with download button
         List<String[][]> buttonRows = new ArrayList<>();
-        SimpleDateFormat sdf = new SimpleDateFormat("MMM dd HH:mm", Locale.US);
+        Locale locale = displayLocale();
+        SimpleDateFormat sdf = new SimpleDateFormat(eventListDatePattern(locale), locale);
         
         for (int i = startIdx; i < endIdx; i++) {
             File f = recentFiles.get(i);
             String dateStr = sdf.format(new Date(f.lastModified()));
-            String sizeStr = formatFileSize(f.length());
+            String sizeStr = formatFileSize(f.length(), ctx);
             
             // Status indicator
             String status;
@@ -158,7 +160,7 @@ public class EventCommandHandler implements TelegramCommandHandler {
             }
             
             // Button text: "📥 Jan 13 14:30 (7.1MB)"
-            String buttonText = status + " " + dateStr + " (" + sizeStr + ")";
+            String buttonText = ctx.tr("events.download_button", status, dateStr, sizeStr);
             String callbackData = "dl:" + f.getName();
             
             buttonRows.add(new String[][]{{buttonText, callbackData}});
@@ -168,17 +170,17 @@ public class EventCommandHandler implements TelegramCommandHandler {
         if (totalPages > 1) {
             List<String[]> navButtons = new ArrayList<>();
             if (page > 1) {
-                navButtons.add(new String[]{"◀️ Prev", "ev:" + hours + ":" + (page - 1)});
+                navButtons.add(new String[]{ctx.tr("events.previous_button"), "ev:" + hours + ":" + (page - 1)});
             }
             if (page < totalPages) {
-                navButtons.add(new String[]{"Next ▶️", "ev:" + hours + ":" + (page + 1)});
+                navButtons.add(new String[]{ctx.tr("events.next_button"), "ev:" + hours + ":" + (page + 1)});
             }
             if (!navButtons.isEmpty()) {
                 buttonRows.add(navButtons.toArray(new String[0][]));
             }
         }
         
-        sb.append("⏺️ Recording  ⚠️ >50MB  📥 Ready");
+        sb.append(ctx.tr("events.legend"));
         
         // Convert to array
         String[][][] buttons = buttonRows.toArray(new String[0][][]);
@@ -192,24 +194,23 @@ public class EventCommandHandler implements TelegramCommandHandler {
         
         // Ensure it's an event file
         if (!filename.startsWith("event_") || !filename.endsWith(".mp4")) {
-            ctx.sendMessage(chatId, "⚠️ Invalid filename. Must be event_*.mp4");
+            ctx.sendMessage(chatId, ctx.tr("events.invalid_filename"));
             return;
         }
         
         File videoFile = new File(getEventDir(), filename);
         
         if (!videoFile.exists()) {
-            ctx.sendMessage(chatId, "❌ File not found: " + filename);
+            ctx.sendMessage(chatId, ctx.tr("events.file_not_found", filename));
             return;
         }
         
         // Check if file is still being written (recording in progress)
         if (isFileStillWriting(videoFile)) {
-            ctx.sendMessage(chatId, 
-                "⏳ *Recording in progress*\n\n" +
-                "File: `" + filename + "`\n" +
-                "Current size: " + formatFileSize(videoFile.length()) + "\n\n" +
-                "Please wait 10-15 seconds and try again.");
+            ctx.sendMessage(chatId, ctx.tr(
+                    "events.recording_in_progress",
+                    filename,
+                    formatFileSize(videoFile.length(), ctx)));
             return;
         }
         
@@ -217,25 +218,21 @@ public class EventCommandHandler implements TelegramCommandHandler {
         
         // Check file size
         if (fileSize > MAX_VIDEO_SIZE_BYTES) {
-            String sizeStr = formatFileSize(fileSize);
-            ctx.sendMessage(chatId, 
-                "❌ *File too large*\n\n" +
-                "File: `" + filename + "`\n" +
-                "Size: " + sizeStr + "\n" +
-                "Limit: 50MB");
+            String sizeStr = formatFileSize(fileSize, ctx);
+            ctx.sendMessage(chatId, ctx.tr("events.file_too_large", filename, sizeStr));
             return;
         }
         
         // Send uploading message
-        ctx.sendMessage(chatId, "📤 Uploading " + filename + " (" + formatFileSize(fileSize) + ")...");
+        ctx.sendMessage(chatId, ctx.tr("events.uploading", filename, formatFileSize(fileSize, ctx)));
         
         // Extract timestamp from filename for caption
-        String caption = "📹 " + extractEventInfo(filename);
+        String caption = ctx.tr("events.video_caption", extractEventInfo(filename));
         
         boolean success = ctx.sendVideo(chatId, videoFile.getAbsolutePath(), caption);
         
         if (!success) {
-            ctx.sendMessage(chatId, "❌ Failed to upload video. Try again later.");
+            ctx.sendMessage(chatId, ctx.tr("events.upload_failed"));
         }
     }
     
@@ -283,10 +280,11 @@ public class EventCommandHandler implements TelegramCommandHandler {
                 int min = Integer.parseInt(time.substring(2, 4));
                 int sec = Integer.parseInt(time.substring(4, 6));
                 
-                Calendar cal = Calendar.getInstance();
+                Locale locale = displayLocale();
+                Calendar cal = Calendar.getInstance(locale);
                 cal.set(year, month - 1, day, hour, min, sec);
                 
-                SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, HH:mm:ss", Locale.US);
+                SimpleDateFormat sdf = new SimpleDateFormat(eventCaptionDatePattern(locale), locale);
                 return sdf.format(cal.getTime());
             }
         } catch (Exception e) {
@@ -295,9 +293,43 @@ public class EventCommandHandler implements TelegramCommandHandler {
         return filename;
     }
     
-    private String formatFileSize(long bytes) {
-        if (bytes < 1024) return bytes + " B";
-        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
-        return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
+    private String formatFileSize(long bytes, CommandContext ctx) {
+        Locale locale = displayLocale();
+        if (bytes < 1024) {
+            return ctx.tr("events.size_bytes", NumberFormat.getIntegerInstance(locale).format(bytes));
+        }
+
+        NumberFormat decimal = NumberFormat.getNumberInstance(locale);
+        decimal.setGroupingUsed(false);
+        decimal.setMinimumFractionDigits(1);
+        decimal.setMaximumFractionDigits(1);
+        if (bytes < 1024 * 1024) {
+            return ctx.tr("events.size_kb", decimal.format(bytes / 1024.0));
+        }
+        return ctx.tr("events.size_mb", decimal.format(bytes / (1024.0 * 1024.0)));
+    }
+
+    private static String formatInteger(long value) {
+        return NumberFormat.getIntegerInstance(displayLocale()).format(value);
+    }
+
+    private static Locale displayLocale() {
+        try {
+            String tag = LocaleManager.get();
+            if (tag != null && !tag.trim().isEmpty()) {
+                if ("en".equalsIgnoreCase(tag)) return Locale.ENGLISH;
+                Locale locale = Locale.forLanguageTag(tag);
+                if (!locale.getLanguage().isEmpty()) return locale;
+            }
+        } catch (Exception ignored) {}
+        return Locale.ENGLISH;
+    }
+
+    private static String eventListDatePattern(Locale locale) {
+        return "pt".equals(locale.getLanguage()) ? "dd MMM HH:mm" : "MMM dd HH:mm";
+    }
+
+    private static String eventCaptionDatePattern(Locale locale) {
+        return "pt".equals(locale.getLanguage()) ? "dd MMM, HH:mm:ss" : "MMM dd, HH:mm:ss";
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/SendLogCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/SendLogCommandHandler.java
@@ -4,6 +4,8 @@ import com.overdrive.app.logging.DaemonLogPaths;
 
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 /**
  * Handles /sendlog — uploads a single daemon's log to the Cloudflare Worker
  * (via IPC UPLOAD_LOG → SurveillanceIpcServer → LogUploader) and replies with
@@ -19,6 +21,11 @@ import org.json.JSONObject;
 public class SendLogCommandHandler implements TelegramCommandHandler {
 
     private static final int CAMERA_IPC_PORT = 19877;
+    private static final String DISCORD_URL = "https://discord.gg/PZutk9fg4h";
+    private static final String GITHUB_URL =
+            "https://github.com/yash-srivastava/Overdrive-release/issues";
+    private static final String WHATSAPP_URL =
+            "https://chat.whatsapp.com/HChmriCWgr9KwAtE6OEkiM";
     // Upload is network-bound (read log → POST to CF). 35s sits above
     // LogUploader's bounded worst case (proxy 12s + direct-retry 12s = 24s,
     // via its callTimeout) so the IPC read never races a still-running upload.
@@ -33,23 +40,24 @@ public class SendLogCommandHandler implements TelegramCommandHandler {
     public void handle(long chatId, String[] args, CommandContext ctx) {
         if (args.length < 2 || args[1].trim().isEmpty()) {
             // No daemon specified — show the list as tap buttons.
-            StringBuilder sb = new StringBuilder();
-            sb.append("📄 *Send a daemon log*\n\nPick a daemon (or `/sendlog <name>`):");
             java.util.List<String[][]> rows = new java.util.ArrayList<>();
             for (String key : DaemonLogPaths.keys()) {
-                rows.add(new String[][] {{key, "cmd:/sendlog " + key}});
+                rows.add(new String[][] {{ctx.tr("sendlog.daemon_button", key),
+                        "cmd:/sendlog " + key}});
             }
-            ctx.sendMessageWithButtons(chatId, sb.toString(), rows.toArray(new String[0][][]));
+            ctx.sendMessageWithButtons(chatId, ctx.tr("sendlog.choose"),
+                    rows.toArray(new String[0][][]));
             return;
         }
 
-        String daemon = args[1].trim().toLowerCase();
+        String daemon = args[1].trim().toLowerCase(Locale.ROOT);
         if (DaemonLogPaths.pathFor(daemon) == null) {
-            ctx.sendMessage(chatId, "❌ Unknown daemon `" + daemon + "`.\nTry: " + DaemonLogPaths.keyList());
+            ctx.sendMessage(chatId, ctx.tr("sendlog.unknown_daemon",
+                    daemon, DaemonLogPaths.keyList()));
             return;
         }
 
-        ctx.sendMessage(chatId, "⏳ Uploading *" + daemon + "* log…");
+        ctx.sendMessage(chatId, ctx.tr("sendlog.uploading", daemon));
 
         JSONObject req = new JSONObject();
         try {
@@ -59,23 +67,17 @@ public class SendLogCommandHandler implements TelegramCommandHandler {
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, UPLOAD_TIMEOUT_MS);
         if (resp == null) {
-            ctx.sendMessage(chatId, "⚠️ Could not reach the log service. " +
-                    "The camera daemon may not be running (`/daemon camera start`).");
+            ctx.sendMessage(chatId, ctx.tr("sendlog.service_unreachable"));
             return;
         }
         if (!resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId, "⚠️ Upload failed: " + resp.optString("error", "unknown"));
+            ctx.sendMessage(chatId, ctx.tr("sendlog.upload_failed",
+                    ctx.technicalDetail(resp.optString("error", ""))));
             return;
         }
 
         String code = resp.optString("code", "");
-        ctx.sendMessage(chatId,
-                "✅ *" + daemon + "* log uploaded.\n\n" +
-                "Share this code with us, plus a note on what went wrong:\n`" + code + "`\n\n" +
-                "Report on:\n" +
-                "• Discord: https://discord.gg/PZutk9fg4h\n" +
-                "• GitHub: https://github.com/yash-srivastava/Overdrive-release/issues\n" +
-                "• WhatsApp: https://chat.whatsapp.com/HChmriCWgr9KwAtE6OEkiM\n\n" +
-                "_Secrets were redacted before upload. The log auto-expires._");
+        ctx.sendMessage(chatId, ctx.tr("sendlog.upload_success", daemon, code,
+                DISCORD_URL, GITHUB_URL, WHATSAPP_URL));
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/SurveillanceCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/SurveillanceCommandHandler.java
@@ -2,6 +2,8 @@ package com.overdrive.app.daemon.telegram;
 
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 /**
  * Handles surveillance commands: /start, /stop, /status
  */
@@ -16,7 +18,7 @@ public class SurveillanceCommandHandler implements TelegramCommandHandler {
     
     @Override
     public void handle(long chatId, String[] args, CommandContext ctx) {
-        String cmd = args[0].toLowerCase();
+        String cmd = args[0].toLowerCase(Locale.ROOT);
         
         switch (cmd) {
             case "/start":
@@ -34,66 +36,68 @@ public class SurveillanceCommandHandler implements TelegramCommandHandler {
     private void handleStart(long chatId, CommandContext ctx) {
         JSONObject response = sendSurveillanceCommand("START", ctx);
         if (response != null && response.optBoolean("success", false)) {
-            String[][][] buttons = {{{"⛔ Stop", "cmd:/stop"}, {"📊 Status", "cmd:/status"}}};
-            ctx.sendMessageWithButtons(chatId, "✅ Surveillance started", buttons);
+            String[][][] buttons = {{{ctx.tr("buttons.stop"), "cmd:/stop"}, {ctx.tr("buttons.status"), "cmd:/status"}}};
+            ctx.sendMessageWithButtons(chatId, ctx.tr("surveillance.started"), buttons);
         } else {
-            ctx.sendMessage(chatId, "⚠️ Failed to start surveillance");
+            ctx.sendMessage(chatId, ctx.tr("surveillance.start_failed"));
         }
     }
     
     private void handleStop(long chatId, CommandContext ctx) {
         JSONObject response = sendSurveillanceCommand("STOP", ctx);
         if (response != null && response.optBoolean("success", false)) {
-            String[][][] buttons = {{{"✅ Start", "cmd:/start"}, {"📊 Status", "cmd:/status"}}};
-            ctx.sendMessageWithButtons(chatId, "⛔ Surveillance stopped", buttons);
+            String[][][] buttons = {{{ctx.tr("buttons.start"), "cmd:/start"}, {ctx.tr("buttons.status"), "cmd:/status"}}};
+            ctx.sendMessageWithButtons(chatId, ctx.tr("surveillance.stopped"), buttons);
         } else {
-            ctx.sendMessage(chatId, "⚠️ Failed to stop surveillance");
+            ctx.sendMessage(chatId, ctx.tr("surveillance.stop_failed"));
         }
     }
     
     private void handleStatus(long chatId, CommandContext ctx) {
         StringBuilder sb = new StringBuilder();
-        sb.append("📊 *Status*\n\n");
+        sb.append(ctx.tr("surveillance.status_title"));
         
         // Surveillance status
         JSONObject survStatus = sendSurveillanceCommand("STATUS", ctx);
         boolean survEnabled = survStatus != null && survStatus.optBoolean("enabled", false);
-        sb.append("*Surveillance:* ").append(survEnabled ? "✅ Active" : "⛔ Inactive").append("\n");
+        sb.append(ctx.tr(survEnabled
+                ? "surveillance.status_active"
+                : "surveillance.status_inactive"));
         
         // Temperature
-        sb.append("*Temp:* ").append(getTemperature(ctx)).append("\n\n");
+        sb.append(ctx.tr("surveillance.temperature", getTemperature(ctx)));
         
         // All daemons - check all known process names
-        sb.append("*Daemons:*\n");
+        sb.append(ctx.tr("surveillance.daemons_heading"));
         String[][] allDaemons = {
-            {"byd_cam_daemon", "Camera"},
-            {"acc_sentry_daemon", "ACC Sentry"},
-            {"sentry_daemon", "Sentry"},
-            {"telegram_bot_daemon", "Telegram"},
-            {"SurveillanceDaemon", "Surveillance"},
-            {"cloudflared", "Cloudflare Tunnel"},
-            {"zrok", "Zrok Tunnel"},
-            {"sing-box", "Sing-Box"}
+            {"byd_cam_daemon", "daemon_names.camera"},
+            {"acc_sentry_daemon", "daemon_names.acc_sentry"},
+            {"sentry_daemon", "daemon_names.sentry"},
+            {"telegram_bot_daemon", "daemon_names.telegram"},
+            {"SurveillanceDaemon", "daemon_names.surveillance"},
+            {"cloudflared", "daemon_names.cloudflare_tunnel"},
+            {"zrok", "daemon_names.zrok_tunnel"},
+            {"sing-box", "daemon_names.sing_box"}
         };
         
         int runningCount = 0;
         for (String[] d : allDaemons) {
             if (isDaemonRunning(d[0], ctx)) {
-                sb.append("✅ ").append(d[1]).append("\n");
+                sb.append(ctx.tr("surveillance.daemon_running", ctx.tr(d[1])));
                 runningCount++;
             }
         }
         
         if (runningCount == 0) {
-            sb.append("_No daemons running_\n");
+            sb.append(ctx.tr("surveillance.no_daemons_running"));
         }
         
         // Buttons
         String[][][] buttons;
         if (survEnabled) {
-            buttons = new String[][][]{{{"⛔ Stop Surveillance", "cmd:/stop"}, {"📹 Events", "cmd:/events"}}};
+            buttons = new String[][][]{{{ctx.tr("buttons.stop_surveillance"), "cmd:/stop"}, {ctx.tr("buttons.events"), "cmd:/events"}}};
         } else {
-            buttons = new String[][][]{{{"✅ Start Surveillance", "cmd:/start"}, {"📹 Events", "cmd:/events"}}};
+            buttons = new String[][][]{{{ctx.tr("buttons.start_surveillance"), "cmd:/start"}, {ctx.tr("buttons.events"), "cmd:/events"}}};
         }
         
         ctx.sendMessageWithButtons(chatId, sb.toString(), buttons);
@@ -117,7 +121,7 @@ public class SurveillanceCommandHandler implements TelegramCommandHandler {
 
     private String getTemperature(CommandContext ctx) {
         double c = readCpuTemperatureCelsius();
-        if (c <= 0) return "N/A";
+        if (c <= 0) return ctx.tr("surveillance.not_available");
         String emoji = c > 60 ? "🔥" : (c > 45 ? "🌡️" : "✅");
         return String.format("%s %.0f°C", emoji, c);
     }

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/SystemCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/SystemCommandHandler.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.util.Locale;
 
 /**
  * Handles system commands: /daemons, /url, /help
@@ -17,7 +18,7 @@ public class SystemCommandHandler implements TelegramCommandHandler {
     
     @Override
     public void handle(long chatId, String[] args, CommandContext ctx) {
-        String cmd = args[0].toLowerCase();
+        String cmd = args[0].toLowerCase(Locale.ROOT);
         
         switch (cmd) {
             case "/daemons":
@@ -34,21 +35,21 @@ public class SystemCommandHandler implements TelegramCommandHandler {
     
     private void handleDaemons(long chatId, CommandContext ctx) {
         StringBuilder sb = new StringBuilder();
-        sb.append("🤖 *Daemons*\n\n");
+        sb.append(ctx.tr("daemons.title"));
         
         // All known daemons: {cmdName, processName, displayName, canStart, canStop}
         // cmdName is used for /daemon <name> start|stop
         // canStart: "yes" if can be started via telegram, "no" if must use app UI
         // canStop: "yes" if can be stopped via telegram, "no" if should not be stopped remotely
         String[][] allDaemons = {
-            {"camera", "byd_cam_daemon", "Camera", "yes", "yes"},
-            {"acc", "acc_sentry_daemon", "ACC Sentry", "yes", "yes"},
-            {"sentry", "sentry_daemon", "Sentry", "yes", "yes"},
-            {"telegram", "telegram_bot_daemon", "Telegram", "no", "no"},
-            {"cloudflared", "cloudflared", "Cloudflare Tunnel", "yes", "yes"},
-            {"zrok", "zrok", "Zrok Tunnel", "yes", "yes"},
-            {"tailscale", "tailscaled", "Tailscale Tunnel", "yes", "yes"},
-            {"singbox", "sing-box", "Sing-Box", "yes", "no"}
+            {"camera", "byd_cam_daemon", "daemon_names.camera", "yes", "yes"},
+            {"acc", "acc_sentry_daemon", "daemon_names.acc_sentry", "yes", "yes"},
+            {"sentry", "sentry_daemon", "daemon_names.sentry", "yes", "yes"},
+            {"telegram", "telegram_bot_daemon", "daemon_names.telegram", "no", "no"},
+            {"cloudflared", "cloudflared", "daemon_names.cloudflare_tunnel", "yes", "yes"},
+            {"zrok", "zrok", "daemon_names.zrok_tunnel", "yes", "yes"},
+            {"tailscale", "tailscaled", "daemon_names.tailscale_tunnel", "yes", "yes"},
+            {"singbox", "sing-box", "daemon_names.sing_box", "yes", "no"}
         };
         
         java.util.List<String[][]> buttonRows = new java.util.ArrayList<>();
@@ -59,7 +60,7 @@ public class SystemCommandHandler implements TelegramCommandHandler {
         for (String[] d : allDaemons) {
             String cmdName = d[0];
             String processName = d[1];
-            String displayName = d[2];
+            String displayName = ctx.tr(d[2]);
             boolean canStart = "yes".equals(d[3]);
             boolean canStop = "yes".equals(d[4]);
             boolean running = isDaemonRunning(processName, ctx);
@@ -70,7 +71,7 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                 
                 // Add stop button if allowed
                 if (canStop) {
-                    buttonRows.add(new String[][]{{"⛔ Stop " + displayName, "dm:" + cmdName + ":stop"}});
+                    buttonRows.add(new String[][]{{ctx.tr("buttons.stop_named", displayName), "dm:" + cmdName + ":stop"}});
                 }
             } else {
                 sb.append("⛔ ").append(displayName).append("\n");
@@ -78,13 +79,13 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                 
                 // Add start button for startable daemons
                 if (canStart) {
-                    buttonRows.add(new String[][]{{"✅ Start " + displayName, "dm:" + cmdName + ":start"}});
+                    buttonRows.add(new String[][]{{ctx.tr("buttons.start_named", displayName), "dm:" + cmdName + ":start"}});
                 }
             }
         }
         
         // Add refresh button
-        buttonRows.add(new String[][]{{"🔄 Refresh", "cmd:/daemons"}});
+        buttonRows.add(new String[][]{{ctx.tr("buttons.refresh"), "cmd:/daemons"}});
         
         String[][][] buttons = buttonRows.toArray(new String[0][][]);
         ctx.sendMessageWithButtons(chatId, sb.toString(), buttons);
@@ -102,12 +103,12 @@ public class SystemCommandHandler implements TelegramCommandHandler {
             boolean tailscaleUp = tailscaleRunning != null && !tailscaleRunning.trim().isEmpty();
 
             if (!cfUp && !zrokUp && !tailscaleUp) {
-                ctx.sendMessage(chatId, "⚠️ No tunnel running\n\nStart one with:\n`/daemon cloudflared start`\n`/daemon zrok start`\n`/daemon tailscale start`");
+                ctx.sendMessage(chatId, ctx.tr("url.none_running"));
                 return;
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.append("🌐 *Tunnel URLs*\n\n");
+            sb.append(ctx.tr("url.title"));
             int resolved = 0;
             int pending = 0;
 
@@ -128,10 +129,12 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                     }
                 }
                 if (url != null) {
-                    sb.append("• *Cloudflared:* ").append(url).append("\n");
+                    sb.append(ctx.tr("url.resolved_line",
+                            ctx.tr("daemon_names.cloudflare_tunnel"), url));
                     resolved++;
                 } else {
-                    sb.append("• *Cloudflared:* _starting, URL not available yet_\n");
+                    sb.append(ctx.tr("url.pending_line",
+                            ctx.tr("daemon_names.cloudflare_tunnel")));
                     pending++;
                 }
             }
@@ -143,10 +146,12 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                     url = grepResult.trim();
                 }
                 if (url != null) {
-                    sb.append("• *Zrok:* ").append(url).append("\n");
+                    sb.append(ctx.tr("url.resolved_line",
+                            ctx.tr("daemon_names.zrok_tunnel"), url));
                     resolved++;
                 } else {
-                    sb.append("• *Zrok:* _starting, URL not available yet_\n");
+                    sb.append(ctx.tr("url.pending_line",
+                            ctx.tr("daemon_names.zrok_tunnel")));
                     pending++;
                 }
             }
@@ -158,10 +163,12 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                     url = "http://" + getIpResult.trim() + ":8080";
                 }
                 if (url != null) {
-                    sb.append("• *Tailscale:* ").append(url).append("\n");
+                    sb.append(ctx.tr("url.resolved_line",
+                            ctx.tr("daemon_names.tailscale_tunnel"), url));
                     resolved++;
                 } else {
-                    sb.append("• *Tailscale:* _starting, URL not available yet_\n");
+                    sb.append(ctx.tr("url.pending_line",
+                            ctx.tr("daemon_names.tailscale_tunnel")));
                     pending++;
                 }
             }
@@ -174,18 +181,19 @@ public class SystemCommandHandler implements TelegramCommandHandler {
                     String saved = reader.readLine();
                     reader.close();
                     if (saved != null && !saved.isEmpty()) {
-                        sb.append("\n_Last known:_ ").append(saved.trim()).append("\n");
+                        sb.append(ctx.tr("url.last_known", saved.trim()));
                     }
                 }
             }
 
             if (pending > 0) {
-                sb.append("\n_Try again in a few seconds for pending URLs._");
+                sb.append(ctx.tr("url.retry_pending"));
             }
 
             ctx.sendMessage(chatId, sb.toString());
         } catch (Exception e) {
-            ctx.sendMessage(chatId, "⚠️ Error: " + e.getMessage());
+            ctx.sendMessage(chatId, ctx.tr("url.error",
+                    ctx.technicalDetail(e.getMessage())));
         }
     }
     
@@ -197,30 +205,13 @@ public class SystemCommandHandler implements TelegramCommandHandler {
         // absent, malformed, or a stale cross-channel label.
         String version = com.overdrive.app.updater.AppUpdater.getDisplayVersionFromFile();
 
-        String text = "📖 *Commands*\n" +
-                "_OverDrive " + version + "_\n\n" +
-                "*Surveillance*\n" +
-                "`/start` - Start surveillance\n" +
-                "`/stop` - Stop surveillance\n" +
-                "`/status` - System status\n\n" +
-                "*Events*\n" +
-                "`/events [hours] [page]` - List recordings\n" +
-                "`/download <file>` - Download video\n\n" +
-                "*Daemons*\n" +
-                "`/daemons` - List all daemons\n" +
-                "`/daemon <name> start|stop`\n\n" +
-                "*System*\n" +
-                "`/url` - Tunnel URL\n" +
-                "`/update` - Check for app update\n" +
-                "`/backup` - Export settings backup\n" +
-                "`/backup trips` - Backup incl. trip history\n" +
-                "`/help` - This message";
+        String text = ctx.tr("help.text", version);
 
         String[][][] buttons = {
-            {{"📊 Status", "cmd:/status"}, {"📹 Events", "cmd:/events"}},
-            {{"✅ Start Surveillance", "cmd:/start"}, {"⛔ Stop Surveillance", "cmd:/stop"}},
-            {{"🤖 Daemons", "cmd:/daemons"}, {"🌐 Tunnel URL", "cmd:/url"}},
-            {{"⬆️ Check Update", "cmd:/update"}, {"💾 Backup", "cmd:/backup"}}
+            {{ctx.tr("buttons.status"), "cmd:/status"}, {ctx.tr("buttons.events"), "cmd:/events"}},
+            {{ctx.tr("buttons.start_surveillance"), "cmd:/start"}, {ctx.tr("buttons.stop_surveillance"), "cmd:/stop"}},
+            {{ctx.tr("buttons.daemons"), "cmd:/daemons"}, {ctx.tr("buttons.tunnel_url"), "cmd:/url"}},
+            {{ctx.tr("buttons.check_update"), "cmd:/update"}, {ctx.tr("buttons.backup"), "cmd:/backup"}}
         };
         
         ctx.sendMessageWithButtons(chatId, text, buttons);

--- a/app/src/main/java/com/overdrive/app/daemon/telegram/UpdateCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/UpdateCommandHandler.java
@@ -1,7 +1,11 @@
 package com.overdrive.app.daemon.telegram;
 
+import com.overdrive.app.telegram.TelegramMessages;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.Locale;
 
 /**
  * Handles /update — channel-aware, mirroring the web update flow.
@@ -43,7 +47,7 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
     public void handle(long chatId, String[] args, CommandContext ctx) {
         // /update channel <alpha|braveheart>
         if (args.length > 1 && "channel".equalsIgnoreCase(args[1])) {
-            String target = args.length > 2 ? args[2].toLowerCase() : "";
+            String target = args.length > 2 ? args[2].toLowerCase(Locale.ROOT) : "";
             handleSwitchChannel(chatId, target, ctx);
             return;
         }
@@ -57,20 +61,19 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
     }
 
     private void handleCheck(long chatId, CommandContext ctx) {
-        ctx.sendMessage(chatId, "🔍 Checking for updates…");
+        ctx.sendMessage(chatId, ctx.tr("update.checking"));
 
         JSONObject req = new JSONObject();
         try { req.put("command", "CHECK_UPDATE"); } catch (Exception ignored) {}
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, CHECK_TIMEOUT_MS);
         if (resp == null) {
-            ctx.sendMessage(chatId, "⚠️ Could not reach update service.\n\n" +
-                    "The camera daemon may not be running. Try `/daemon camera start`.");
+            ctx.sendMessage(chatId, ctx.tr("update.service_unreachable"));
             return;
         }
         if (!resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId, "⚠️ Update check failed: " +
-                    resp.optString("error", "unknown"));
+            ctx.sendMessage(chatId, ctx.tr("update.check_failed",
+                    ctx.technicalDetail(resp.optString("error", ""))));
             return;
         }
 
@@ -88,38 +91,38 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
         String remoteVersion = resp.optString("remoteVersion", "?");
 
         if (resp.has("error")) {
-            ctx.sendMessage(chatId, "⚠️ Update check error: " + resp.optString("error"));
+            ctx.sendMessage(chatId, ctx.tr("update.check_failed",
+                    ctx.technicalDetail(resp.optString("error"))));
             return;
         }
 
         if (!available) {
             String[][][] buttons = {
-                    {{"📚 Switch to Alpha (all versions)", "cmd:/update channel alpha"}}
+                    {{ctx.tr("update.switch_alpha_all_button"), "cmd:/update channel alpha"}}
             };
             ctx.sendMessageWithButtons(chatId,
-                    "✅ *Up to date*\n_OverDrive " + currentVersion + " · Braveheart_", buttons);
+                    ctx.tr("update.up_to_date", currentVersion), buttons);
             return;
         }
 
         String releaseNotes = resp.optString("releaseNotes", "").trim();
-        StringBuilder sb = new StringBuilder();
-        sb.append("⬆️ *Update available* _(Braveheart)_\n\n")
-          .append("*Current:* ").append(currentVersion).append("\n")
-          .append("*Latest:* ").append(remoteVersion).append("\n");
-        if (!releaseNotes.isEmpty()) {
+        String text;
+        if (!releaseNotes.isEmpty() && !TelegramMessages.isPortuguese()) {
             String trimmed = releaseNotes.length() > 600
                     ? releaseNotes.substring(0, 600) + "…"
                     : releaseNotes;
-            sb.append("\n*Release notes:*\n").append(stripMarkdown(trimmed)).append("\n");
+            text = ctx.tr("update.available_with_notes",
+                    currentVersion, remoteVersion, stripMarkdown(trimmed));
+        } else {
+            text = ctx.tr("update.available", currentVersion, remoteVersion);
         }
-        sb.append("\n_Install takes ~2 minutes. The bot will restart and post a new tunnel URL when done._");
 
         String[][][] buttons = {
-                {{"🔄 Install Now", "cmd:/update install"}},
-                {{"📚 Switch to Alpha", "cmd:/update channel alpha"}},
-                {{"❌ Cancel", "cmd:/help"}}
+                {{ctx.tr("update.install_now_button"), "cmd:/update install"}},
+                {{ctx.tr("update.switch_alpha_button"), "cmd:/update channel alpha"}},
+                {{ctx.tr("common.cancel_button"), "cmd:/help"}}
         };
-        ctx.sendMessageWithButtons(chatId, sb.toString(), buttons);
+        ctx.sendMessageWithButtons(chatId, text, buttons);
     }
 
     /**
@@ -133,14 +136,18 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, CHECK_TIMEOUT_MS);
         if (resp == null || !resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId, "⚠️ Could not list versions: " +
-                    (resp != null ? resp.optString("error", "unknown") : "update service unreachable"));
+            if (resp == null) {
+                ctx.sendMessage(chatId, ctx.tr("update.list_service_unreachable"));
+            } else {
+                ctx.sendMessage(chatId, ctx.tr("update.list_failed",
+                        ctx.technicalDetail(resp.optString("error", ""))));
+            }
             return;
         }
         JSONArray versions = resp.optJSONArray("versions");
         String current = resp.optString("currentVersion", "?");
         if (versions == null || versions.length() == 0) {
-            ctx.sendMessage(chatId, "ℹ️ No versions published yet.");
+            ctx.sendMessage(chatId, ctx.tr("update.no_versions"));
             return;
         }
 
@@ -159,27 +166,30 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
             // alpha-v<semver> tags are ~12 bytes, so this never trips in
             // practice — it's a guard against a pathological tag).
             if (callback.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > 64) continue;
-            String label = version;
-            if ("current".equals(relation)) label = "✅ " + version + " (installed)";
-            else if ("older".equals(relation)) label = "⬇️ " + version;
+            String label = ctx.tr("update.version_button", version);
+            if ("current".equals(relation)) {
+                label = ctx.tr("update.version_installed_button", version);
+            } else if ("older".equals(relation)) {
+                label = ctx.tr("update.version_older_button", version);
+            }
             rows.add(new String[][] {{label, callback}});
         }
-        rows.add(new String[][] {{"🚀 Switch to Braveheart (latest only)", "cmd:/update channel braveheart"}});
+        rows.add(new String[][] {{ctx.tr("update.switch_braveheart_button"),
+                "cmd:/update channel braveheart"}});
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("📚 *Alpha — choose a version*\n_Installed: ").append(current).append("_\n");
+        String text;
         if (versions.length() > max) {
-            sb.append("\n_Showing newest ").append(max).append(" of ")
-              .append(versions.length()).append(". Older builds remain on GitHub Releases._");
+            text = ctx.tr("update.alpha_list_truncated", current, max, versions.length());
+        } else {
+            text = ctx.tr("update.alpha_list", current);
         }
-        sb.append("\n_Downgrades are allowed._");
 
-        ctx.sendMessageWithButtons(chatId, sb.toString(), rows.toArray(new String[0][][]));
+        ctx.sendMessageWithButtons(chatId, text, rows.toArray(new String[0][][]));
     }
 
     private void handleSwitchChannel(long chatId, String target, CommandContext ctx) {
         if (!CHANNEL_ALPHA.equals(target) && !CHANNEL_BRAVEHEART.equals(target)) {
-            ctx.sendMessage(chatId, "Usage: `/update channel alpha` or `/update channel braveheart`");
+            ctx.sendMessage(chatId, ctx.tr("update.channel_usage"));
             return;
         }
         JSONObject req = new JSONObject();
@@ -190,13 +200,19 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, CHANNEL_TIMEOUT_MS);
         if (resp == null || !resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId, "⚠️ Could not switch channel: " +
-                    (resp != null ? resp.optString("error", "unknown") : "update service unreachable"));
+            if (resp == null) {
+                ctx.sendMessage(chatId, ctx.tr("update.channel_service_unreachable"));
+            } else {
+                ctx.sendMessage(chatId, ctx.tr("update.channel_switch_failed",
+                        ctx.technicalDetail(resp.optString("error", ""))));
+            }
             return;
         }
-        String label = CHANNEL_BRAVEHEART.equals(target) ? "Braveheart (latest only)"
-                                                         : "Alpha (all versions)";
-        ctx.sendMessage(chatId, "✅ Update channel set to *" + label + "*.\nSend /update to continue.");
+        if (CHANNEL_BRAVEHEART.equals(target)) {
+            ctx.sendMessage(chatId, ctx.tr("update.channel_set_braveheart"));
+        } else {
+            ctx.sendMessage(chatId, ctx.tr("update.channel_set_alpha"));
+        }
     }
 
     private void handleInstall(long chatId, String tag, CommandContext ctx) {
@@ -212,11 +228,7 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
         // verify failure), permanently blocking future /update installs from
         // Telegram while web/app could retry immediately — a real cross-surface
         // divergence. Relying on the shared gate removes it.
-        ctx.sendMessage(chatId,
-                "⏳ *Installing update…*\n\n" +
-                "Daemons will stop, the APK will install, and the device will\n" +
-                "relaunch. This bot will go silent for ~2 minutes; you'll get a\n" +
-                "fresh tunnel URL message once it's back.");
+        ctx.sendMessage(chatId, ctx.tr("update.installing"));
 
         JSONObject req = new JSONObject();
         try {
@@ -228,13 +240,12 @@ public class UpdateCommandHandler implements TelegramCommandHandler {
 
         JSONObject resp = ctx.sendIpcCommand(CAMERA_IPC_PORT, req, INSTALL_TIMEOUT_MS);
         if (resp == null) {
-            ctx.sendMessage(chatId,
-                    "⚠️ Could not start install — camera daemon unreachable.");
+            ctx.sendMessage(chatId, ctx.tr("update.install_service_unreachable"));
             return;
         }
         if (!resp.optBoolean("success", false)) {
-            ctx.sendMessage(chatId,
-                    "⚠️ Install rejected: " + resp.optString("error", "unknown"));
+            ctx.sendMessage(chatId, ctx.tr("update.install_rejected",
+                    ctx.technicalDetail(resp.optString("error", ""))));
             return;
         }
         // Success path: daemons are now dying. No further messages until the

--- a/app/src/main/java/com/overdrive/app/notifications/ChargingEventNotifier.java
+++ b/app/src/main/java/com/overdrive/app/notifications/ChargingEventNotifier.java
@@ -297,7 +297,40 @@ public final class ChargingEventNotifier {
     }
 
     private static String stateLabel(int stateCode) {
-        return new ChargingStateData(stateCode).stateName;
+        String key;
+        switch (stateCode) {
+            case ChargingStateData.CHARGING_BATTERY_STATE_READY:
+                key = "ready"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_CHARGING:
+                key = "charging"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_CHARG_FINISH:
+                key = "finished"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_DISCHARG:
+                key = "discharging"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_CHARG_TERMINATE:
+                key = "terminated"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_BREAKDOWN_C10:
+                key = "fault_c10"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_BREAKDOWN_CHARGING_GUN:
+                key = "fault_gun"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_BREAKDOWN_AC:
+                key = "fault_ac"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_BREAKDOWN_CHARGER:
+                key = "fault_charger"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_SCHEDULE:
+                key = "scheduled"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_TIMEOUT:
+                key = "timeout"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_DISCHARG_CBU:
+                key = "discharging_cbu"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_DISCHARG_FINISH:
+                key = "discharge_finished"; break;
+            case ChargingStateData.CHARGING_BATTERY_STATE_IDLE:
+                key = "idle"; break;
+            default:
+                return Messages.get("notifications.charging_state.unknown", stateCode);
+        }
+        return Messages.get("notifications.charging_state." + key);
     }
 
     private static boolean isFinite(double v) {

--- a/app/src/main/java/com/overdrive/app/proximity/ProximityRecordingHandler.java
+++ b/app/src/main/java/com/overdrive/app/proximity/ProximityRecordingHandler.java
@@ -4,6 +4,8 @@ import com.overdrive.app.logging.DaemonLogger;
 import com.overdrive.app.storage.StorageManager;
 import com.overdrive.app.surveillance.GpuSurveillancePipeline;
 import com.overdrive.app.telegram.TelegramNotifier;
+import com.overdrive.app.telegram.TelegramMessages;
+import com.overdrive.app.server.LocaleManager;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -299,16 +301,19 @@ public class ProximityRecordingHandler {
      */
     private void sendTelegramNotification(String triggerLevel) {
         try {
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+            String language = LocaleManager.get();
+            Locale locale = Locale.forLanguageTag(language);
+            String datePattern = language.startsWith("pt")
+                    ? "dd/MM/yyyy HH:mm:ss" : "yyyy-MM-dd HH:mm:ss";
+            SimpleDateFormat sdf = new SimpleDateFormat(datePattern, locale);
             String timestamp = sdf.format(new Date());
             
-            String emoji = "🚨";
             String distance = triggerLevel.equals("RED") ? "0-0.5m" : "0-0.8m";
-            
-            String message = emoji + " Proximity Alert\n" +
-                           "Time: " + timestamp + "\n" +
-                           "Trigger: " + triggerLevel + " (" + distance + ")\n" +
-                           "Recording started...";
+            String triggerKey = "RED".equals(triggerLevel)
+                    ? "proximity.trigger.red" : "proximity.trigger.yellow";
+            String triggerLabel = TelegramMessages.get(triggerKey);
+            String message = TelegramMessages.get("proximity_alert",
+                    timestamp, triggerLabel, distance);
             
             TelegramNotifier.sendMessage(message);
             logger.info("Telegram notification sent: " + triggerLevel);

--- a/app/src/main/java/com/overdrive/app/server/Messages.java
+++ b/app/src/main/java/com/overdrive/app/server/Messages.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.text.MessageFormat;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -34,7 +35,7 @@ public final class Messages {
         if (raw == null) return key; // dev-visible miss
         if (args == null || args.length == 0) return raw;
         try {
-            return MessageFormat.format(raw, args);
+            return new MessageFormat(raw, Locale.forLanguageTag(lang)).format(args);
         } catch (Exception e) {
             return raw;
         }

--- a/app/src/main/java/com/overdrive/app/server/SurveillanceIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/server/SurveillanceIpcServer.java
@@ -2307,28 +2307,18 @@ public class SurveillanceIpcServer implements Runnable {
         }
         if (!wasIpcTriggered) return;
         String raw = (error != null && !error.trim().isEmpty())
-                ? error.trim() : "unknown (see head unit)";
-        // The bot sends with parse_mode=Markdown and does NOT escape the body,
-        // so an unescaped control char in the download/verify error (e.g. a CDN
-        // message with '_' or '*') would 400 "can't parse entities" and the
-        // message would be silently dropped. Strip the legacy-Markdown control
-        // chars from the reason, mirroring the bot-side failure copy's
-        // mdEscape (UpdateCommandHandler.stripMarkdown uses the same set).
-        StringBuilder safe = new StringBuilder(raw.length());
-        for (int i = 0; i < raw.length(); i++) {
-            char c = raw.charAt(i);
-            if (c == '*' || c == '_' || c == '`' || c == '[' || c == ']') continue;
-            safe.append(c);
-        }
-        String reason = safe.toString();
+                ? error.trim() : Messages.get("telegram.update.unknown_reason");
+        // Localize known backend failures and Markdown-escape English details
+        // before handing the copy to the bot's legacy Markdown send path.
+        String reason = com.overdrive.app.telegram.TelegramMessages
+                .technicalDetail(raw);
         // TelegramNotifier runs the IPC on its own background executor + gates
         // on the criticalAlerts toggle (matching the bot-side failure message
-        // category). Hardcoded English literals match the bot's house style.
+        // category). Copy follows the app locale through TelegramMessages.
         try {
             com.overdrive.app.telegram.TelegramNotifier.sendMessage(
-                    "⚠️ *Overdrive update failed*\n"
-                    + "The device is still on the previous version.\n"
-                    + "Reason: " + reason,
+                    com.overdrive.app.telegram.TelegramMessages.get(
+                            "update.install_failed", reason),
                     "CRITICAL");
         } catch (Exception ignored) {}
     }

--- a/app/src/main/java/com/overdrive/app/surveillance/SurveillanceEngineGpu.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/SurveillanceEngineGpu.java
@@ -6945,7 +6945,8 @@ public class SurveillanceEngineGpu {
         try {
             if (config != null && config.isTelegramSendStartPing()) {
                 com.overdrive.app.telegram.TelegramNotifier.sendMessage(
-                        "✅ Motion cleared — no event recorded (filtered as a non-actor false alert).",
+                        com.overdrive.app.telegram.TelegramMessages.get(
+                                "motion.cleared_no_event"),
                         "MOTION");
             }
         } catch (Throwable t) {

--- a/app/src/main/java/com/overdrive/app/telegram/TelegramMessages.java
+++ b/app/src/main/java/com/overdrive/app/telegram/TelegramMessages.java
@@ -1,0 +1,125 @@
+package com.overdrive.app.telegram;
+
+import com.overdrive.app.server.LocaleManager;
+import com.overdrive.app.server.Messages;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Localized, user-facing copy used by the Telegram bot.
+ *
+ * <p>The bot intentionally follows the app's global locale so commands and
+ * asynchronous notifications use the same language.</p>
+ */
+public final class TelegramMessages {
+
+    private static final String PREFIX = "telegram.";
+    private static final Pattern HTTP_STATUS =
+            Pattern.compile("(?i).*\\bHTTP\\s*(\\d{3})\\b.*");
+
+    private TelegramMessages() {}
+
+    public static String get(String key, Object... args) {
+        return Messages.get(PREFIX + key, args);
+    }
+
+    public static boolean isPortuguese() {
+        String language = LocaleManager.get();
+        return language != null
+                && language.toLowerCase(Locale.ROOT).startsWith("pt");
+    }
+
+    /**
+     * Keep backend/exception details from reintroducing English into a PT-BR
+     * chat. English keeps the original diagnostic detail; PT-BR maps known
+     * failures and falls back to a localized pointer to the device logs.
+     */
+    public static String technicalDetail(String detail) {
+        String value = detail == null ? "" : detail.trim();
+        if (value.isEmpty()) return get("common.unknown_error");
+        if (!isPortuguese()) return escapeMarkdown(value);
+
+        // Codes, percentages, paths, versions, and numeric values are
+        // language-neutral and remain useful as-is.
+        if (value.matches("[\\d\\s%+./:_-]+")) return escapeMarkdown(value);
+
+        String lower = value.toLowerCase(Locale.ROOT);
+        if (lower.matches(".*[áàâãéêíóôõúç].*")) {
+            return escapeMarkdown(value);
+        }
+        if (lower.equals("unknown") || lower.startsWith("unknown (")) {
+            return get("common.unknown_error");
+        }
+        if (lower.contains("app context not ready")) {
+            return get("error_details.app_context_not_ready");
+        }
+        if (lower.contains("timed out") || lower.contains("timeout")) {
+            return get("error_details.timeout");
+        }
+        if (lower.contains("public mode")) {
+            return get("error_details.public_mode");
+        }
+        if (lower.contains("invalid update channel")) {
+            return get("error_details.invalid_channel");
+        }
+        if (lower.contains("could not save") && lower.contains("channel")) {
+            return get("error_details.channel_save_failed");
+        }
+        if (lower.contains("already in progress")) {
+            return get("error_details.update_in_progress");
+        }
+        if (lower.contains("not on the active channel")) {
+            return get("error_details.inactive_channel");
+        }
+        if (lower.contains("no update available")) {
+            return get("error_details.no_update");
+        }
+        if (lower.contains("not available in this build")) {
+            return get("error_details.unavailable_build");
+        }
+        if (lower.contains("permission denied") || lower.contains("eacces")) {
+            return get("error_details.permission_denied");
+        }
+        if (lower.contains("no space") || lower.contains("enospc")
+                || lower.contains("storage full")) {
+            return get("error_details.storage_full");
+        }
+        Matcher http = HTTP_STATUS.matcher(value);
+        if (http.matches()) {
+            return get("error_details.http_status", http.group(1));
+        }
+        if (lower.contains("unable to resolve") || lower.contains("failed to connect")
+                || lower.contains("network") || lower.contains("connection")
+                || lower.contains("socket") || lower.contains("resolve failed")) {
+            return get("error_details.network");
+        }
+        if (lower.contains("download")) {
+            return get("error_details.download_failed");
+        }
+        if (lower.contains("verify") || lower.contains("verification")
+                || lower.contains("signature")) {
+            return get("error_details.verification_failed");
+        }
+        if (lower.contains("install")) {
+            return get("error_details.install_failed");
+        }
+        if (lower.contains("unknown daemon")) {
+            return get("error_details.unknown_daemon");
+        }
+        return get("error_details.generic");
+    }
+
+    private static String escapeMarkdown(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '_' || c == '*' || c == '`' || c == '[' || c == ']') {
+                escaped.append('\\');
+            }
+            escaped.append(c);
+        }
+        return escaped.toString();
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telegram/TelegramNotifier.java
+++ b/app/src/main/java/com/overdrive/app/telegram/TelegramNotifier.java
@@ -3,7 +3,7 @@ package com.overdrive.app.telegram;
 import android.util.Log;
 
 import com.overdrive.app.config.UnifiedConfigManager;
-import com.overdrive.app.server.Messages;
+import com.overdrive.app.server.LocaleManager;
 import com.overdrive.app.telegram.config.UnifiedTelegramConfig;
 import com.overdrive.app.telegram.event.CriticalEvent;
 import com.overdrive.app.telegram.event.MotionEvent;
@@ -135,8 +135,9 @@ public class TelegramNotifier {
                 cmd.put("cmd", "sendVideo");
                 cmd.put("path", filePath);
                 String caption = (aiDetection != null)
-                        ? Messages.get("telegram.recording_caption", aiDetection, durationSeconds)
-                        : Messages.get("telegram.recording_caption_no_label", durationSeconds);
+                        ? TelegramMessages.get("recording_caption",
+                                localizedDetection(aiDetection), durationSeconds)
+                        : TelegramMessages.get("recording_caption_no_label", durationSeconds);
                 cmd.put("caption", caption);
                 // Fire-and-forget: the response is unused, and the upload can
                 // take tens of seconds — don't tie up even this lane waiting on
@@ -345,6 +346,20 @@ public class TelegramNotifier {
         if (a > 0) return "animal";
         return "motion";
     }
+
+    private static String localizedDetection(String detection) {
+        if (detection == null || detection.isEmpty()) return "";
+        switch (detection.toLowerCase(java.util.Locale.ROOT)) {
+            case "person": return TelegramMessages.get("recording_label.person");
+            case "bike":
+            case "bicycle": return TelegramMessages.get("recording_label.bike");
+            case "car":
+            case "vehicle": return TelegramMessages.get("recording_label.vehicle");
+            case "animal": return TelegramMessages.get("recording_label.animal");
+            case "motion": return TelegramMessages.get("recording_label.motion");
+            default: return detection;
+        }
+    }
     
     /**
      * Notify critical system event.
@@ -446,14 +461,19 @@ public class TelegramNotifier {
                     Log.d(TAG, "sendProximityAlert skipped — critical alerts disabled");
                     return;
                 }
+                String language = LocaleManager.get();
+                String pattern = language.startsWith("pt")
+                        ? "dd/MM/yyyy HH:mm:ss" : "yyyy-MM-dd HH:mm:ss";
                 java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(
-                    "yyyy-MM-dd HH:mm:ss", java.util.Locale.US);
+                        pattern, java.util.Locale.forLanguageTag(language));
                 String timeStr = sdf.format(new java.util.Date(timestamp));
 
                 String distance = triggerLevel.equals("RED") ? "0-0.5m" : "0-0.8m";
+                String triggerKey = "RED".equals(triggerLevel)
+                        ? "proximity.trigger.red" : "proximity.trigger.yellow";
 
-                String message = Messages.get("telegram.proximity_alert",
-                        timeStr, triggerLevel, distance);
+                String message = TelegramMessages.get("proximity_alert",
+                        timeStr, TelegramMessages.get(triggerKey), distance);
 
                 JSONObject cmd = new JSONObject();
                 cmd.put("cmd", "sendMessage");

--- a/app/src/main/java/com/overdrive/app/telegram/event/ConnectivityEvent.java
+++ b/app/src/main/java/com/overdrive/app/telegram/event/ConnectivityEvent.java
@@ -1,5 +1,7 @@
 package com.overdrive.app.telegram.event;
 
+import com.overdrive.app.telegram.TelegramMessages;
+
 /**
  * Network connectivity change event.
  */
@@ -18,10 +20,9 @@ public class ConnectivityEvent extends SystemEvent {
     
     @Override
     public String getMessage() {
-        if (connected) {
-            return "📶 Connected via " + networkType;
-        } else {
-            return "📵 Disconnected from " + networkType;
-        }
+        return TelegramMessages.get(connected
+                        ? "legacy.connectivity.connected"
+                        : "legacy.connectivity.disconnected",
+                networkType);
     }
 }

--- a/app/src/main/java/com/overdrive/app/telegram/event/CriticalEvent.java
+++ b/app/src/main/java/com/overdrive/app/telegram/event/CriticalEvent.java
@@ -1,5 +1,7 @@
 package com.overdrive.app.telegram.event;
 
+import com.overdrive.app.telegram.TelegramMessages;
+
 /**
  * Critical system event requiring immediate attention.
  */
@@ -8,15 +10,15 @@ public class CriticalEvent extends SystemEvent {
     private final String details;
     
     public enum CriticalType {
-        LOW_BATTERY("🔋 Low battery"),
-        STORAGE_FULL("💾 Storage full"),
-        DAEMON_CRASH("⚠️ Daemon crashed"),
-        SYSTEM_ERROR("❌ System error"),
-        SYSTEM_REBOOT("🔄 System reboot");
+        LOW_BATTERY("critical.type.low_battery"),
+        STORAGE_FULL("critical.type.storage_full"),
+        DAEMON_CRASH("critical.type.daemon_crash"),
+        SYSTEM_ERROR("critical.type.system_error"),
+        SYSTEM_REBOOT("critical.type.system_reboot");
         
-        private final String prefix;
-        CriticalType(String prefix) { this.prefix = prefix; }
-        public String getPrefix() { return prefix; }
+        private final String messageKey;
+        CriticalType(String messageKey) { this.messageKey = messageKey; }
+        public String getPrefix() { return TelegramMessages.get(messageKey); }
     }
     
     public CriticalEvent(CriticalType criticalType, String details) {
@@ -30,6 +32,7 @@ public class CriticalEvent extends SystemEvent {
     
     @Override
     public String getMessage() {
-        return criticalType.getPrefix() + ": " + details;
+        return TelegramMessages.get("legacy.critical_with_details",
+                criticalType.getPrefix(), details);
     }
 }

--- a/app/src/main/java/com/overdrive/app/telegram/event/MotionEvent.java
+++ b/app/src/main/java/com/overdrive/app/telegram/event/MotionEvent.java
@@ -1,6 +1,7 @@
 package com.overdrive.app.telegram.event;
 
 import androidx.annotation.Nullable;
+import com.overdrive.app.telegram.TelegramMessages;
 
 /**
  * Event emitted when motion is detected.
@@ -21,14 +22,24 @@ public class MotionEvent extends SystemEvent {
     @Override
     public String getMessage() {
         if (aiDetection != null) {
-            return "🚨 " + capitalize(aiDetection) + " detected (" + Math.round(confidence * 100) + "%)";
+            return TelegramMessages.get("legacy.motion.detected_actor",
+                    localizedDetection(aiDetection),
+                    String.valueOf(Math.round(confidence * 100)));
         } else {
-            return "👁 Motion detected";
+            return TelegramMessages.get("legacy.motion.detected");
         }
     }
     
-    private String capitalize(String s) {
-        if (s == null || s.isEmpty()) return s;
-        return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    private String localizedDetection(String value) {
+        switch (value.toLowerCase(java.util.Locale.ROOT)) {
+            case "person": return TelegramMessages.get("motion.actor.person");
+            case "bike":
+            case "bicycle": return TelegramMessages.get("motion.actor.bike");
+            case "car":
+            case "vehicle": return TelegramMessages.get("motion.actor.vehicle");
+            case "animal": return TelegramMessages.get("motion.actor.animal");
+            case "motion": return TelegramMessages.get("motion.actor.motion");
+            default: return value;
+        }
     }
 }

--- a/app/src/main/java/com/overdrive/app/telegram/event/TunnelEvent.java
+++ b/app/src/main/java/com/overdrive/app/telegram/event/TunnelEvent.java
@@ -1,5 +1,7 @@
 package com.overdrive.app.telegram.event;
 
+import com.overdrive.app.telegram.TelegramMessages;
+
 /**
  * Event emitted when Cloudflare tunnel URL is created or changed.
  */
@@ -18,10 +20,7 @@ public class TunnelEvent extends SystemEvent {
     
     @Override
     public String getMessage() {
-        if (isNew) {
-            return "🌐 Tunnel connected:\n" + url;
-        } else {
-            return "🔄 Tunnel URL changed:\n" + url;
-        }
+        return TelegramMessages.get(isNew
+                ? "legacy.tunnel.connected" : "legacy.tunnel.changed", url);
     }
 }

--- a/app/src/main/java/com/overdrive/app/telegram/event/VideoEvent.java
+++ b/app/src/main/java/com/overdrive/app/telegram/event/VideoEvent.java
@@ -1,6 +1,7 @@
 package com.overdrive.app.telegram.event;
 
 import androidx.annotation.Nullable;
+import com.overdrive.app.telegram.TelegramMessages;
 
 /**
  * Event emitted when a surveillance recording is finalized.
@@ -23,11 +24,24 @@ public class VideoEvent extends SystemEvent {
     
     @Override
     public String getMessage() {
-        StringBuilder sb = new StringBuilder("🎬 Recording saved");
         if (aiDetection != null) {
-            sb.append(" (").append(aiDetection).append(" detected)");
+            return TelegramMessages.get("legacy.video.saved_with_detection",
+                    localizedDetection(aiDetection), String.valueOf(durationSeconds));
         }
-        sb.append(" - ").append(durationSeconds).append("s");
-        return sb.toString();
+        return TelegramMessages.get("legacy.video.saved",
+                String.valueOf(durationSeconds));
+    }
+
+    private String localizedDetection(String value) {
+        switch (value.toLowerCase(java.util.Locale.ROOT)) {
+            case "person": return TelegramMessages.get("recording_label.person");
+            case "bike":
+            case "bicycle": return TelegramMessages.get("recording_label.bike");
+            case "car":
+            case "vehicle": return TelegramMessages.get("recording_label.vehicle");
+            case "animal": return TelegramMessages.get("recording_label.animal");
+            case "motion": return TelegramMessages.get("recording_label.motion");
+            default: return value;
+        }
     }
 }

--- a/app/src/test/java/com/overdrive/app/daemon/telegram/TelegramCommandLocalizationTest.java
+++ b/app/src/test/java/com/overdrive/app/daemon/telegram/TelegramCommandLocalizationTest.java
@@ -1,0 +1,198 @@
+package com.overdrive.app.daemon.telegram;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TelegramCommandLocalizationTest {
+
+    private static final long CHAT_ID = 123456L;
+
+    @Test
+    public void unknownCommandUsesLocalizedRouterMessage() {
+        FakeCommandContext context = new FakeCommandContext();
+
+        assertTrue(new CommandRouter(context).route(CHAT_ID, "/not-a-command"));
+
+        assertEquals(Arrays.asList("router.unknown_command"), context.translationKeys());
+        assertEquals(1, context.textMessages.size());
+        assertEquals(CHAT_ID, context.textMessages.get(0).chatId);
+        assertEquals("tr:router.unknown_command", context.textMessages.get(0).text);
+    }
+
+    @Test
+    public void helpUsesLocalizedTextAndEveryLocalizedButtonLabel() {
+        FakeCommandContext context = new FakeCommandContext();
+
+        assertTrue(new CommandRouter(context).route(CHAT_ID, "/help"));
+
+        assertEquals(Arrays.asList(
+                "help.text",
+                "buttons.status",
+                "buttons.events",
+                "buttons.start_surveillance",
+                "buttons.stop_surveillance",
+                "buttons.daemons",
+                "buttons.tunnel_url",
+                "buttons.check_update",
+                "buttons.backup"
+        ), context.translationKeys());
+
+        TranslationCall help = context.translationCalls.get(0);
+        assertEquals("help.text", help.key);
+        assertEquals(1, help.args.length);
+        assertNotNull(help.args[0]);
+
+        assertEquals(1, context.buttonMessages.size());
+        ButtonMessage sent = context.buttonMessages.get(0);
+        assertEquals(CHAT_ID, sent.chatId);
+        assertEquals("tr:help.text", sent.text);
+        assertButton(sent.buttons, 0, 0, "buttons.status", "cmd:/status");
+        assertButton(sent.buttons, 0, 1, "buttons.events", "cmd:/events");
+        assertButton(sent.buttons, 1, 0, "buttons.start_surveillance", "cmd:/start");
+        assertButton(sent.buttons, 1, 1, "buttons.stop_surveillance", "cmd:/stop");
+        assertButton(sent.buttons, 2, 0, "buttons.daemons", "cmd:/daemons");
+        assertButton(sent.buttons, 2, 1, "buttons.tunnel_url", "cmd:/url");
+        assertButton(sent.buttons, 3, 0, "buttons.check_update", "cmd:/update");
+        assertButton(sent.buttons, 3, 1, "buttons.backup", "cmd:/backup");
+    }
+
+    @Test
+    public void startSuccessUsesLocalizedMessageAndButtons() {
+        FakeCommandContext context = new FakeCommandContext();
+        context.ipcResponse = jsonResponse(true);
+
+        assertTrue(new CommandRouter(context).route(CHAT_ID, "/start"));
+
+        assertEquals(Arrays.asList(
+                "buttons.stop",
+                "buttons.status",
+                "surveillance.started"
+        ), context.translationKeys());
+        assertEquals(0, context.textMessages.size());
+        assertEquals(1, context.buttonMessages.size());
+
+        ButtonMessage sent = context.buttonMessages.get(0);
+        assertEquals("tr:surveillance.started", sent.text);
+        assertButton(sent.buttons, 0, 0, "buttons.stop", "cmd:/stop");
+        assertButton(sent.buttons, 0, 1, "buttons.status", "cmd:/status");
+    }
+
+    @Test
+    public void startFailureUsesLocalizedFailureMessage() {
+        FakeCommandContext context = new FakeCommandContext();
+        context.ipcResponse = jsonResponse(false);
+
+        assertTrue(new CommandRouter(context).route(CHAT_ID, "/start"));
+
+        assertEquals(Arrays.asList("surveillance.start_failed"), context.translationKeys());
+        assertEquals(1, context.textMessages.size());
+        assertEquals("tr:surveillance.start_failed", context.textMessages.get(0).text);
+        assertEquals(0, context.buttonMessages.size());
+    }
+
+    private static JSONObject jsonResponse(boolean success) {
+        try {
+            return new JSONObject().put("success", success);
+        } catch (Exception e) {
+            throw new AssertionError("Could not build test IPC response", e);
+        }
+    }
+
+    private static void assertButton(String[][][] buttons, int row, int column,
+                                     String translationKey, String callbackData) {
+        assertEquals("tr:" + translationKey, buttons[row][column][0]);
+        assertEquals(callbackData, buttons[row][column][1]);
+    }
+
+    private static final class FakeCommandContext implements CommandContext {
+        final List<TranslationCall> translationCalls = new ArrayList<>();
+        final List<TextMessage> textMessages = new ArrayList<>();
+        final List<ButtonMessage> buttonMessages = new ArrayList<>();
+        JSONObject ipcResponse;
+
+        @Override
+        public String tr(String key, Object... args) {
+            Object[] capturedArgs = args == null ? new Object[0] : args.clone();
+            translationCalls.add(new TranslationCall(key, capturedArgs));
+            return "tr:" + key;
+        }
+
+        List<String> translationKeys() {
+            List<String> keys = new ArrayList<>();
+            for (TranslationCall call : translationCalls) keys.add(call.key);
+            return keys;
+        }
+
+        @Override
+        public boolean sendMessage(long chatId, String text) {
+            textMessages.add(new TextMessage(chatId, text));
+            return true;
+        }
+
+        @Override
+        public boolean sendMessageWithButtons(long chatId, String text, String[][][] buttons) {
+            buttonMessages.add(new ButtonMessage(chatId, text, buttons));
+            return true;
+        }
+
+        @Override
+        public boolean sendVideo(long chatId, String videoPath, String caption) {
+            return true;
+        }
+
+        @Override
+        public JSONObject sendIpcCommand(int port, JSONObject command) {
+            return ipcResponse;
+        }
+
+        @Override
+        public String execShell(String command) {
+            return "";
+        }
+
+        @Override
+        public void log(String message) {
+            // No-op for pure JVM tests.
+        }
+    }
+
+    private static final class TranslationCall {
+        final String key;
+        final Object[] args;
+
+        TranslationCall(String key, Object[] args) {
+            this.key = key;
+            this.args = args;
+        }
+    }
+
+    private static final class TextMessage {
+        final long chatId;
+        final String text;
+
+        TextMessage(long chatId, String text) {
+            this.chatId = chatId;
+            this.text = text;
+        }
+    }
+
+    private static final class ButtonMessage {
+        final long chatId;
+        final String text;
+        final String[][][] buttons;
+
+        ButtonMessage(long chatId, String text, String[][][] buttons) {
+            this.chatId = chatId;
+            this.text = text;
+            this.buttons = buttons;
+        }
+    }
+}

--- a/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
+++ b/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
@@ -1,0 +1,176 @@
+package com.overdrive.app.telegram;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TelegramCatalogParityTest {
+
+    private static final Pattern POSITIONAL_PLACEHOLDER =
+            Pattern.compile("\\{(\\d+)(?:,[^{}]*)?\\}");
+
+    private static Map<String, Object> english;
+    private static Map<String, Object> portuguese;
+
+    @BeforeClass
+    public static void loadCatalogs() throws IOException {
+        english = loadTelegramCatalog("en");
+        portuguese = loadTelegramCatalog("pt-BR");
+    }
+
+    @Test
+    public void catalogsHaveIdenticalTelegramLeafKeys() {
+        Set<String> onlyEnglish = new TreeSet<>(english.keySet());
+        onlyEnglish.removeAll(portuguese.keySet());
+
+        Set<String> onlyPortuguese = new TreeSet<>(portuguese.keySet());
+        onlyPortuguese.removeAll(english.keySet());
+
+        assertTrue("Telegram keys missing from pt-BR: " + onlyEnglish, onlyEnglish.isEmpty());
+        assertTrue("Telegram keys missing from en: " + onlyPortuguese, onlyPortuguese.isEmpty());
+        assertFalse("Telegram catalogs must contain at least one leaf", english.isEmpty());
+    }
+
+    @Test
+    public void everyTelegramLeafIsANonemptyString() {
+        assertNonemptyStrings("en", english);
+        assertNonemptyStrings("pt-BR", portuguese);
+    }
+
+    @Test
+    public void catalogsUseIdenticalPositionalPlaceholders() {
+        assertEquals("Leaf-key parity is required before comparing placeholders",
+                english.keySet(), portuguese.keySet());
+
+        for (String key : english.keySet()) {
+            String enTemplate = requireString("en", key, english.get(key));
+            String ptTemplate = requireString("pt-BR", key, portuguese.get(key));
+            assertEquals("Placeholder mismatch for telegram." + key,
+                    placeholders(enTemplate), placeholders(ptTemplate));
+        }
+    }
+
+    @Test
+    public void placeholderTemplatesHaveNoUnescapedSingleApostrophes() {
+        assertApostropheSafety("en", english);
+        assertApostropheSafety("pt-BR", portuguese);
+    }
+
+    @Test
+    public void portugueseHelpHeadingIsLocalized() {
+        Object help = portuguese.get("help.text");
+        assertNotNull("pt-BR must define telegram.help.text", help);
+        String text = requireString("pt-BR", "help.text", help);
+        assertTrue("pt-BR help must contain the Portuguese heading",
+                text.contains("*Comandos*"));
+        assertFalse("pt-BR help must not retain the English heading",
+                text.contains("*Commands*"));
+    }
+
+    private static Map<String, Object> loadTelegramCatalog(String locale) throws IOException {
+        Path catalog = findCatalog(locale);
+        String json = new String(Files.readAllBytes(catalog), StandardCharsets.UTF_8);
+        JSONObject root = new JSONObject(json);
+        JSONObject telegram = root.optJSONObject("telegram");
+        if (telegram == null) {
+            fail(catalog + " must contain a telegram object");
+        }
+
+        Map<String, Object> flattened = new TreeMap<>();
+        flatten(telegram, "", flattened);
+        return flattened;
+    }
+
+    private static Path findCatalog(String locale) {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path fromModule = current.resolve("src/main/assets/server-i18n/" + locale + ".json");
+            if (Files.isRegularFile(fromModule)) return fromModule;
+
+            Path fromRepository = current.resolve(
+                    "app/src/main/assets/server-i18n/" + locale + ".json");
+            if (Files.isRegularFile(fromRepository)) return fromRepository;
+
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not find server-i18n/" + locale
+                + ".json from working directory " + System.getProperty("user.dir"));
+    }
+
+    private static void flatten(JSONObject object, String prefix, Map<String, Object> output) {
+        for (String name : object.keySet()) {
+            String path = prefix.isEmpty() ? name : prefix + "." + name;
+            Object value = object.get(name);
+            if (value instanceof JSONObject) {
+                flatten((JSONObject) value, path, output);
+            } else {
+                assertNull("Duplicate flattened Telegram key: " + path,
+                        output.put(path, value));
+            }
+        }
+    }
+
+    private static void assertNonemptyStrings(String locale, Map<String, Object> catalog) {
+        for (Map.Entry<String, Object> entry : catalog.entrySet()) {
+            String value = requireString(locale, entry.getKey(), entry.getValue());
+            assertFalse(locale + " telegram." + entry.getKey() + " must not be blank",
+                    value.trim().isEmpty());
+        }
+    }
+
+    private static String requireString(String locale, String key, Object value) {
+        assertTrue(locale + " telegram." + key + " must be a string, but was "
+                        + (value == null ? "null" : value.getClass().getSimpleName()),
+                value instanceof String);
+        return (String) value;
+    }
+
+    private static Set<Integer> placeholders(String template) {
+        Set<Integer> positions = new TreeSet<>();
+        Matcher matcher = POSITIONAL_PLACEHOLDER.matcher(template);
+        while (matcher.find()) {
+            positions.add(Integer.parseInt(matcher.group(1)));
+        }
+        return positions;
+    }
+
+    private static void assertApostropheSafety(String locale, Map<String, Object> catalog) {
+        for (Map.Entry<String, Object> entry : catalog.entrySet()) {
+            String template = requireString(locale, entry.getKey(), entry.getValue());
+            if (!placeholders(template).isEmpty()) {
+                assertFalse(locale + " telegram." + entry.getKey()
+                                + " contains an unescaped apostrophe in a MessageFormat template",
+                        hasOddApostropheRun(template));
+            }
+        }
+    }
+
+    private static boolean hasOddApostropheRun(String template) {
+        for (int i = 0; i < template.length(); i++) {
+            if (template.charAt(i) != '\'') continue;
+            int start = i;
+            while (i + 1 < template.length() && template.charAt(i + 1) == '\'') i++;
+            if ((i - start + 1) % 2 != 0) return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Route Telegram commands, buttons, pairing, callbacks, and notifications through the app locale.
- Add complete English and Brazilian Portuguese Telegram catalogs, including localized error messages.
- Localize vehicle alerts forwarded to Telegram and use locale-aware dates and numbers.
- Add unit coverage for command localization and catalog parity.

## Why

`/help` and most Telegram bot responses were hardcoded in English even when the app was configured for PT-BR.

## Impact

Owners using PT-BR now receive the bot interface and alerts in Brazilian Portuguese. Command names, arguments, and callback data remain unchanged. Other locales continue to fall back to English for missing keys.

## Validation

- `TelegramCommandLocalizationTest`: 4 tests passed.
- `TelegramCatalogParityTest`: 5 tests passed.
- Validated 230 Telegram catalog entries and 42 notification entries with exact EN/PT-BR key and placeholder parity.
- Audited 287 translation references and 31 dynamic key targets.
- `git diff --check` passed.
- Full Gradle execution was not available because the environment does not include an Android SDK.
