### PR TITLE
fix: Prevents prematurely cancelling the ghostview's finish.

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/AppLauncherGhostActivity.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/AppLauncherGhostActivity.kt
@@ -37,7 +37,11 @@ class AppLauncherGhostActivity : Activity() {
 
     override fun onPause() {
         super.onPause()
-        handler.removeCallbacks(finishRunnable)
+
+//        It is unnecessary and prematurely cancels the ghostview's termination.
+//        It only needs to be called in onDestroy. The activity should pause when the app
+//        is injected on top of it in the stack.
+//        handler.removeCallbacks(finishRunnable)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
The call to handler.removeCallbacks(finishRunnable) in onPause prematurely cancels the closing of the GhostView.