### PR TITLE
fix(mqtt): recover the HA link instead of stranding when the Tailscale proxy isn't up (#182)

### DIFF
--- a/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/MqttPublisherService.java
@@ -38,6 +38,11 @@ public class MqttPublisherService implements MqttCallback {
     private static final int BACKOFF_BASE_SECONDS = 5;
     private static final int BACKOFF_CAP_SECONDS = 300;
 
+    // How long to wait for an enabled-but-not-yet-up Tailscale proxy before falling back to a
+    // direct dial. Covers the boot window (tailscaled still binding) without permanently refusing
+    // a directly-reachable broker if the proxy is genuinely dead.
+    private static final long PROXY_WARMUP_GRACE_MS = 60_000L;
+
     // Connection config
     private final MqttConnectionConfig config;
     private final String deviceId;
@@ -53,6 +58,10 @@ public class MqttPublisherService implements MqttCallback {
     private volatile long lastPublishTime = 0;
     private volatile int consecutiveFailures = 0;
     private volatile String lastError = null;
+    // Proxy warm-up tracking (issue #182): when the first defer started, and whether we've already
+    // logged this warm-up so the health loop doesn't spam an identical warning every cycle.
+    private volatile long proxyWaitStartMs = 0L;
+    private volatile boolean loggedProxyWait = false;
 
     // Change detection (report-by-exception) + Home Assistant discovery state.
     // TelemetryDiffer is documented single-thread-owned: ALL access to it must
@@ -101,6 +110,44 @@ public class MqttPublisherService implements MqttCallback {
             logger.error(lastError);
             return false;
         }
+
+        // Mark the connection active as soon as it has a broker to attempt, independent of whether
+        // this first connect succeeds. Otherwise a failed OR deferred initial connect leaves
+        // running=false, and MqttConnectionManager's health loop bails on !isRunning() and never
+        // reschedules — the connection stays dead until a daemon restart. That gate (not the direct
+        // dial alone) is the real "never recovers" root cause behind #182, and the reason the
+        // "will retry on first publish" contract at the call site never actually held.
+        running = true;
+
+        // issue #182: when the Tailscale SOCKS proxy is ENABLED the broker is normally reachable
+        // ONLY through it (e.g. a LAN broker behind a subnet router while the car is on cellular).
+        // A DIRECT dial in that state can never succeed off Wi-Fi and strands the connection, so
+        // hold off while the proxy is warming up (tailscaled still binding at boot / after a link
+        // change) instead of falling through to the direct-socket path below. We do NOT bump
+        // consecutiveFailures — the health loop re-probes at the min-interval floor and connects the
+        // instant the proxy binds. Bounded by PROXY_WARMUP_GRACE_MS so a genuinely dead proxy can't
+        // permanently refuse a directly-reachable broker: after the grace window we fall through and
+        // try a direct dial as a last resort.
+        if (ProxyHelper.isProxyExpected() && !ProxyHelper.isProxyAvailable()) {
+            long now = System.currentTimeMillis();
+            if (proxyWaitStartMs == 0L) proxyWaitStartMs = now;
+            long waitedMs = now - proxyWaitStartMs;
+            if (waitedMs < PROXY_WARMUP_GRACE_MS) {
+                connected = false;
+                lastError = "Tailscale proxy enabled but not reachable yet (127.0.0.1:"
+                        + ProxyHelper.getTailscaleProxyPort() + ") — deferring connect until proxy is up";
+                if (!loggedProxyWait) {
+                    logger.warn(lastError);
+                    loggedProxyWait = true;
+                }
+                return false;
+            }
+            logger.warn("Tailscale proxy still unreachable after " + (waitedMs / 1000)
+                    + "s — attempting a direct connect as a fallback");
+        }
+        // Proxy is up (or the grace window elapsed) — clear the warm-up state and proceed to connect.
+        proxyWaitStartMs = 0L;
+        loggedProxyWait = false;
 
         String effectiveClientId = config.getEffectiveClientId(deviceId);
 

--- a/app/src/main/java/com/overdrive/app/mqtt/ProxyHelper.java
+++ b/app/src/main/java/com/overdrive/app/mqtt/ProxyHelper.java
@@ -2,6 +2,8 @@ package com.overdrive.app.mqtt;
 
 import com.overdrive.app.logging.DaemonLogger;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -39,6 +41,7 @@ public class ProxyHelper {
     private static final String PROXY_HOST = "127.0.0.1";
     private static final int PROXY_PORT = 8119;
     private static final int TAILSCALE_PROXY_PORT = 8539;
+    private static final String PROXY_ENABLED_FILE = "/data/local/tmp/.tailscale/proxy_enabled";
     // Loopback TCP connect budget. 200ms was too tight: a cold/loaded sing-box (or a
     // probe issued while the proxy is still binding) could miss, and a SINGLE miss
     // poisoned a whole minute (see the asymmetric cache below) → every map search /
@@ -82,23 +85,33 @@ public class ProxyHelper {
         proxyChecked = true;
         lastProbeTime = now;
 
-        try (Socket probe = new Socket()) {
-            try {
-                probe.connect(new InetSocketAddress(PROXY_HOST, TAILSCALE_PROXY_PORT), PROBE_TIMEOUT_MS);
-                proxyAvailable = true;
-                proxyPort = TAILSCALE_PROXY_PORT;
-                logger.info("Proxy probe: Tailscale proxy available on port " + TAILSCALE_PROXY_PORT);
-            } catch (Exception e) {
-                probe.connect(new InetSocketAddress(PROXY_HOST, PROXY_PORT), PROBE_TIMEOUT_MS);
-                proxyAvailable = true;
-                proxyPort = PROXY_PORT;
-                logger.info("Proxy probe: sing-box available on port " + PROXY_PORT);
-            }
-        } catch (Exception e) {
+        // Probe each candidate port on its OWN socket. A Socket cannot be reconnected after a
+        // failed connect(), so the previous single-socket form made the sing-box fallback throw
+        // "Socket closed" whenever the Tailscale probe missed — reporting "no proxy" even when a
+        // proxy was actually up (and, during the boot window, stranding MQTT on a direct dial).
+        if (probePort(TAILSCALE_PROXY_PORT)) {
+            proxyAvailable = true;
+            proxyPort = TAILSCALE_PROXY_PORT;
+            logger.info("Proxy probe: Tailscale proxy available on port " + TAILSCALE_PROXY_PORT);
+        } else if (probePort(PROXY_PORT)) {
+            proxyAvailable = true;
+            proxyPort = PROXY_PORT;
+            logger.info("Proxy probe: sing-box available on port " + PROXY_PORT);
+        } else {
             proxyAvailable = false;
         }
 
         return proxyAvailable;
+    }
+
+    /** Loopback TCP probe of a single port on a FRESH socket (see caller for why per-port). */
+    private static boolean probePort(int port) {
+        try (Socket probe = new Socket()) {
+            probe.connect(new InetSocketAddress(PROXY_HOST, port), PROBE_TIMEOUT_MS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**
@@ -110,12 +123,42 @@ public class ProxyHelper {
     }
 
     /**
+     * The Tailscale SOCKS port we expect when the proxy is enabled. Unlike {@link #getProxyPort()}
+     * (which stays at the sing-box default until a successful probe updates it), this is stable, so
+     * callers can name the right port in "proxy warming up" diagnostics.
+     */
+    public static int getTailscaleProxyPort() {
+        return TAILSCALE_PROXY_PORT;
+    }
+
+    /**
      * Invalidate the proxy cache.
      * Call this on connection failures so the next attempt re-probes.
      */
     public static void invalidateCache() {
         proxyAvailable = false;
         proxyChecked = false;
+    }
+
+    /**
+     * Whether the user has ENABLED the Tailscale SOCKS proxy (persisted flag written by the
+     * Daemons screen to {@code .tailscale/proxy_enabled}). When true, outbound traffic is
+     * expected to go through the proxy ONLY, so callers must not fall back to a direct dial
+     * that cannot reach a proxy-only (e.g. subnet-routed LAN) broker off Wi-Fi.
+     */
+    public static boolean isProxyExpected() {
+        try (BufferedReader r = new BufferedReader(new FileReader(PROXY_ENABLED_FILE))) {
+            return isProxyEnabledValue(r.readLine());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** Parse a persisted {@code proxy_enabled} value: true iff "true" (any case) or "1", trimmed. */
+    static boolean isProxyEnabledValue(String raw) {
+        if (raw == null) return false;
+        String v = raw.trim();
+        return "true".equalsIgnoreCase(v) || "1".equals(v);
     }
 
     /**

--- a/app/src/test/java/com/overdrive/app/mqtt/ProxyHelperProxyEnabledFlagTest.java
+++ b/app/src/test/java/com/overdrive/app/mqtt/ProxyHelperProxyEnabledFlagTest.java
@@ -1,0 +1,50 @@
+package com.overdrive.app.mqtt;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ProxyHelper#isProxyEnabledValue(String)} — the parse of the persisted
+ * {@code .tailscale/proxy_enabled} flag that gates the issue #182 "defer instead of direct dial"
+ * behaviour. TailscaleLauncher writes the flag with {@code echo $enabled > file}, so the value
+ * carries a trailing newline that the parser must tolerate.
+ */
+public class ProxyHelperProxyEnabledFlagTest {
+
+    @Test
+    public void trueWithTrailingNewlineIsEnabled() {
+        assertTrue(ProxyHelper.isProxyEnabledValue("true\n"));
+    }
+
+    @Test
+    public void trueAnyCaseAndSurroundingWhitespaceIsEnabled() {
+        assertTrue(ProxyHelper.isProxyEnabledValue("  TRUE  "));
+        assertTrue(ProxyHelper.isProxyEnabledValue("True"));
+    }
+
+    @Test
+    public void numericOneIsEnabled() {
+        assertTrue(ProxyHelper.isProxyEnabledValue("1"));
+    }
+
+    @Test
+    public void falseIsNotEnabled() {
+        assertFalse(ProxyHelper.isProxyEnabledValue("false\n"));
+    }
+
+    @Test
+    public void nullOrBlankIsNotEnabled() {
+        assertFalse(ProxyHelper.isProxyEnabledValue(null));
+        assertFalse(ProxyHelper.isProxyEnabledValue(""));
+        assertFalse(ProxyHelper.isProxyEnabledValue("   "));
+    }
+
+    @Test
+    public void unrelatedValuesAreNotEnabled() {
+        assertFalse(ProxyHelper.isProxyEnabledValue("enabled"));
+        assertFalse(ProxyHelper.isProxyEnabledValue("0"));
+        assertFalse(ProxyHelper.isProxyEnabledValue("yes"));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Keeps the Home Assistant MQTT connection alive when the broker is reachable **only** through the Tailscale SOCKS proxy — a LAN broker behind a subnet router while the car is on cellular. Instead of binding a direct dial that can't work off Wi‑Fi and then never retrying, `connect()` defers while the proxy is warming up and the health loop keeps retrying until it connects.

Three changes in `app/src/main/java/com/overdrive/app/mqtt/`:

- **`MqttPublisherService.connect()`** — when the Tailscale proxy is *enabled* but not yet reachable, defer (bounded by a 60 s grace, then fall back to a direct dial as a last resort) instead of dialing direct immediately; and set `running = true` as soon as there is a broker to attempt, so a failed/deferred **first** connect no longer wedges the publish loop.
- **`ProxyHelper`** — probe each candidate port on its **own** socket (the old code reused one `Socket` for the 8539→8119 fallback, and a `Socket` can't reconnect after a failed `connect()`); add `isProxyExpected()` and `getTailscaleProxyPort()`.
- Adds **`ProxyHelperProxyEnabledFlagTest`**.

## Why is this change needed?

Fixes #182.

On a head unit that reaches HA only via `tailscaled --socks5-server 127.0.0.1:8539` (broker `192.168.1.20` on the LAN behind a subnet router; car on cellular), every HA entity went `unavailable` for ~2 days across a daemon restart **and** a reboot. `GET /api/mqtt/status`:

```
"connected": false,
"lastError": "Connect failed (reason=0) Cause: MqttException → SocketTimeoutException:
   failed to connect to /192.168.1.20 (port 1883) from /10.247.169.156 (port 38850) after 10000ms"
```

`10.247.169.156` is the **cellular** interface — MQTT was dialing the LAN broker **directly**, bypassing the proxy (which is healthy over cellular). Two root causes:

1. **Direct‑dial fallback.** `connect()` chose proxy‑vs‑direct from a 500 ms probe; a miss (e.g. `tailscaled` still binding at boot) fell through to a direct dial that can never reach a proxy‑only broker off Wi‑Fi.
2. **The publish loop only ran after the first *successful* connect.** `running` was set true only on success (`MqttPublisherService.java:224`), but `MqttConnectionManager.runPublishCycle` bails on `!isRunning()` **without rescheduling** — so a failed or deferred first connect left the loop dead with nothing to revive it. This is the actual "never recovers", and why the call site's own *"will retry on first publish"* comment never held.

Plus a latent probe bug: `isProxyAvailable()` reused one `Socket` for the 8539→8119 fallback, so a down primary port made the fallback `connect()` throw `SocketException` and report "no proxy" even when one was up.

## How to test

Verified on the reporting vehicle — BYD Seal, Android 10, `tailscaled` userspace SOCKS on 8539, HA broker on the LAN behind a subnet router.

**Build + unit tests** (`./gradlew :app:testDebugUnitTest :app:assembleDebug`):

```
> Task :app:assembleDebug
BUILD SUCCESSFUL in 1m 55s
```
- **134 tests, 0 failures** — including the new `ProxyHelperProxyEnabledFlagTest` (6/6: trailing‑newline, case/whitespace, "1", "false", null/blank, unrelated values).

**On‑vehicle — cold start with the proxy down (the #182 scenario).** The camera daemon (which hosts the MQTT publisher) started while `tailscaled` was down, so its very first connect had no proxy. It deferred instead of stranding, the loop stayed alive, and it recovered on its own — **same daemon pid throughout, no restart**:

```
12:29:10  [WARN] [MqttPublisher-559bec57] Tailscale proxy enabled but not reachable yet (127.0.0.1:8539) — deferring connect until proxy is up
12:30:11  [INFO] [MqttPublisher-559bec57] Connected to tcp://192.168.1.20:1883
12:30:11  [INFO] [MqttPublisher-559bec57] Published HA discovery bundle … (97 keys)
          byd_cam_daemon pid 27866 before and after
```
Before this change the deferred/failed first connect left `running=false` and the loop never rescheduled — it stayed dead until a manual daemon restart.

**On‑vehicle — connects through the proxy when it is up.** Fresh daemon, `tailscaled` running:

```
8539 ESTABLISHED: 2        # app ↔ SOCKS proxy
12:34:11  [INFO] [MqttPublisher-559bec57] Connected to tcp://192.168.1.20:1883
```

**On‑vehicle — proxy dead but broker directly reachable (grace fallback).** With the proxy down for >60 s on Wi‑Fi, it stops deferring and falls back to a direct dial (`8539 ESTABLISHED: 0`, one direct socket to `:1883`) so a reachable broker is not refused forever — HA came back, `sensor.state_of_charge` updated.

**On‑vehicle — Wi‑Fi → cellular handover.** Turning the car's Wi‑Fi off drops it to cellular; MQTT reconnects through the proxy over the modem within ~7 s (HA entities update) with no daemon restart.

## Safety / blast radius

- When the proxy is **disabled** (the default for anyone not using Tailscale), `isProxyExpected()` returns false and behaviour is unchanged — normal direct dial. The new file read only happens on a (re)connect attempt, not while connected.
- Setting `running = true` earlier only makes the loop retry a connection it was already meant to be running — it fixes the missing retry the call site already promised; it starts nothing new.
- The 60 s grace bounds the new "wait for the proxy" behaviour so a genuinely dead proxy can't permanently block a directly‑reachable broker.
