### PR TITLE
Harden CredentialCipher device-id key derivation

### DIFF
--- a/app/src/main/java/com/overdrive/app/byd/cloud/crypto/CredentialCipher.java
+++ b/app/src/main/java/com/overdrive/app/byd/cloud/crypto/CredentialCipher.java
@@ -177,11 +177,12 @@ public final class CredentialCipher {
         // a non-encrypted result over a working encrypted blob.
         if (!isEncrypted(reEncrypted)) return null;
         // Round-trip verify before committing: if the DID file flapped unreadable
-        // between the decrypt above and this encrypt, deriveKey would have used
-        // the sentinel DID, producing a valid-looking ENC: blob keyed to the
-        // WRONG key that decrypts to "" forever (and needsStableReEncrypt won't
-        // retry it). Confirm it actually round-trips back to the same plaintext;
-        // if not, leave the working legacy blob untouched for the next run.
+        // between the decrypt above and this encrypt, deriveKey throws and the
+        // isEncrypted() check above already catches that (encrypt() fails open
+        // to plaintext). This verifies the rarer case of a readable-but-CHANGED
+        // DID producing a validly-encrypted blob under the wrong key. Confirm it
+        // actually round-trips back to the same plaintext; if not, leave the
+        // working legacy blob untouched for the next run.
         if (!plain.equals(decrypt(reEncrypted))) return null;
         return reEncrypted;
     }
