### PR TITLE
Encrypt Zrok tunnel tokens at rest

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/telegram/DaemonCommandHandler.java
+++ b/app/src/main/java/com/overdrive/app/daemon/telegram/DaemonCommandHandler.java
@@ -648,13 +648,20 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
                 // Falls back to public mode only if no reserved token exists
                 String identityCheck = ctx.execShell("test -f /data/local/tmp/.zrok/environment.json && echo yes || echo no");
                 if (identityCheck == null || !identityCheck.trim().equals("yes")) {
-                    // Need to enable — read token from saved file (set via app UI)
+                    // Need to enable — read token from saved file (set via app UI).
+                    // The file is encrypted at rest (CredentialCipher) since it's
+                    // written by ZrokLauncher.saveEnableToken(); decrypt() passes
+                    // plaintext through unchanged for tokens saved before that.
                     String enableToken = ctx.execShell("cat /data/local/tmp/.zrok/enable_token 2>/dev/null");
                     if (enableToken == null || enableToken.trim().isEmpty() || enableToken.contains("No such file")) {
                         ctx.log("❌ No zrok enable token found. Set it from the app UI first.");
                         return false;
                     }
-                    enableToken = enableToken.trim();
+                    enableToken = com.overdrive.app.byd.cloud.crypto.CredentialCipher.decrypt(enableToken.trim());
+                    if (enableToken.isEmpty()) {
+                        ctx.log("❌ Zrok enable token could not be decrypted. Re-set it from the app UI.");
+                        return false;
+                    }
                     ctx.log("⚠️ Device not enabled. Registering now (uses 1 of 5 slots)...");
                     String enableCmd = "HOME=/data/local/tmp " +
                         "ALL_PROXY=socks5://127.0.0.1:8119 " +
@@ -669,11 +676,16 @@ public class DaemonCommandHandler implements TelegramCommandHandler {
                     ctx.log("✅ Device already enabled.");
                 }
                 
-                // Check for saved reserved token (from app UI's zrok reserve)
+                // Check for saved reserved token (from app UI's zrok reserve).
+                // Encrypted at rest by ZrokLauncher.saveReservedToken(); decrypt()
+                // passes plaintext through unchanged for pre-existing tokens.
                 String reservedToken = null;
                 String tokenRead = ctx.execShell("cat /data/local/tmp/.zrok/reserved_token 2>/dev/null");
                 if (tokenRead != null && !tokenRead.trim().isEmpty() && !tokenRead.contains("No such file")) {
-                    reservedToken = tokenRead.trim();
+                    String decrypted = com.overdrive.app.byd.cloud.crypto.CredentialCipher.decrypt(tokenRead.trim());
+                    if (!decrypted.isEmpty()) {
+                        reservedToken = decrypted;
+                    }
                 }
                 
                 // Also read saved unique name for logging

--- a/app/src/main/java/com/overdrive/app/launcher/ZrokLauncher.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/ZrokLauncher.kt
@@ -1,6 +1,7 @@
 package com.overdrive.app.launcher
 
 import android.content.Context
+import com.overdrive.app.byd.cloud.crypto.CredentialCipher
 import com.overdrive.app.logging.LogManager
 
 /**
@@ -517,8 +518,9 @@ class ZrokLauncher(
     }
     
     private fun saveReservedToken(token: String) {
+        val encryptedToken = CredentialCipher.encrypt(token)
         adbShellExecutor.execute(
-            command = "echo '$token' > $ZROK_RESERVED_TOKEN_FILE",
+            command = "echo '$encryptedToken' > $ZROK_RESERVED_TOKEN_FILE",
             callback = object : AdbShellExecutor.ShellCallback {
                 override fun onSuccess(output: String) {
                     logManager.info(TAG, "Reserved token saved to file")
@@ -538,8 +540,12 @@ class ZrokLauncher(
             command = "cat $ZROK_RESERVED_TOKEN_FILE 2>/dev/null",
             callback = object : AdbShellExecutor.ShellCallback {
                 override fun onSuccess(output: String) {
-                    val token = output.trim()
-                    if (token.isNotEmpty() && !token.contains("No such file")) {
+                    val raw = output.trim()
+                    if (raw.isNotEmpty() && !raw.contains("No such file")) {
+                        // decrypt() passes plaintext through unchanged, so this also
+                        // transparently migrates tokens saved before this field was
+                        // encrypted — the next saveReservedToken() re-encrypts it.
+                        val token = CredentialCipher.decrypt(raw)
                         reservedShareToken = token
                         callback(token)
                     } else {
@@ -1903,9 +1909,10 @@ class ZrokLauncher(
         // Update in-memory token
         zrokToken = trimmedToken
         tokenLoaded = true
-        
+
+        val encryptedToken = CredentialCipher.encrypt(trimmedToken)
         adbShellExecutor.execute(
-            command = "mkdir -p /data/local/tmp/.zrok && echo '$trimmedToken' > $ZROK_ENABLE_TOKEN_FILE && chmod 666 $ZROK_ENABLE_TOKEN_FILE",
+            command = "mkdir -p /data/local/tmp/.zrok && echo '$encryptedToken' > $ZROK_ENABLE_TOKEN_FILE && chmod 666 $ZROK_ENABLE_TOKEN_FILE",
             callback = object : AdbShellExecutor.ShellCallback {
                 override fun onSuccess(output: String) {
                     logManager.info(TAG, "Enable token saved to unified storage")
@@ -1928,8 +1935,12 @@ class ZrokLauncher(
             command = "cat $ZROK_ENABLE_TOKEN_FILE 2>/dev/null",
             callback = object : AdbShellExecutor.ShellCallback {
                 override fun onSuccess(output: String) {
-                    val token = output.trim()
-                    if (token.isNotEmpty() && !token.contains("No such file")) {
+                    val raw = output.trim()
+                    if (raw.isNotEmpty() && !raw.contains("No such file")) {
+                        // decrypt() passes plaintext through unchanged, so this also
+                        // transparently migrates tokens saved before this field was
+                        // encrypted — the next saveEnableToken() re-encrypts it.
+                        val token = CredentialCipher.decrypt(raw)
                         zrokToken = token
                         tokenLoaded = true
                         logManager.info(TAG, "Enable token loaded from unified storage")

--- a/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
+++ b/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class TelegramCatalogParityTest {
     private static Map<String, Object> portuguese;
 
     @BeforeClass
-    public static void loadCatalogs() throws IOException {
+    public static void loadCatalogs() throws IOException, JSONException {
         english = loadTelegramCatalog("en");
         portuguese = loadTelegramCatalog("pt-BR");
     }
@@ -86,7 +87,8 @@ public class TelegramCatalogParityTest {
                 text.contains("*Commands*"));
     }
 
-    private static Map<String, Object> loadTelegramCatalog(String locale) throws IOException {
+    private static Map<String, Object> loadTelegramCatalog(String locale)
+            throws IOException, JSONException {
         Path catalog = findCatalog(locale);
         String json = new String(Files.readAllBytes(catalog), StandardCharsets.UTF_8);
         JSONObject root = new JSONObject(json);
@@ -116,8 +118,17 @@ public class TelegramCatalogParityTest {
                 + ".json from working directory " + System.getProperty("user.dir"));
     }
 
-    private static void flatten(JSONObject object, String prefix, Map<String, Object> output) {
-        for (String name : object.keySet()) {
+    private static void flatten(JSONObject object, String prefix, Map<String, Object> output)
+            throws JSONException {
+        // keys() (Iterator), not keySet(): android.jar's org.json.JSONObject stub
+        // (present on the unit-test compile classpath alongside the real
+        // org.json:json test dependency) only declares keys() — keySet() is an
+        // upstream json.org addition Android's fork never picked up, so using it
+        // here made ./gradlew test fail to compile regardless of which
+        // JSONObject the classpath happened to resolve to.
+        java.util.Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String name = keys.next();
             String path = prefix.isEmpty() ? name : prefix + "." + name;
             Object value = object.get(name);
             if (value instanceof JSONObject) {


### PR DESCRIPTION
ZrokLauncher stored the enable token and reserved share token in plain files (/data/local/tmp/.zrok/enable_token, .../reserved_token), written via ADB shell echo since the app UID can't write directly to files created by the shell-UID daemon. Once a tunnel is active these tokens control who can register/re-share the device's public URL - Zrok's free tier caps device registration at 5 total, so a leaked enable token also burns a scarce, hard-to-recover resource.

saveEnableToken()/saveReservedToken() now encrypt the token via CredentialCipher before it's embedded in the echo command; loadEnableToken()/loadReservedToken() decrypt after reading. The in-memory zrokToken/reservedShareToken fields stay plaintext (they're interpolated directly into the real `zrok enable`/`zrok share reserved` shell commands). decrypt() passes plaintext through unchanged when the ENC: marker is absent, so tokens saved by prior installs keep working and are transparently re-encrypted on the next save - no migration step needed. As a side effect, embedding the encrypted (fixed-alphabet Base64) blob in the shell command is also safer than the previous raw token interpolation, which had no shell-metacharacter handling.

DaemonCommandHandler's Telegram `/tunnel zrok` command handler reads both files directly via `cat` (its own execShell, not ZrokLauncher's methods) to launch the tunnel from a chat command without an app UI session - updated both read sites to decrypt as well, or this path would have tried to use the encrypted blob as a literal zrok token.

Included here: the pre-existing TelegramCatalogParityTest fix (already on security/credential-cipher-key-derivation) so `./gradlew test` passes independent of merge order between the PRs.