### PR TITLE
perf(daemon): skip re-granting permissions the app already holds (#178)

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/PermissionGranter.java
+++ b/app/src/main/java/com/overdrive/app/daemon/PermissionGranter.java
@@ -227,19 +227,30 @@ public final class PermissionGranter {
             int alreadyHeld = 0;
             List<String> failures = new ArrayList<>();
 
-            // One dumpsys read instead of 145 speculative grants. Every grant we
-            // can skip is a `sh` fork, a `cmd package` fork, a PMS binder call
-            // and a GRANT_THROTTLE_MS sleep that no longer lands on top of the
-            // camera HAL's first-frame window during daemon start.
+            // One dumpsys read instead of speculative grants for permissions
+            // the app already holds. Every grant we can skip is a `sh` fork, a
+            // `cmd package` fork, a PMS binder call and a GRANT_THROTTLE_MS
+            // sleep that no longer lands on top of the camera HAL's
+            // first-frame window during daemon start.
             //
-            // On a settled device this empties the loop almost completely; after
-            // a fresh install it is one extra call before the same full pass.
-            // Reading the live state (rather than persisting a "done" marker)
-            // keeps it self-correcting if a permission is ever revoked.
+            // Scope honestly stated: on the measured settled device this skips
+            // the ~33 grantable permissions dumpsys reports as held (19.1s ->
+            // 15.1s). The ~112 signature-level entries are never reported
+            // granted, so they still pay fork + binder + throttle every start;
+            // eliminating those would need a device-fingerprint-keyed cache
+            // whose stale-skip failure mode is worse than the waste (see
+            // issue #178). Reading live state (rather than persisting a
+            // "done" marker) keeps this self-correcting if a permission is
+            // ever revoked.
             Set<String> alreadyGranted = readGrantedPermissions(packageName);
+            // Intersect with our grant list before logging so the count here
+            // matches the "already held" counter in the Done line — dumpsys
+            // also reports grants we never attempt (auto-granted install-time
+            // and vendor permissions outside ALL_PERMISSIONS).
+            alreadyGranted.retainAll(java.util.Arrays.asList(ALL_PERMISSIONS));
             if (!alreadyGranted.isEmpty()) {
-                log("dumpsys reports " + alreadyGranted.size()
-                    + " permissions already held — those will be skipped");
+                log("dumpsys: " + alreadyGranted.size() + " of " + ALL_PERMISSIONS.length
+                    + " grant-list permissions already held — skipping those");
             }
 
             for (String permission : ALL_PERMISSIONS) {
@@ -270,10 +281,12 @@ public final class PermissionGranter {
                 }
                 
                 // Throttle: yield between grants to avoid flooding PMS.
-                // 50ms per grant ISSUED — permissions we already hold skip the
-                // loop body above, so a settled device now sleeps ~0s here
-                // instead of the full 145 × 50ms ≈ 7s. Unthrottled, this was
-                // observed at 199s when PMS was overloaded by rapid restarts.
+                // 50ms per grant ISSUED — already-held permissions skip the
+                // loop body above. Measured on a settled device: ~112
+                // signature-level entries still reach here (dumpsys never
+                // reports them granted), so this sleeps ~5.6s per start, down
+                // from ~7.25s. Unthrottled, this was observed at 199s when PMS
+                // was overloaded by rapid restarts.
                 try { Thread.sleep(GRANT_THROTTLE_MS); } catch (InterruptedException e) {
                     log("Interrupted during throttle — aborting remaining grants");
                     break;
@@ -353,6 +366,14 @@ public final class PermissionGranter {
      * bare names with no grant marker, and treating those as granted would skip
      * exactly the grants we still need to issue.
      *
+     * <p>A permission reported {@code granted=false} ANYWHERE in the dump is
+     * excluded even if another line reports it {@code granted=true}. DiLink
+     * head units are single-user, but dumpsys emits one runtime block per
+     * Android user and {@code pm grant} (no {@code --user}) only fixes user 0 —
+     * so if a multi-user image ever appears, a permission revoked for user 0
+     * but held by another user must be re-granted, not skipped. Denied-wins is
+     * the safe direction: under-collecting merely re-issues a no-op grant.
+     *
      * <p>Returns an empty set for null / empty / unrecognised output. That is
      * the safe direction: an unreadable dumpsys degrades to "grant everything"
      * (the old behaviour), never to "skip everything".
@@ -361,20 +382,27 @@ public final class PermissionGranter {
         Set<String> granted = new HashSet<>();
         if (dumpsysOutput == null || dumpsysOutput.isEmpty()) return granted;
 
+        Set<String> denied = new HashSet<>();
         for (String rawLine : dumpsysOutput.split("\n")) {
             String line = rawLine.trim();
             int marker = line.indexOf(": granted=");
             if (marker <= 0) continue;
 
+            String name = line.substring(0, marker).trim();
+            if (name.isEmpty()) continue;
+
             // Value runs to the next comma (runtime entries append flags=[...]).
             String value = line.substring(marker + ": granted=".length());
             int comma = value.indexOf(',');
             if (comma >= 0) value = value.substring(0, comma);
-            if (!"true".equals(value.trim())) continue;
 
-            String name = line.substring(0, marker).trim();
-            if (!name.isEmpty()) granted.add(name);
+            if ("true".equals(value.trim())) {
+                granted.add(name);
+            } else {
+                denied.add(name);
+            }
         }
+        granted.removeAll(denied);
         return granted;
     }
 
@@ -384,9 +412,20 @@ public final class PermissionGranter {
      * attempting every grant — the pre-existing behaviour.
      */
     private static Set<String> readGrantedPermissions(String packageName) {
+        // The old code's first observable action was its interrupt check; keep
+        // that ordering — don't spawn a probe the shutdown path can't unblock
+        // (a parked pipe read does not respond to Thread.interrupt()).
+        if (Thread.currentThread().isInterrupted()) {
+            return new HashSet<>();
+        }
         try {
+            // -t 5: bound the dump at 5s (supported since Android 8.1; on an
+            // exotic build that rejects the flag, dumpsys errors out, we parse
+            // nothing, and the loop safely falls back to attempting every
+            // grant). Android's dumpsys also self-bounds per service (~10s),
+            // so this is belt and suspenders, not the only limit.
             Process process = Runtime.getRuntime().exec(
-                new String[]{"sh", "-c", "dumpsys package " + packageName + " 2>/dev/null"});
+                new String[]{"sh", "-c", "dumpsys -t 5 package " + packageName + " 2>/dev/null"});
 
             StringBuilder output = new StringBuilder(16384);
             try (BufferedReader reader =
@@ -396,8 +435,15 @@ public final class PermissionGranter {
                     output.append(line).append('\n');
                 }
             }
-            process.waitFor();
-            return parseGrantedPermissions(output.toString());
+            int exitCode = process.waitFor();
+            Set<String> parsed = parseGrantedPermissions(output.toString());
+            // A silent zero-result probe would be indistinguishable from a
+            // fresh install in the Done line; name the cause for field logs.
+            if (exitCode != 0 || parsed.isEmpty()) {
+                log("dumpsys probe yielded nothing (exit=" + exitCode
+                    + ", bytes=" + output.length() + ") — will attempt every grant");
+            }
+            return parsed;
         } catch (InterruptedException e) {
             // Preserve the interrupt so the grant loop's own check still fires.
             Thread.currentThread().interrupt();
@@ -432,6 +478,13 @@ public final class PermissionGranter {
     }
 
     private static void log(String msg) {
-        System.out.println(TAG + ": " + msg);
+        // DaemonLogger, not a bare System.out.println: proguard-rules.pro
+        // applies -assumenosideeffects to java.io.PrintStream in EVERY release
+        // build, so raw println calls are stripped and the field would see
+        // nothing from this class. DaemonLogger's file channel writes via
+        // PrintWriter (not PrintStream), survives that rule, and is gated by
+        // DaemonLogConfig — the supported field-diagnostics path. Its stdout
+        // channel also covers debug daemon runs (with timestamps).
+        com.overdrive.app.logging.DaemonLogger.getInstance(TAG).info(msg);
     }
 }

--- a/app/src/main/java/com/overdrive/app/daemon/PermissionGranter.java
+++ b/app/src/main/java/com/overdrive/app/daemon/PermissionGranter.java
@@ -3,7 +3,9 @@ package com.overdrive.app.daemon;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Shell-based permission granter for daemon processes.
@@ -222,7 +224,23 @@ public final class PermissionGranter {
             int granted = 0;
             int failed = 0;
             int skipped = 0;
+            int alreadyHeld = 0;
             List<String> failures = new ArrayList<>();
+
+            // One dumpsys read instead of 145 speculative grants. Every grant we
+            // can skip is a `sh` fork, a `cmd package` fork, a PMS binder call
+            // and a GRANT_THROTTLE_MS sleep that no longer lands on top of the
+            // camera HAL's first-frame window during daemon start.
+            //
+            // On a settled device this empties the loop almost completely; after
+            // a fresh install it is one extra call before the same full pass.
+            // Reading the live state (rather than persisting a "done" marker)
+            // keeps it self-correcting if a permission is ever revoked.
+            Set<String> alreadyGranted = readGrantedPermissions(packageName);
+            if (!alreadyGranted.isEmpty()) {
+                log("dumpsys reports " + alreadyGranted.size()
+                    + " permissions already held — those will be skipped");
+            }
 
             for (String permission : ALL_PERMISSIONS) {
                 // Check if daemon is shutting down — stop spawning new processes
@@ -230,7 +248,12 @@ public final class PermissionGranter {
                     log("Interrupted — aborting remaining grants");
                     break;
                 }
-                
+
+                if (alreadyGranted.contains(permission)) {
+                    alreadyHeld++;
+                    continue;   // no fork, no binder call, no throttle sleep
+                }
+
                 try {
                     int result = execGrant(packageName, permission);
                     if (result == 0) {
@@ -247,8 +270,10 @@ public final class PermissionGranter {
                 }
                 
                 // Throttle: yield between grants to avoid flooding PMS.
-                // 50ms × 141 permissions = ~7s total, vs the unthrottled 199s
-                // observed in logs when PMS was overloaded from rapid restarts.
+                // 50ms per grant ISSUED — permissions we already hold skip the
+                // loop body above, so a settled device now sleeps ~0s here
+                // instead of the full 145 × 50ms ≈ 7s. Unthrottled, this was
+                // observed at 199s when PMS was overloaded by rapid restarts.
                 try { Thread.sleep(GRANT_THROTTLE_MS); } catch (InterruptedException e) {
                     log("Interrupted during throttle — aborting remaining grants");
                     break;
@@ -256,8 +281,8 @@ public final class PermissionGranter {
             }
 
             long elapsed = System.currentTimeMillis() - start;
-            log("Done in " + elapsed + "ms: " + granted + " granted, " 
-                + skipped + " skipped, " + failed + " failed");
+            log("Done in " + elapsed + "ms: " + alreadyHeld + " already held, "
+                + granted + " granted, " + skipped + " skipped, " + failed + " failed");
             if (!failures.isEmpty() && failures.size() <= 15) {
                 log("Failed: " + String.join(", ", failures));
             } else if (!failures.isEmpty()) {
@@ -315,6 +340,71 @@ public final class PermissionGranter {
             return -1;
         } catch (Exception e) {
             return -1;
+        }
+    }
+
+    /**
+     * Permissions {@code dumpsys package <pkg>} reports as already granted.
+     *
+     * <p>Parses both blocks the platform emits — {@code install permissions:}
+     * (bare {@code name: granted=true}) and the per-user
+     * {@code runtime permissions:} (which appends {@code , flags=[...]}). The
+     * {@code requested permissions:} block is deliberately NOT counted: it lists
+     * bare names with no grant marker, and treating those as granted would skip
+     * exactly the grants we still need to issue.
+     *
+     * <p>Returns an empty set for null / empty / unrecognised output. That is
+     * the safe direction: an unreadable dumpsys degrades to "grant everything"
+     * (the old behaviour), never to "skip everything".
+     */
+    static Set<String> parseGrantedPermissions(String dumpsysOutput) {
+        Set<String> granted = new HashSet<>();
+        if (dumpsysOutput == null || dumpsysOutput.isEmpty()) return granted;
+
+        for (String rawLine : dumpsysOutput.split("\n")) {
+            String line = rawLine.trim();
+            int marker = line.indexOf(": granted=");
+            if (marker <= 0) continue;
+
+            // Value runs to the next comma (runtime entries append flags=[...]).
+            String value = line.substring(marker + ": granted=".length());
+            int comma = value.indexOf(',');
+            if (comma >= 0) value = value.substring(0, comma);
+            if (!"true".equals(value.trim())) continue;
+
+            String name = line.substring(0, marker).trim();
+            if (!name.isEmpty()) granted.add(name);
+        }
+        return granted;
+    }
+
+    /**
+     * Run {@code dumpsys package <pkg>} and return the permissions it reports as
+     * granted. Returns an empty set on any failure so the caller falls back to
+     * attempting every grant — the pre-existing behaviour.
+     */
+    private static Set<String> readGrantedPermissions(String packageName) {
+        try {
+            Process process = Runtime.getRuntime().exec(
+                new String[]{"sh", "-c", "dumpsys package " + packageName + " 2>/dev/null"});
+
+            StringBuilder output = new StringBuilder(16384);
+            try (BufferedReader reader =
+                         new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append('\n');
+                }
+            }
+            process.waitFor();
+            return parseGrantedPermissions(output.toString());
+        } catch (InterruptedException e) {
+            // Preserve the interrupt so the grant loop's own check still fires.
+            Thread.currentThread().interrupt();
+            return new HashSet<>();
+        } catch (Exception e) {
+            log("dumpsys probe failed (" + e.getMessage() + ") — will attempt every grant");
+            return new HashSet<>();
         }
     }
 

--- a/app/src/test/java/com/overdrive/app/daemon/PermissionGranterTest.java
+++ b/app/src/test/java/com/overdrive/app/daemon/PermissionGranterTest.java
@@ -71,6 +71,30 @@ public class PermissionGranterTest {
     }
 
     @Test
+    public void deniedAnywhereWinsOverGrantedElsewhere() {
+        // dumpsys emits one runtime block per Android user; pm grant (no
+        // --user) only fixes user 0. A permission revoked in one block but
+        // granted in another must be re-granted, not skipped — regardless of
+        // which line the parser encounters first.
+        String multiUser = String.join("\n",
+                "      runtime permissions:",
+                "        android.permission.ACCESS_FINE_LOCATION: granted=false, flags=[ USER_SET]",
+                "    User 10: ceDataInode=456 installed=true hidden=false",
+                "      runtime permissions:",
+                "        android.permission.ACCESS_FINE_LOCATION: granted=true",
+                "");
+        assertFalse(PermissionGranter.parseGrantedPermissions(multiUser)
+                .contains("android.permission.ACCESS_FINE_LOCATION"));
+
+        String reversedOrder = String.join("\n",
+                "        android.permission.ACCESS_FINE_LOCATION: granted=true",
+                "        android.permission.ACCESS_FINE_LOCATION: granted=false, flags=[ USER_SET]",
+                "");
+        assertFalse(PermissionGranter.parseGrantedPermissions(reversedOrder)
+                .contains("android.permission.ACCESS_FINE_LOCATION"));
+    }
+
+    @Test
     public void excludesMerelyRequestedPermissions() {
         // The "requested permissions:" block lists bare names with no
         // granted= marker. Treating those as granted would skip the very

--- a/app/src/test/java/com/overdrive/app/daemon/PermissionGranterTest.java
+++ b/app/src/test/java/com/overdrive/app/daemon/PermissionGranterTest.java
@@ -1,0 +1,97 @@
+package com.overdrive.app.daemon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * Parsing the already-granted permission set out of {@code dumpsys package}.
+ *
+ * <p>The fixture below is trimmed verbatim from a BYD Seal head unit
+ * (firmware 13.1.33.2602030.1, Android 10) so the indentation, the
+ * {@code flags=[...]} suffix on runtime entries, and the bare-name
+ * {@code requested permissions:} block all match what the parser really sees.
+ */
+public class PermissionGranterTest {
+
+    /**
+     * Real {@code dumpsys package com.overdrive.app} excerpt. A
+     * {@code granted=false} runtime entry is included — absent on the sampled
+     * device, but a permission can be revoked and the parser must not claim it.
+     */
+    private static final String DUMPSYS = String.join("\n",
+            "    requested permissions:",
+            "      android.permission.DEVICE_POWER",
+            "      com.byd.car.server.PROVIDER",
+            "      android.permission.ACCESS_MEDIA_LOCATION",
+            "    install permissions:",
+            "      android.permission.SYSTEM_ALERT_WINDOW: granted=true",
+            "      android.permission.FOREGROUND_SERVICE: granted=true",
+            "      com.byd.car.server.PROVIDER: granted=true",
+            "      android.permission.WRITE_SECURE_SETTINGS: granted=true",
+            "    User 0: ceDataInode=123 installed=true hidden=false",
+            "      gids=[3002, 3003, 3001, 1007]",
+            "      runtime permissions:",
+            "        android.permission.ACCESS_FINE_LOCATION: granted=true, "
+                    + "flags=[ USER_SENSITIVE_WHEN_GRANTED|USER_SENSITIVE_WHEN_DENIED]",
+            "        android.permission.BYDAUTO_SAFETY_BELT_COMMON: granted=true",
+            "        android.permission.RECORD_AUDIO: granted=false, flags=[ USER_SET]",
+            "");
+
+    @Test
+    public void collectsInstallPermissions() {
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertTrue(granted.contains("android.permission.SYSTEM_ALERT_WINDOW"));
+        assertTrue(granted.contains("android.permission.WRITE_SECURE_SETTINGS"));
+    }
+
+    @Test
+    public void collectsRuntimePermissionsDespiteFlagsSuffix() {
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertTrue(granted.contains("android.permission.ACCESS_FINE_LOCATION"));
+        assertTrue(granted.contains("android.permission.BYDAUTO_SAFETY_BELT_COMMON"));
+    }
+
+    @Test
+    public void collectsNonAndroidPermissionNamespaces() {
+        // BYD ships vendor permissions under their own package namespace.
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertTrue(granted.contains("com.byd.car.server.PROVIDER"));
+    }
+
+    @Test
+    public void excludesRevokedPermissions() {
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertFalse("granted=false must not count as granted",
+                granted.contains("android.permission.RECORD_AUDIO"));
+    }
+
+    @Test
+    public void excludesMerelyRequestedPermissions() {
+        // The "requested permissions:" block lists bare names with no
+        // granted= marker. Treating those as granted would skip the very
+        // grants we need to issue.
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertFalse(granted.contains("android.permission.DEVICE_POWER"));
+        assertFalse(granted.contains("android.permission.ACCESS_MEDIA_LOCATION"));
+    }
+
+    @Test
+    public void countsOnlyGrantedEntries() {
+        Set<String> granted = PermissionGranter.parseGrantedPermissions(DUMPSYS);
+        assertEquals(6, granted.size());
+    }
+
+    @Test
+    public void emptyOrUnparseableOutputYieldsNothingRatherThanThrowing() {
+        // A dumpsys failure must degrade to "grant everything", never to
+        // "skip everything" — losing permissions would break the daemon.
+        assertTrue(PermissionGranter.parseGrantedPermissions("").isEmpty());
+        assertTrue(PermissionGranter.parseGrantedPermissions(null).isEmpty());
+        assertTrue(PermissionGranter.parseGrantedPermissions("garbage output").isEmpty());
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Reads the already-granted permission set once via `dumpsys package <pkg>` and skips those permissions, instead of speculatively re-granting all 145 on every CameraDaemon launch.

## Why is this change needed?

Fixes #178.

`PermissionGranter.grantAllPermissions` is guarded only by `private static boolean hasRun`. Each daemon restart is a fresh process, so it always redid the full pass: 145 × (`sh` fork + `cmd package` fork + PMS binder call + 50 ms throttle sleep).

It runs on a background thread so it never blocked startup — but it dumped that load across the first ~19 s of daemon life, which is exactly when the BYD AVM HAL is taking its documented 5–8 s to deliver a first frame and the GL watchdog is on its extended 10 s warm-up timeout. The class's own docs record that an earlier unthrottled version caused binder timeouts that broke `createPackageContext()`.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests '*PermissionGranterTest*'
./gradlew :app:assembleDebug
```

`PermissionGranterTest` — 7 cases against a fixture trimmed verbatim from a real `dumpsys package com.overdrive.app` on the affected head unit, so the indentation, the `flags=[...]` suffix and the bare-name `requested permissions:` block all match production. Covers install perms, runtime perms with flags, vendor namespaces (`com.byd.car.server.PROVIDER`), `granted=false` exclusion, `requested`-but-not-granted exclusion, and null/empty/garbage input.

Confirmed RED first: the tests failed with `cannot find symbol: parseGrantedPermissions` before the parser existed.

### Measured on the vehicle

BYD Seal, firmware `13.1.33.2602030.1`, Android 10. Debug build run against the release baseline via the daemon's own `CLASSPATH` (no reinstall):

```
before:  PermissionGranter: Done in 19057ms: 30 granted, 115 skipped, 0 failed
after:   PermissionGranter: dumpsys reports 44 permissions already held — those will be skipped
         PermissionGranter: Done in 15146ms: 33 already held, 0 granted, 112 skipped, 0 failed
```

**19.1 s → 15.1 s (−20%)**, 33 fewer fork pairs.

Note `0 granted` in the after line: every one of the 30 the old log counted as "granted" was a no-op re-grant of a permission the app already held — which was the premise of the issue, now directly confirmed.

## Scope — please read before merging

**I overstated the achievable win when I filed #178** and have [corrected it there](https://github.com/yash-srivastava/Overdrive-release/issues/178#issuecomment-5065679104). I assumed most of the 145 were already granted. They are not:

| | count | fate |
|---|---|---|
| already granted | 33 | skipped by this PR |
| requested but not grantable | 112 | still attempted |
| not in manifest | 1 | — |

The 112 are signature/privileged-level permissions the manifest declares but the app cannot hold, so `pm grant` returns "not a changeable permission". They are the bulk of the remaining ~13 s.

**Removing those is deliberately not in this PR.** It would need a marker persisted against something like `ro.build.fingerprint` + `versionCode`, and its failure mode is worse than the waste it removes: a stale or mis-keyed cache would silently skip a grant that had become possible, and the daemon would quietly lose a capability rather than just burn a few seconds. That is your risk call about your own vehicle software, not something to fold into a perf patch. Happy to add it as a follow-up if you want it.

So: a real but modest −20%, honestly measured. If that is not worth the extra `dumpsys` call to you, closing this is a reasonable outcome.

## Notes for review

- Failure is biased safe: an unreadable `dumpsys` yields an empty set, so the loop attempts every grant exactly as before.
- `InterruptedException` during the probe re-sets the interrupt flag so the grant loop's own shutdown check still fires.
- Reading live state (rather than a "done" marker) means a revoked permission is re-granted on the next launch.
- The `dumpsys reports N already held` log line reports the parsed set size (44), which is a superset of the entries in `ALL_PERMISSIONS`; the accurate per-run figure is the `33 already held` counter on the Done line.
- CI note: this branch is cut from `main`, where `TelegramCatalogParityTest` is already red — unrelated, and fixed by #179. `PermissionGranterTest` passes 7/7 and `assembleDebug` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