@@ -195,6 +196,15 @@ public final class CredentialCipher {
      */
     private static byte[] deriveKey(boolean includeFingerprint) throws Exception {
         String did = readDid();
+        if (did == null) {
+            // No fallback to a fixed sentinel here: this source is public, so a
+            // constant key material would let anyone decrypt any credential
+            // blob written while the DID was unreadable. Throwing forces
+            // encrypt() to fail-open to plaintext (visibly unprotected, not
+            // falsely "ENC:"-tagged) and decrypt() to fail-closed to "" —
+            // both already-handled paths in the callers below.
+            throw new IllegalStateException("device id unavailable at " + DID_PATH);
+        }
         MessageDigest d = MessageDigest.getInstance("SHA-256");
         String material = KD_SALT + ":" + did;
         if (includeFingerprint) {
@@ -209,6 +219,15 @@ public final class CredentialCipher {
         return d.digest(material.getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Reads the cross-UID device id (app 10xxx + daemon 2000) that
+     * {@link #deriveKey} binds the credential key to. Returns {@code null} if
+     * the file doesn't exist or is empty/unreadable — callers must NOT
+     * substitute a fixed string here (see {@link #deriveKey}). The daemon
+     * ({@code CameraDaemon.generateDeviceId()}) is responsible for seeding
+     * this file with a {@code SecureRandom} value on first boot; this method
+     * only reads it.
+     */
     private static String readDid() {
         try {
             File f = new File(DID_PATH);
@@ -219,6 +238,6 @@ public final class CredentialCipher {
                 if (id != null && !id.trim().isEmpty()) return id.trim();
             }
         } catch (Exception ignored) {}
-        return "overdrive-default-device";
+        return null;
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -4933,10 +4933,9 @@ public class CameraDaemon {
             if (idFile.exists()) {
                 // Self-heal for older installs: the legacy saveDeviceId()
                 // didn't chmod the file, leaving it at the shell-UID-only
-                // mode 0600 default. The app UID couldn't read it, fell
-                // back to the "overdrive-default-device" sentinel, derived
-                // a different AES key, and silently failed to decrypt every
-                // stored credential. setReadable(true, false) is idempotent
+                // mode 0600 default. The app UID couldn't read it, so
+                // CredentialCipher.deriveKey() threw and every stored
+                // credential failed to decrypt. setReadable(true, false) is idempotent
                 // — no-op if it's already world-readable from a recent
                 // install. Apply on every daemon start so a re-deploy
                 // repairs older devices automatically.
@@ -4957,34 +4956,21 @@ public class CameraDaemon {
             log("WARN: Could not read device ID from file: " + e.getMessage());
         }
         
-        // Fallback: use serial number hash
-        try {
-            String serial = android.os.Build.SERIAL;
-            if (serial != null && !serial.equals("unknown")) {
-                deviceId = "byd-" + Integer.toHexString(serial.hashCode()).substring(0, 8);
-                saveDeviceId(deviceId);
-                log("Device ID generated from serial: " + deviceId);
-                return;
-            }
-        } catch (Exception e) {
-            log("WARN: Could not get serial: " + e.getMessage());
+        // No existing file: mint a fresh device id. This is the sole seed for
+        // CredentialCipher's AES key (protects the Telegram bot token, BYD
+        // Cloud password, NavMap routing key), so it must be unpredictable —
+        // NOT derived from Build.SERIAL (only a 32-bit hash, and the serial is
+        // often readable by other apps / shown on the vehicle's info screen)
+        // or Build.FINGERPRINT (identical across every unit running the same
+        // firmware build, so every car of that model+version would share the
+        // exact same derived key). SecureRandom removes both shortcuts.
+        byte[] randomBytes = new byte[16];
+        new java.security.SecureRandom().nextBytes(randomBytes);
+        StringBuilder hex = new StringBuilder("byd-");
+        for (byte b : randomBytes) {
+            hex.append(String.format(java.util.Locale.US, "%02x", b));
         }
-        
-        // Fallback: use build fingerprint hash
-        try {
-            String fingerprint = android.os.Build.FINGERPRINT;
-            if (fingerprint != null && !fingerprint.isEmpty()) {
-                deviceId = "byd-" + Integer.toHexString(fingerprint.hashCode()).substring(0, 8);
-                saveDeviceId(deviceId);
-                log("Device ID generated from fingerprint: " + deviceId);
-                return;
-            }
-        } catch (Exception e) {
-            log("WARN: Could not get fingerprint: " + e.getMessage());
-        }
-        
-        // Last resort: generate random ID
-        deviceId = "byd-" + Long.toHexString(System.currentTimeMillis()).substring(4);
+        deviceId = hex.toString();
         saveDeviceId(deviceId);
         log("Device ID generated randomly: " + deviceId);
     }
@@ -4997,10 +4983,9 @@ public class CameraDaemon {
             writer.close();
             // Files created in /data/local/tmp by the shell-UID daemon land
             // at mode 0600 owned by shell. The app UID can't read them at
-            // that mode, so CredentialCipher.readDid() falls through to the
-            // "overdrive-default-device" sentinel and derives a different
-            // AES key — every encrypted credential (telegram bot token,
-            // BYD-cloud password) decodes to "" in the app process.
+            // that mode, so CredentialCipher.readDid() returns null, deriveKey()
+            // throws, and every encrypted credential (telegram bot token,
+            // BYD-cloud password) fails to decrypt in the app process.
             // Set world-readable so both UIDs read the same DID and derive
             // the same key. setWritable too so the app can update the DID
             // if a future migration ever needs to.

--- a/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
+++ b/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class TelegramCatalogParityTest {
     private static Map<String, Object> portuguese;
 
     @BeforeClass
-    public static void loadCatalogs() throws IOException {
+    public static void loadCatalogs() throws IOException, JSONException {
         english = loadTelegramCatalog("en");
         portuguese = loadTelegramCatalog("pt-BR");
     }
@@ -86,7 +87,8 @@ public class TelegramCatalogParityTest {
                 text.contains("*Commands*"));
     }
 
-    private static Map<String, Object> loadTelegramCatalog(String locale) throws IOException {
+    private static Map<String, Object> loadTelegramCatalog(String locale)
+            throws IOException, JSONException {
         Path catalog = findCatalog(locale);
         String json = new String(Files.readAllBytes(catalog), StandardCharsets.UTF_8);
         JSONObject root = new JSONObject(json);
@@ -116,8 +118,17 @@ public class TelegramCatalogParityTest {
                 + ".json from working directory " + System.getProperty("user.dir"));
     }
 
-    private static void flatten(JSONObject object, String prefix, Map<String, Object> output) {
-        for (String name : object.keySet()) {
+    private static void flatten(JSONObject object, String prefix, Map<String, Object> output)
+            throws JSONException {
+        // keys() (Iterator), not keySet(): android.jar's org.json.JSONObject stub
+        // (present on the unit-test compile classpath alongside the real
+        // org.json:json test dependency) only declares keys() — keySet() is an
+        // upstream json.org addition Android's fork never picked up, so using it
+        // here made ./gradlew test fail to compile regardless of which
+        // JSONObject the classpath happened to resolve to.
+        java.util.Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String name = keys.next();
             String path = prefix.isEmpty() ? name : prefix + "." + name;
             Object value = object.get(name);
             if (value instanceof JSONObject) {


### PR DESCRIPTION
The AES key protecting the Telegram bot token, BYD Cloud password, and NavMap routing key was derivable without any device access in two cases: CredentialCipher.readDid() fell back to the hardcoded literal "overdrive-default-device" when the shared device-id file was missing/unreadable (public in this repo, so anyone could compute the same key), and CameraDaemon.generateDeviceId() - the actual first-boot generator - derived the id from a hash of Build.SERIAL or, failing that, Build.FINGERPRINT, which is identical across every vehicle running the same firmware build.

CameraDaemon now always mints a 128-bit SecureRandom device id on first boot. CredentialCipher.readDid() now returns null instead of the sentinel on failure, so deriveKey() throws - encrypt() already fails open to visible plaintext and decrypt() already fails closed to "", both pre-existing behaviors every caller already handles via isEncrypted()/empty-string checks.

Also fixes TelegramCatalogParityTest, which the unit-test compile classpath resolves org.json against Android's frozen stub (keys(): Iterator, checked JSONException) rather than the real org.json:json test dependency - the test used keySet() and assumed an unchecked exception, so `./gradlew test` failed to compile before this change.