### PR TITLE
feat: allow editing the electricity rate of a completed charging session

### DIFF
--- a/app/src/main/assets/web/i18n/en.json
+++ b/app/src/main/assets/web/i18n/en.json
@@ -404,6 +404,11 @@
   },
   "charge": {
     "title": "Charging",
+    "cannot_edit_in_progress_cost": "Cannot edit cost of an in-progress session",
+    "edit_rate_prompt": "Enter electricity rate per kWh (leave empty to reset):",
+    "invalid_rate": "Please enter a valid non-negative number",
+    "rate_updated": "Electricity rate updated",
+    "rate_update_failed": "Could not update electricity rate",
     "kicker": "Energy",
     "card_title": "Charging",
     "open": "Charging details",

--- a/app/src/main/assets/web/local/charging.html
+++ b/app/src/main/assets/web/local/charging.html
@@ -356,7 +356,15 @@
         }
         .ch-stat span { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; }
         .ch-stat strong { font-size: 18px; font-weight: 700; color: var(--text-primary); }
-
+        .ch-stat.interactive {
+            cursor: pointer;
+            transition: background 0.15s, border-color 0.15s;
+            border: 1px solid transparent;
+        }
+        .ch-stat.interactive:hover {
+            background: var(--bg-hover);
+            border-color: var(--border-subtle);
+        }
         .load-more-btn {
             display: block;
             width: 100%;
@@ -719,7 +727,16 @@
                             <div class="ch-stat"><span data-i18n="charge.detail_peak_power">Peak power</span><strong id="detailPeakPower">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_range_gained">Range gained</span><strong id="detailRangeGained">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_odometer">Odometer</span><strong id="detailOdometer">--</strong></div>
-                            <div class="ch-stat"><span data-i18n="charge.detail_cost">Cost</span><strong id="detailCost">--</strong></div>
+                            <div class="ch-stat interactive" onclick="CHARGING.editCost()" title="Edit cost">
+                                <span style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
+                                    <span data-i18n="charge.detail_cost" style="margin-bottom: 0;">Cost</span>
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;color:var(--text-muted);"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                </span>
+                                <div>
+                                    <strong id="detailCost">--</strong>
+                                    <span id="detailCostRate" style="font-size: 11px; font-weight: normal; color: var(--text-muted); display: inline-block; margin-left: 4px;"></span>
+                                </div>
+                            </div>
                             <div class="ch-stat"><span data-i18n="charge.detail_type">Type</span><strong id="detailType">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_temp">Battery temp</span><strong id="detailTemp">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_time_to_full">Time to full</span><strong id="detailTimeToFull">--</strong></div>

--- a/app/src/main/assets/web/shared/charging.js
+++ b/app/src/main/assets/web/shared/charging.js
@@ -686,11 +686,7 @@ var CHARGING = {
         if (list) list.classList.add('hidden');
         if (detail) { detail.classList.remove('hidden'); detail.classList.add('active'); }
 
-        // Find the row we already have for the header; fetch full + samples.
-        var row = null;
-        for (var i = 0; i < this.sessions.length; i++) {
-            if (this.sessions[i].id === id) { row = this.sessions[i]; break; }
-        }
+        var row = this._getSession(id);
         if (row) this._fillDetailHeader(row);
 
         fetch('/api/charging/' + id).then(function (r) { return r.json(); })
@@ -742,7 +738,8 @@ var CHARGING = {
         this._setText('detailPeakPower', (s.peakPower != null && s.peakPower > 0) ? s.peakPower.toFixed(1) + ' kW' : '--');
         this._setText('detailRangeGained', (s.rangeGained != null && s.rangeGained > 0) ? this._dist(s.rangeGained) : '--');
         this._setText('detailOdometer', (s.startOdometerKm != null && s.startOdometerKm > 0) ? this._dist(s.startOdometerKm) : '--');
-        this._setText('detailCost', (s.cost != null && s.cost > 0) ? this._money(s.cost) : '--');
+        this._setText('detailCost', (s.cost != null && s.cost >= 0) ? this._money(s.cost) : '--');
+        this._setText('detailCostRate', (s.electricityRate != null && s.electricityRate >= 0) ? '(' + this._money(s.electricityRate) + this._t('charge.per_kwh', '/kWh') + ')' : '');
         this._setText('detailType', this._typeLabel(s));
         this._setText('detailTimeToFull', (s.timeToFullMin != null && s.timeToFullMin > 0)
             ? this._fmtDuration(s.timeToFullMin) : '--');
@@ -847,6 +844,59 @@ var CHARGING = {
               self._toast(self._t('charge.save_failed', 'Could not save charging settings'), 'error');
               self.showApplyNeeded();
           });
+    },
+
+    editCost: function () {
+        var self = this;
+        if (this.currentSessionId == null) return;
+        
+        var s = this._getSession(this.currentSessionId);
+        if (!s) return;
+        
+        if (s.inProgress === true) {
+            this._toast(this._t('charge.cannot_edit_in_progress_cost', 'Cannot edit cost of an in-progress session'), 'error');
+            return;
+        }
+
+        var oldRateVal = (s.electricityRate != null && s.electricityRate >= 0) ? s.electricityRate.toString() : '';
+        var msg = this._t('charge.edit_rate_prompt', 'Enter electricity rate per kWh (leave empty to reset):');
+        var input = window.prompt(msg, oldRateVal);
+        if (input === null) return;
+        
+        var newRate = parseFloat(input.trim());
+        if (input.trim() === '') {
+            newRate = -1;
+        } else if (isNaN(newRate) || newRate < 0) {
+            this._toast(this._t('charge.invalid_rate', 'Please enter a valid non-negative number'), 'error');
+            return;
+        }
+
+        var currentRate = (s.electricityRate != null && s.electricityRate >= 0) ? s.electricityRate : -1;
+        if (newRate === currentRate) return;
+
+        var showError = function () {
+            self._toast(self._t('charge.rate_update_failed', 'Could not update electricity rate'), 'error');
+        };
+        
+        fetch('/api/charging/' + this.currentSessionId + '/rate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ rate: newRate })
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            if (d && d.success) {
+                self._toast(self._t('charge.rate_updated', 'Electricity rate updated'));
+                s.electricityRate = newRate >= 0 ? newRate : null;
+                s.cost = (newRate >= 0 && s.energyAdded != null && s.energyAdded > 0) ? (s.energyAdded * newRate) : null;
+                self._renderSessionCards();
+                self._fillDetailHeader(s);
+                self.loadSummary();
+            } else {
+                showError();
+            }
+        })
+        .catch(showError);
     },
 
     deleteCurrent: function () {
@@ -1854,6 +1904,13 @@ var CHARGING = {
     },
 
     // ==================== FORMAT / DOM HELPERS ====================
+
+    _getSession: function (id) {
+        for (var i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i] && this.sessions[i].id === id) return this.sessions[i];
+        }
+        return null;
+    },
 
     _money: function (v) {
         if (v == null) return '--';

--- a/app/src/main/java/com/overdrive/app/charging/ChargingApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/charging/ChargingApiHandler.java
@@ -32,8 +32,8 @@ public class ChargingApiHandler {
 
     private static final Pattern SESSION_ID_PATTERN = Pattern.compile("^/api/charging/(\\d+)$");
     private static final Pattern SESSION_SAMPLES_PATTERN = Pattern.compile("^/api/charging/(\\d+)/samples$");
-    // POST fallback for per-session delete (the in-app WebView can drop DELETE).
     private static final Pattern SESSION_DELETE_PATTERN = Pattern.compile("^/api/charging/(\\d+)/delete$");
+    private static final Pattern SESSION_RATE_PATTERN = Pattern.compile("^/api/charging/(\\d+)/rate$");
 
     private final ChargingSessionManager manager;
 
@@ -85,6 +85,13 @@ public class ChargingApiHandler {
             if (delMatcher.matches() && "POST".equals(method)) {
                 long id = Long.parseLong(delMatcher.group(1));
                 return handleDeleteSession(id);
+            }
+
+            // POST /api/charging/{id}/rate — update rate
+            Matcher rateMatcher = SESSION_RATE_PATTERN.matcher(path);
+            if (rateMatcher.matches() && "POST".equals(method)) {
+                long id = Long.parseLong(rateMatcher.group(1));
+                return handleUpdateSessionRate(id, body);
             }
 
             // GET/DELETE /api/charging/{id}
@@ -220,12 +227,32 @@ public class ChargingApiHandler {
         try {
             boolean ok = db().deleteChargingSession(id);
             if (!ok) return errorResponse("Failed to delete session", 500);
-            JSONObject response = new JSONObject();
-            response.put("success", true);
-            return response;
+            return successResponse();
         } catch (Exception e) {
             logger.error("Error deleting charging session " + id, e);
             return errorResponse("Failed to delete session", 500);
+        }
+    }
+
+    /** POST /api/charging/{id}/rate — update electricity rate of a completed session. */
+    private JSONObject handleUpdateSessionRate(long id, String body) {
+        try {
+            JSONObject bodyJson;
+            try {
+                bodyJson = new JSONObject(body != null ? body : "{}");
+            } catch (org.json.JSONException je) {
+                return errorResponse("Invalid JSON payload", 400);
+            }
+            if (!bodyJson.has("rate")) {
+                return errorResponse("Missing 'rate' parameter", 400);
+            }
+            double rate = bodyJson.getDouble("rate");
+            boolean ok = db().updateChargingSessionRate(id, rate);
+            if (!ok) return errorResponse("Failed to update session rate (session may be in progress or not found)", 500);
+            return successResponse();
+        } catch (Exception e) {
+            logger.error("Error updating rate for session " + id, e);
+            return errorResponse("Failed to update rate: " + e.getMessage(), 500);
         }
     }
 
@@ -471,6 +498,14 @@ public class ChargingApiHandler {
         } catch (NumberFormatException e) {
             return defaultValue;
         }
+    }
+
+    private JSONObject successResponse() {
+        JSONObject response = new JSONObject();
+        try {
+            response.put("success", true);
+        } catch (Exception ignored) {}
+        return response;
     }
 
     private JSONObject errorResponse(String message, int status) {

--- a/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
+++ b/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
@@ -2627,6 +2627,71 @@ public class SocHistoryDatabase {
     }
 
     /**
+     * Update the electricity rate of a single charging session, recalculate its
+     * cost, and adjust the daily rollup so lifetime / monthly-cost totals stay consistent.
+     */
+    public boolean updateChargingSessionRate(long id, double newRate) {
+        if (!isInitialized || connection == null) return false;
+        try {
+            long startTime = -1, endTime = 0;
+            double energyAdded = 0;
+            double oldCost = 0;
+            try (PreparedStatement sel = connection.prepareStatement(
+                    "SELECT start_time, end_time, energy_added_kwh, session_cost FROM " + TABLE_CHARGING + " WHERE id = ?;")) {
+                sel.setLong(1, id);
+                try (ResultSet rs = sel.executeQuery()) {
+                    if (rs.next()) {
+                        startTime = rs.getLong("start_time");
+                        endTime = rs.getLong("end_time");
+                        if (endTime == 0 || endTime <= startTime) {
+                            logger.warn("updateChargingSessionRate: cannot edit rate of an in-progress session " + id);
+                            return false; // cannot edit in-progress session
+                        }
+                        double energyRead = rs.getDouble("energy_added_kwh");
+                        energyAdded = (rs.wasNull() || energyRead < 0) ? 0 : energyRead;
+                        double costRead = rs.getDouble("session_cost");
+                        oldCost = (rs.wasNull() || costRead < 0) ? 0 : costRead;
+                    } else {
+                        return false; // not found
+                    }
+                }
+            }
+
+            // Calculate the new cost
+            double newCost = (newRate >= 0 && energyAdded > 0) ? (energyAdded * newRate) : -1;
+
+            // Update the session rate and cost in charging_sessions
+            try (PreparedStatement updSession = connection.prepareStatement(
+                    "UPDATE " + TABLE_CHARGING + " SET electricity_rate = ?, session_cost = ? WHERE id = ?;")) {
+                updSession.setDouble(1, newRate);
+                updSession.setDouble(2, newCost);
+                updSession.setLong(3, id);
+                updSession.executeUpdate();
+            }
+
+            // Adjust the daily rollup if there's a non-zero change
+            long dayBasis = endTime > 0 ? endTime : startTime;
+            if (dayBasis > 0) {
+                double delta = (newCost >= 0 ? newCost : 0) - oldCost;
+                if (delta != 0) {
+                    long day = (dayBasis / 86_400_000L) * 86_400_000L;
+                    try (PreparedStatement updDaily = connection.prepareStatement(
+                            "UPDATE " + TABLE_CHARGING_DAILY + " SET cost = GREATEST(cost + ?, 0) WHERE day_epoch = ?;")) {
+                        updDaily.setDouble(1, delta);
+                        updDaily.setLong(2, day);
+                        updDaily.executeUpdate();
+                    }
+                }
+            }
+            logger.info("Updated charging session " + id + " to rate " + newRate + ", calculated cost " + newCost);
+            return true;
+        } catch (Exception e) {
+            logger.error("updateChargingSessionRate failed for " + id, e);
+            return false;
+        }
+    }
+
+    /**
      * Get SOC statistics.
      */
     public JSONObject getSocStats(int hoursBack) {


### PR DESCRIPTION
## Description

  This PR introduces support for editing the electricity rate (price per kWh) of completed charging sessions, dynamically recalculating the total cost and updating database daily
  rollups accordingly.

  ### Key Changes

  #### Database & Business Logic:
      • Implemented updateChargingSessionRate in *SocHistoryDatabase.java* to recalculate the session cost (energy * newRate) and adjust the daily rollup.
      • Added validation to prevent editing of in-progress sessions.
      • Added a guard to skip rollup updates if the cost delta is 0.
  #### API Endpoints:
      • Added POST /api/charging/{id}/rate in *ChargingApiHandler.java*.
  #### Frontend UI:
        • Added a hover highlight and edit SVG pencil icon to the Cost card in *charging.html*.
        • Implemented the editCost() method in *charging.js* to prompt the user for the rate, validate input, guard against no-op rate inputs, and refresh the UI/totals on success.
        • Separated cost and rate display into distinct elements for a cleaner HTML/JS design.


  ### Verification
  • Validated locally using a mock HTTP server to verify independent session edits, calculations, and overall totals updates.
  
  
<img width="975" height="397" alt="Screenshot 2026-07-27 at 12 50 31" src="https://github.com/user-attachments/assets/8a477265-99f8-424e-9244-c395cb45b785" />

<img width="453" height="258" alt="Screenshot 2026-07-27 at 12 50 40" src="https://github.com/user-attachments/assets/6202c8ad-5e74-4589-8a2f-f3e87817048a" />

