### PR TITLE
Encrypt MQTT broker credentials at rest

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionConfig.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttConnectionConfig.java
@@ -1,5 +1,7 @@
 package com.overdrive.app.mqtt;
 
+import com.overdrive.app.byd.cloud.crypto.CredentialCipher;
+
 import org.json.JSONObject;
 
 import java.util.UUID;
@@ -217,6 +219,11 @@ public class MqttConnectionConfig {
 
     /**
      * Serialize to JSON for storage.
+     *
+     * <p>username/password are encrypted at rest via {@link CredentialCipher} —
+     * every other field is non-secret config. The in-memory {@link #username}/
+     * {@link #password} stay plaintext (MqttPublisherService feeds {@link #password}
+     * straight into Paho's {@code setPassword()}); only this on-disk form is protected.
      */
     public JSONObject toJson() {
         JSONObject json = new JSONObject();
@@ -227,8 +234,8 @@ public class MqttConnectionConfig {
             json.put("port", port);
             json.put("topic", topic);
             json.put("clientId", clientId);
-            json.put("username", username);
-            json.put("password", password);
+            json.put("username", CredentialCipher.encrypt(username));
+            json.put("password", CredentialCipher.encrypt(password));
             json.put("qos", qos);
             json.put("enabled", enabled);
             json.put("publishIntervalSeconds", publishIntervalSeconds);
@@ -251,10 +258,16 @@ public class MqttConnectionConfig {
 
     /**
      * Serialize to JSON for API responses (masks password).
+     *
+     * <p>toJson() now encrypts username/password for on-disk storage, so both
+     * are put back here in their real (API-facing) form: username in the
+     * clear — callers display it for reference — and password masked, never
+     * echoed even in encrypted form.
      */
     public JSONObject toSafeJson() {
         JSONObject json = toJson();
         try {
+            json.put("username", username);
             json.put("password", getMaskedPassword());
             json.put("configured", isConfigured());
         } catch (Exception ignored) {}
@@ -272,8 +285,11 @@ public class MqttConnectionConfig {
         config.port = json.optInt("port", DEFAULT_PORT);
         config.topic = json.optString("topic", "overdrive/vehicle/telemetry");
         config.clientId = json.optString("clientId", "");
-        config.username = json.optString("username", "");
-        config.password = json.optString("password", "");
+        // decrypt() passes plaintext through unchanged (isEncrypted() check),
+        // so this also transparently migrates connections saved before
+        // username/password were encrypted — the next save() re-encrypts them.
+        config.username = CredentialCipher.decrypt(json.optString("username", ""));
+        config.password = CredentialCipher.decrypt(json.optString("password", ""));
         config.qos = json.optInt("qos", DEFAULT_QOS);
         config.enabled = json.optBoolean("enabled", false);
         config.publishIntervalSeconds = json.optInt("publishIntervalSeconds", DEFAULT_PUBLISH_INTERVAL);

--- a/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
+++ b/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class TelegramCatalogParityTest {
     private static Map<String, Object> portuguese;
 
     @BeforeClass
-    public static void loadCatalogs() throws IOException {
+    public static void loadCatalogs() throws IOException, JSONException {
         english = loadTelegramCatalog("en");
         portuguese = loadTelegramCatalog("pt-BR");
     }
@@ -86,7 +87,8 @@ public class TelegramCatalogParityTest {
                 text.contains("*Commands*"));
     }
 
-    private static Map<String, Object> loadTelegramCatalog(String locale) throws IOException {
+    private static Map<String, Object> loadTelegramCatalog(String locale)
+            throws IOException, JSONException {
         Path catalog = findCatalog(locale);
         String json = new String(Files.readAllBytes(catalog), StandardCharsets.UTF_8);
         JSONObject root = new JSONObject(json);
@@ -116,8 +118,17 @@ public class TelegramCatalogParityTest {
                 + ".json from working directory " + System.getProperty("user.dir"));
     }
 
-    private static void flatten(JSONObject object, String prefix, Map<String, Object> output) {
-        for (String name : object.keySet()) {
+    private static void flatten(JSONObject object, String prefix, Map<String, Object> output)
+            throws JSONException {
+        // keys() (Iterator), not keySet(): android.jar's org.json.JSONObject stub
+        // (present on the unit-test compile classpath alongside the real
+        // org.json:json test dependency) only declares keys() — keySet() is an
+        // upstream json.org addition Android's fork never picked up, so using it
+        // here made ./gradlew test fail to compile regardless of which
+        // JSONObject the classpath happened to resolve to.
+        java.util.Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String name = keys.next();
             String path = prefix.isEmpty() ? name : prefix + "." + name;
             Object value = object.get(name);
             if (value instanceof JSONObject) {


### PR DESCRIPTION
MqttConnectionConfig persisted username/password in plain JSON at /data/local/tmp/mqtt_connections.json - the one credential type in this app not routed through CredentialCipher (Telegram bot token, BYD Cloud password, and NavMap key already are).

toJson() now encrypts both fields before serialization; fromJson() decrypts them on load. CredentialCipher.decrypt() passes plaintext through unchanged when the ENC: marker is absent, so connections saved before this change keep working and are transparently re-encrypted on their next save() - no migration step needed.

The in-memory MqttConnectionConfig instance stays plaintext throughout (MqttPublisherService feeds password straight into Paho's setPassword()); only the on-disk form is protected. toSafeJson() (the API-response path) now explicitly restores the plaintext username after toJson()'s encryption, since - unlike password - it was previously echoed back to callers unmasked.

Included here: the pre-existing TelegramCatalogParityTest fix (already on the security/credential-cipher-key-derivation branch) so `./gradlew test` passes independent of merge order between the two PRs.