### PR TITLE
Shorten JWT expiry from 1 year to 30 days

### DIFF
--- a/app/src/main/java/com/overdrive/app/auth/AuthManager.java
+++ b/app/src/main/java/com/overdrive/app/auth/AuthManager.java
@@ -25,7 +25,7 @@ import javax.crypto.spec.SecretKeySpec;
  * Auth Flow:
  * 1. User enters device token (displayed in app)
  * 2. Token validated → JWT session created
- * 3. JWT used for subsequent requests (1 year expiry)
+ * 3. JWT used for subsequent requests (30 day expiry, then re-login)
  *
  * Security:
  * - Device token = deviceId + secret (e.g., byd-a1b2c3d4-x7k9m2p5)
@@ -68,8 +68,26 @@ public class AuthManager {
     // deviceId yet (cold-start before MainActivity has synced).
     private static final String DEVICE_ID_FILE = "/data/local/tmp/.overdrive_device_id";
 
-    // JWT settings
-    private static final long JWT_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000L; // 1 year (effectively indefinite)
+    // JWT settings.
+    //
+    // Was 1 year ("effectively indefinite") — anyone who read the device
+    // secret once (a co-located process reading the world-rw unified config,
+    // or a leaked config backup per ConfigBackupService's own documented
+    // risk) got near-permanent API access, since nothing re-validates a
+    // still-unexpired JWT against anything but its signature. 30 days caps
+    // that exposure window at roughly 1/12th of the previous one.
+    //
+    // There's no silent-refresh endpoint: a client's cookie/localStorage JWT
+    // is minted once at login (AuthApiHandler.handleTokenValidation) and used
+    // until it expires, at which point auth.js's 401 handler redirects to
+    // /login.html for the user to re-enter their (unchanged) device token.
+    // That's an acceptable, deliberately simple trade-off at 30 days; a
+    // shorter expiry would need an actual refresh mechanism to avoid
+    // constant re-login friction.
+    private static final long JWT_EXPIRY_MS = 30L * 24 * 60 * 60 * 1000L; // 30 days
+    // Public so AuthApiHandler's login response can report the real value
+    // instead of hardcoding its own copy that could drift from this one.
+    public static final long JWT_EXPIRY_SECONDS = JWT_EXPIRY_MS / 1000;
     private static final String JWT_ALGORITHM = "HS256";
 
     // In-memory cache. UnifiedConfigManager already mtime-invalidates its

--- a/app/src/main/java/com/overdrive/app/server/AuthApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/AuthApiHandler.java
@@ -234,7 +234,7 @@ public class AuthApiHandler {
                     response.put("success", true);
                     response.put("jwt", jwt);
                     response.put("deviceId", state.deviceId);
-                    response.put("expiresIn", 365 * 24 * 60 * 60); // 1 year — matches JWT expiry
+                    response.put("expiresIn", AuthManager.JWT_EXPIRY_SECONDS);
 
                     log("Token validated for device: " + state.deviceId);
                 }

--- a/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
+++ b/app/src/test/java/com/overdrive/app/telegram/TelegramCatalogParityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class TelegramCatalogParityTest {
     private static Map<String, Object> portuguese;
 
     @BeforeClass
-    public static void loadCatalogs() throws IOException {
+    public static void loadCatalogs() throws IOException, JSONException {
         english = loadTelegramCatalog("en");
         portuguese = loadTelegramCatalog("pt-BR");
     }
@@ -86,7 +87,8 @@ public class TelegramCatalogParityTest {
                 text.contains("*Commands*"));
     }
 
-    private static Map<String, Object> loadTelegramCatalog(String locale) throws IOException {
+    private static Map<String, Object> loadTelegramCatalog(String locale)
+            throws IOException, JSONException {
         Path catalog = findCatalog(locale);
         String json = new String(Files.readAllBytes(catalog), StandardCharsets.UTF_8);
         JSONObject root = new JSONObject(json);
@@ -116,8 +118,17 @@ public class TelegramCatalogParityTest {
                 + ".json from working directory " + System.getProperty("user.dir"));
     }
 
-    private static void flatten(JSONObject object, String prefix, Map<String, Object> output) {
-        for (String name : object.keySet()) {
+    private static void flatten(JSONObject object, String prefix, Map<String, Object> output)
+            throws JSONException {
+        // keys() (Iterator), not keySet(): android.jar's org.json.JSONObject stub
+        // (present on the unit-test compile classpath alongside the real
+        // org.json:json test dependency) only declares keys() — keySet() is an
+        // upstream json.org addition Android's fork never picked up, so using it
+        // here made ./gradlew test fail to compile regardless of which
+        // JSONObject the classpath happened to resolve to.
+        java.util.Iterator<String> keys = object.keys();
+        while (keys.hasNext()) {
+            String name = keys.next();
             String path = prefix.isEmpty() ? name : prefix + "." + name;
             Object value = object.get(name);
             if (value instanceof JSONObject) {


### PR DESCRIPTION
AuthManager's JWT_EXPIRY_MS was 365 days ("effectively indefinite"), so anyone who read the device secret once - a co-located process reading the world-rw unified config at /data/local/tmp/overdrive_config.json, or a leaked config backup (ConfigBackupService's own docs already flag that risk) - could forge/keep a session valid for a full year, no matter when the read happened.

A manual rotation mechanism already existed (AuthManager.regenerateToken(), wired to a "Regenerate" action in DashboardFragment) that immediately invalidates every outstanding JWT by changing the signing secret - that part of the original plan was already done and didn't need touching. The actual gap was the default expiry itself: nothing forces rotation to happen, so a token minted once was good for a year regardless.

30 days caps that exposure window at roughly 1/12th of the previous one. There's no silent-refresh endpoint, so this trades some convenience for it: auth.js's existing 401 handler already redirects to /login.html, where the user re-enters their (unchanged) device token - the same re-auth path that already exists for an invalid or manually-regenerated session, just now reachable by calendar time too.

Also fixed a duplicate-constant drift bug found while tracing this: AuthApiHandler's login response hardcoded its own copy of the expiry ("365 * 24 * 60 * 60 // 1 year — matches JWT expiry") instead of reading it from AuthManager. Had this been left in place, the client cookie (whose max-age comes directly from this response field, per login.html) would have kept a 1-year lifetime even after the actual JWT expired in 30 days, doing nothing but confusing the failure mode. Exposed AuthManager.JWT_EXPIRY_SECONDS so both sides read one source of truth.