### PR TITLE
fix: make camera onboarding vehicle and restore aware

### DIFF
--- a/app/src/main/java/com/overdrive/app/abrp/SohEstimator.java
+++ b/app/src/main/java/com/overdrive/app/abrp/SohEstimator.java
@@ -1862,9 +1862,8 @@ public class SohEstimator {
 
             // Read fresh — model can change without touching SOH state.
             try {
-                JSONObject vehicle = UnifiedConfigManager.getVehicle();
-                String modelId = vehicle.optString("modelId", "");
-                if (!modelId.isEmpty()) {
+                String modelId = UnifiedConfigManager.getSelectedVehicleModelId();
+                if (modelId != null && !modelId.isEmpty()) {
                     status.put("modelId", modelId);
                 } else {
                     status.put("modelId", JSONObject.NULL);

--- a/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraConfigResolver.java
@@ -15,7 +15,7 @@ import java.util.EnumMap;
  * Per-role mappings (windshield / cabin / 360-front/right/rear/left) are stored
  * under {@code unified.camera.roleMappings} keyed by role; the resolver merges
  * profile defaults with persisted overrides at runtime. Profile selection
- * ({@code cameraProfile}) tracks vehicle-class geometry (Seal/Atto vs Tang),
+ * ({@code cameraProfile}) tracks vehicle-class geometry,
  * and probe results ({@code probedCameraId}, {@code probedSurfaceMode},
  * {@code probedWidth}, {@code probedHeight}) record the actual stream the GL
  * pipeline locked onto.
@@ -35,8 +35,10 @@ public final class CameraConfigResolver {
         String selectedProfileId = camera.optString("cameraProfile", CameraProfiles.PROFILE_AUTO);
         boolean autoProfile = selectedProfileId.isEmpty()
                 || CameraProfiles.PROFILE_AUTO.equalsIgnoreCase(selectedProfileId);
+        String vehicleModelHint = preferSelectedVehicleModel(
+                readSelectedVehicleModel(), vehicleModel);
         CameraProfile profile = autoProfile
-                ? CameraProfiles.infer(vehicleModel)
+                ? CameraProfiles.infer(vehicleModelHint)
                 : CameraProfiles.get(selectedProfileId);
 
         int panoCameraId = optNonNegative(camera, "probedCameraId", profile.getPanoCameraId());
@@ -256,6 +258,30 @@ public final class CameraConfigResolver {
             object.put(key, value);
         } catch (JSONException e) {
             throw new IllegalStateException("Failed to write JSON field '" + key + "'", e);
+        }
+    }
+
+    /**
+     * Prefer the model explicitly selected in OverDrive over the often-generic
+     * Android product string ("BYD AUTO"). A non-auto camera profile and any
+     * persisted probe/manual camera ID still take precedence later in resolve().
+     */
+    static String preferSelectedVehicleModel(String selectedModelId, String systemModel) {
+        if (selectedModelId != null && !selectedModelId.trim().isEmpty()) {
+            return selectedModelId.trim();
+        }
+        if (systemModel != null && !systemModel.trim().isEmpty()) {
+            return systemModel.trim();
+        }
+        return "unknown";
+    }
+
+    private static String readSelectedVehicleModel() {
+        try {
+            String selected = UnifiedConfigManager.getSelectedVehicleModelId();
+            return selected != null ? selected : "";
+        } catch (Exception e) {
+            return "";
         }
     }
 

--- a/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
+++ b/app/src/main/java/com/overdrive/app/camera/CameraProfiles.java
@@ -12,13 +12,15 @@ import java.util.Map;
 /**
  * Registry of known camera profiles.
  *
- * Add new vehicle variants here. {@link #infer(String)} matches lowercase
- * substrings of {@code ro.product.model}; that property's content varies
- * across BYD firmwares so verify on real hardware before relying on auto.
+ * Add new vehicle variants here. {@link #infer(String)} accepts either the
+ * user-selected vehicle model ID or a system model string. BYD head units
+ * often expose only a generic {@code ro.product.model} such as "BYD AUTO",
+ * so field-verified selected-model mappings are preferred by the resolver.
  */
 public final class CameraProfiles {
     public static final String PROFILE_AUTO = "auto";
     public static final String PROFILE_LEGACY_SEAL_ATTO = "legacy_seal_atto";
+    public static final String PROFILE_ATTO_3 = "atto3";
     public static final String PROFILE_TANG_2022 = "tang_2022";
 
     private static final LinkedHashMap<String, CameraProfile> PROFILES = new LinkedHashMap<>();
@@ -48,8 +50,25 @@ public final class CameraProfiles {
 
         register(new CameraProfile(
                 PROFILE_LEGACY_SEAL_ATTO,
-                "Legacy panoramic (Seal / Atto)",
+                "Legacy panoramic (camera 1)",
                 1,
+                5120,
+                960,
+                0,
+                1280,
+                960,
+                legacyMappings,
+                FOV_DEG_DEFAULT));
+
+        // Field-verified on a DiLink 3.0 Atto 3 (Android 10): the BMM HAL
+        // advertises pano_h -> camera 0 at 5120x960. Camera 1 is invalid on
+        // this unit and even crashes the vendor bmmcameraserver during the
+        // failed close path, so Atto 3 must not inherit the camera-1 legacy
+        // default.
+        register(new CameraProfile(
+                PROFILE_ATTO_3,
+                "BYD Atto 3 (field verified)",
+                0,
                 5120,
                 960,
                 0,
@@ -90,10 +109,19 @@ public final class CameraProfiles {
     }
 
     public static CameraProfile infer(String vehicleModel) {
-        // Tang profile split disabled — every vehicle gets legacy Seal/Atto
-        // 5120x960 / cameraId=1 / surfaceMode=0. Tang's actual panoramic
-        // strip turned out to behave the same on this firmware, and the
-        // separate profile was causing daemon hangs.
+        if (vehicleModel != null) {
+            String normalized = vehicleModel.toLowerCase(Locale.US)
+                    .replace("-", "")
+                    .replace("_", "")
+                    .replace(" ", "");
+            if (normalized.contains("atto3") || normalized.contains("yuanplus")) {
+                return get(PROFILE_ATTO_3);
+            }
+        }
+
+        // Tang profile split remains disabled. Its separate profile caused
+        // daemon hangs on the tested firmware, so unknown/Tang models retain
+        // the camera-1 legacy fallback until a field-verified mapping exists.
         // if (vehicleModel != null) {
         //     String normalized = vehicleModel.toLowerCase(Locale.US);
         //     if (normalized.contains("tang")) {

--- a/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
+++ b/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
@@ -817,10 +817,26 @@ object UnifiedConfigManager {
         // Stored unified so AVN and remote (phone-over-tunnel) clients show the
         // same vehicle. modelId must match an entry in models/manifest.json; the
         // bundled default 'seal' is always available offline.
-        val vehicle = config.optJSONObject("vehicle") ?: JSONObject().also {
+        val storedVehicle = config.optJSONObject("vehicle")
+        val hadPersistedModel = storedVehicle?.has("modelId") == true
+        val vehicle = storedVehicle ?: JSONObject().also {
             config.put("vehicle", it)
         }
+        // Keep Seal as the offline 3D-renderer fallback, but do not present it
+        // to camera/SOH logic as a selected physical model on fresh installs.
+        // Existing configs predate provenance, so preserve their prior model
+        // behavior with the legacy source.
         if (!vehicle.has("modelId")) vehicle.put("modelId", "seal")
+        if (!vehicle.has("modelSource")) {
+            vehicle.put(
+                "modelSource",
+                if (hadPersistedModel) {
+                    VehicleModelSelection.SOURCE_LEGACY
+                } else {
+                    VehicleModelSelection.SOURCE_UNSET
+                }
+            )
+        }
         if (!vehicle.has("color")) vehicle.put("color", "#E8E8EC")  // Aurora White
 
         // Geocoding (place-name tagging) defaults — opt-in, fully offline by
@@ -922,9 +938,12 @@ object UnifiedConfigManager {
                     // nested keys wouldn't exist.
                     //
                     // Detect "needs migration" cheaply (legacy key at the
-                    // top of geocoding, or missing new sections).
+                    // top of geocoding, or missing new sections/selection
+                    // provenance).
                     val migrationNeeded = run {
                         if (!config.has("cloudflared")) return@run true
+                        val vehicle = config.optJSONObject("vehicle") ?: return@run true
+                        if (!vehicle.has("modelSource")) return@run true
                         val geo = config.optJSONObject("geocoding") ?: return@run true
                         geo.has("enabled") || geo.has("allowOnline")
                             || geo.has("customNominatimBase")
@@ -2206,13 +2225,35 @@ object UnifiedConfigManager {
             // Backfill driveSide on configs written before this field existed
             // so call sites can read it unconditionally without a default.
             if (!stored.has("driveSide")) stored.put("driveSide", "rhd")
+            if (!stored.has("modelSource")) {
+                stored.put(
+                    "modelSource",
+                    VehicleModelSelection.normalizeSource(
+                        null, stored.optString("modelId", "")
+                    )
+                )
+            }
             return stored
         }
         return JSONObject().apply {
             put("modelId", "seal")
+            put("modelSource", VehicleModelSelection.SOURCE_UNSET)
             put("color", "#E8E8EC")
             put("driveSide", "rhd")
         }
+    }
+
+    /**
+     * Physical vehicle model selected by the user or a future verified
+     * detector. Returns null when modelId is only the renderer fallback.
+     */
+    @JvmStatic
+    fun getSelectedVehicleModelId(): String? {
+        val vehicle = getVehicle()
+        return VehicleModelSelection.resolvedModelId(
+            vehicle.optString("modelId", ""),
+            vehicle.optString("modelSource", "")
+        )
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/config/VehicleModelSelection.java
+++ b/app/src/main/java/com/overdrive/app/config/VehicleModelSelection.java
@@ -1,0 +1,56 @@
+package com.overdrive.app.config;
+
+import java.util.Locale;
+
+/**
+ * Provenance rules for {@code unified.vehicle.modelId}.
+ *
+ * <p>The 3D vehicle renderer needs a visual fallback, but that fallback must
+ * not masquerade as a user-selected physical vehicle. In particular, a fresh
+ * install historically wrote {@code modelId=seal}; camera auto-configuration
+ * then treated every unconfigured BYD as a Seal before onboarding had asked
+ * the owner which car they had.
+ */
+public final class VehicleModelSelection {
+    public static final String SOURCE_UNSET = "unset";
+    public static final String SOURCE_USER = "user";
+    public static final String SOURCE_AUTO = "auto";
+    public static final String SOURCE_LEGACY = "legacy";
+
+    private VehicleModelSelection() {
+    }
+
+    /**
+     * Normalize persisted provenance. Configs written before provenance was
+     * introduced keep their model as a legacy selection for compatibility.
+     */
+    public static String normalizeSource(String source, String modelId) {
+        String normalized = source == null
+                ? ""
+                : source.trim().toLowerCase(Locale.US);
+        if (SOURCE_UNSET.equals(normalized)
+                || SOURCE_USER.equals(normalized)
+                || SOURCE_AUTO.equals(normalized)
+                || SOURCE_LEGACY.equals(normalized)) {
+            return normalized;
+        }
+        return hasModelId(modelId) ? SOURCE_LEGACY : SOURCE_UNSET;
+    }
+
+    /**
+     * True only when the model represents physical-vehicle intent rather than
+     * the renderer's cosmetic fallback.
+     */
+    public static boolean isResolvedSelection(String modelId, String source) {
+        if (!hasModelId(modelId)) return false;
+        return !SOURCE_UNSET.equals(normalizeSource(source, modelId));
+    }
+
+    public static String resolvedModelId(String modelId, String source) {
+        return isResolvedSelection(modelId, source) ? modelId.trim() : null;
+    }
+
+    private static boolean hasModelId(String modelId) {
+        return modelId != null && !modelId.trim().isEmpty();
+    }
+}

--- a/app/src/main/java/com/overdrive/app/onboarding/OnboardingConfigPolicy.java
+++ b/app/src/main/java/com/overdrive/app/onboarding/OnboardingConfigPolicy.java
@@ -1,0 +1,54 @@
+package com.overdrive.app.onboarding;
+
+import com.overdrive.app.config.VehicleModelSelection;
+
+/**
+ * Pure onboarding decisions, kept Android-free so fresh-install and restore
+ * behavior can be covered by local unit tests.
+ */
+public final class OnboardingConfigPolicy {
+    public enum Step {
+        AUTHORIZE,
+        MODE,
+        VEHICLE,
+        CAMERA,
+        DASHBOARD,
+        DONE
+    }
+
+    private OnboardingConfigPolicy() {
+    }
+
+    /**
+     * Vehicle selection intentionally precedes camera setup: camera profiles
+     * may depend on the selected physical model.
+     */
+    public static Step nextStep(boolean daemonAuthorized,
+                                boolean modeChosen,
+                                boolean vehicleConfigured,
+                                boolean cameraConfigured,
+                                boolean dashboardTourDone) {
+        if (!daemonAuthorized) return Step.AUTHORIZE;
+        if (!modeChosen) return Step.MODE;
+        if (!vehicleConfigured) return Step.VEHICLE;
+        if (!cameraConfigured) return Step.CAMERA;
+        if (!dashboardTourDone) return Step.DASHBOARD;
+        return Step.DONE;
+    }
+
+    public static boolean hasConfiguredVehicle(String modelId, String modelSource) {
+        return VehicleModelSelection.isResolvedSelection(modelId, modelSource);
+    }
+
+    /**
+     * A restored camera selection is enough to skip the destructive/redundant
+     * first-run preview walk. Profile defaults alone still show the wizard so
+     * a genuinely new vehicle gets visual verification.
+     */
+    public static boolean hasConfiguredCamera(int cameraId,
+                                              boolean manualOverride,
+                                              boolean probedAndValidated) {
+        return cameraId >= 0 && cameraId <= 5
+                && (manualOverride || probedAndValidated);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/onboarding/OnboardingHost.kt
+++ b/app/src/main/java/com/overdrive/app/onboarding/OnboardingHost.kt
@@ -9,6 +9,8 @@ import android.view.ViewGroup
 import com.overdrive.app.R
 import com.overdrive.app.launcher.AdbDaemonLauncher
 
+private typealias SetupStep = OnboardingConfigPolicy.Step
+
 /**
  * Drives the two-track onboarding guide: owns the [OnboardingOverlayView] lifecycle, the
  * parked-only [OnboardingGate], a cached encoder-busy signal, and the ordered novice
@@ -122,7 +124,7 @@ class OnboardingHost(
     /** Called from MainActivity.onAuthGranted — advances Step 0 if we're waiting on it. */
     fun onDaemonAuthGranted() {
         state.daemonAuthorized = true
-        if (started && currentStep == Step.AUTHORIZE) {
+        if (started && currentStep == SetupStep.AUTHORIZE) {
             mainHandler.post { advanceFromAuthorize() }
         }
     }
@@ -140,8 +142,7 @@ class OnboardingHost(
 
     // ---- step machine ----------------------------------------------------------------
 
-    private enum class Step { AUTHORIZE, MODE, CAMERA, VEHICLE, DASHBOARD, DONE }
-    private var currentStep = Step.AUTHORIZE
+    private var currentStep = SetupStep.AUTHORIZE
 
     private fun routeFirstStep() {
         // If the daemon is ALREADY running (already-installed device / auth granted on a
@@ -152,14 +153,14 @@ class OnboardingHost(
             mainHandler.post {
                 if (!started) return@post
                 if (running) state.daemonAuthorized = true
-                currentStep = when {
-                    !state.daemonAuthorized -> Step.AUTHORIZE
-                    !state.modeChosen -> Step.MODE
-                    state.cameraStep != OnboardingState.CameraStep.SAVED_OK -> Step.CAMERA
-                    !state.vehicleStepDone -> Step.VEHICLE
-                    !state.dashboardTourDone -> Step.DASHBOARD
-                    else -> Step.DONE
-                }
+                reconcilePersistedSetupState()
+                currentStep = OnboardingConfigPolicy.nextStep(
+                    state.daemonAuthorized,
+                    state.modeChosen,
+                    state.vehicleStepDone,
+                    state.cameraStep == OnboardingState.CameraStep.SAVED_OK,
+                    state.dashboardTourDone,
+                )
                 renderCurrent()
             }
         }
@@ -168,12 +169,44 @@ class OnboardingHost(
     private fun renderCurrent() {
         val ov = overlay ?: return
         when (currentStep) {
-            Step.AUTHORIZE -> renderAuthorize(ov)
-            Step.MODE -> renderModeChoice(ov)
-            Step.CAMERA -> launchCameraChapter()
-            Step.VEHICLE -> launchVehicleChapter()
-            Step.DASHBOARD -> launchDashboardChapter()
-            Step.DONE -> renderDone(ov)
+            SetupStep.AUTHORIZE -> renderAuthorize(ov)
+            SetupStep.MODE -> renderModeChoice(ov)
+            SetupStep.VEHICLE -> launchVehicleChapter()
+            SetupStep.CAMERA -> launchCameraChapter()
+            SetupStep.DASHBOARD -> launchDashboardChapter()
+            SetupStep.DONE -> renderDone(ov)
+        }
+    }
+
+    /**
+     * App-private onboarding flags are not part of config backups. Reconcile
+     * them with durable setup state so reinstall+restore does not ask the
+     * owner to reconfigure a validated camera or re-select a known vehicle.
+     */
+    private fun reconcilePersistedSetupState() {
+        try {
+            val vehicle = com.overdrive.app.config.UnifiedConfigManager.getVehicle()
+            if (OnboardingConfigPolicy.hasConfiguredVehicle(
+                    vehicle.optString("modelId", ""),
+                    vehicle.optString("modelSource", ""),
+                )) {
+                state.vehicleStepDone = true
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "vehicle setup reconciliation failed: ${t.message}")
+        }
+
+        try {
+            val camera = com.overdrive.app.camera.CameraConfigResolver.getCameraSection()
+            if (OnboardingConfigPolicy.hasConfiguredCamera(
+                    camera.optInt("probedCameraId", -1),
+                    camera.optBoolean("manualOverride", false),
+                    camera.optBoolean("probedAndValidated", false),
+                )) {
+                state.cameraStep = OnboardingState.CameraStep.SAVED_OK
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "camera setup reconciliation failed: ${t.message}")
         }
     }
 
@@ -203,7 +236,7 @@ class OnboardingHost(
                 // Failsafe: if the grant never arrives (popup dismissed / already authed),
                 // re-offer with a Try-again + Dismiss instead of hanging.
                 mainHandler.postDelayed({
-                    if (started && currentStep == Step.AUTHORIZE && !state.daemonAuthorized) {
+                    if (started && currentStep == SetupStep.AUTHORIZE && !state.daemonAuthorized) {
                         renderAuthorizeRetry(ov)
                     }
                 }, AUTH_WAIT_MS)
@@ -226,7 +259,8 @@ class OnboardingHost(
     }
 
     private fun advanceFromAuthorize() {
-        currentStep = Step.MODE
+        reconcilePersistedSetupState()
+        currentStep = SetupStep.MODE
         renderCurrent()
     }
 
@@ -270,7 +304,14 @@ class OnboardingHost(
             state.pendingOperatingMode = mode
         }
         persistOperatingMode(mode)
-        currentStep = Step.CAMERA
+        reconcilePersistedSetupState()
+        currentStep = OnboardingConfigPolicy.nextStep(
+            true,
+            true,
+            state.vehicleStepDone,
+            state.cameraStep == OnboardingState.CameraStep.SAVED_OK,
+            state.dashboardTourDone,
+        )
         renderCurrent()
     }
 
@@ -307,11 +348,11 @@ class OnboardingHost(
 
     private fun launchCameraChapter() {
         val ov = overlay ?: return
-        val coach = CameraWizardCoach(activity, ov, state, adbLauncher) { outcome ->
-            // Camera chapter always advances to vehicle whether saved or deferred —
-            // it is strongly encouraged, not a hard gate (Auto-detect is a valid baseline).
+        val coach = CameraWizardCoach(activity, ov, state, adbLauncher) { _ ->
+            // Vehicle selection has already run (or was restored), so camera
+            // completion now advances directly to the dashboard tour.
             activeCameraCoach = null
-            currentStep = Step.VEHICLE
+            currentStep = SetupStep.DASHBOARD
             renderCurrent()
         }
         activeCameraCoach = coach
@@ -321,7 +362,12 @@ class OnboardingHost(
     private fun launchVehicleChapter() {
         val ov = overlay ?: return
         VehicleWizardCoach(activity, ov, state) {
-            currentStep = Step.DASHBOARD
+            reconcilePersistedSetupState()
+            currentStep = if (state.cameraStep == OnboardingState.CameraStep.SAVED_OK) {
+                SetupStep.DASHBOARD
+            } else {
+                SetupStep.CAMERA
+            }
             renderCurrent()
         }.begin()
     }
@@ -329,7 +375,7 @@ class OnboardingHost(
     private fun launchDashboardChapter() {
         val ov = overlay ?: return
         DashboardTourCoach(activity, ov, state) {
-            currentStep = Step.DONE
+            currentStep = SetupStep.DONE
             renderCurrent()
         }.begin()
     }

--- a/app/src/main/java/com/overdrive/app/onboarding/VehicleWizardCoach.kt
+++ b/app/src/main/java/com/overdrive/app/onboarding/VehicleWizardCoach.kt
@@ -25,13 +25,21 @@ class VehicleWizardCoach(
             body = activity.getString(R.string.onboarding_vehicle_body),
             primaryText = activity.getString(R.string.onboarding_vehicle_primary),
             onPrimary = {
-                state.vehicleStepDone = true
                 try {
-                    (activity as? com.overdrive.app.ui.MainActivity)?.openVehicleProfileForOnboarding()
+                    val opened = (activity as? com.overdrive.app.ui.MainActivity)
+                        ?.openVehicleProfileForOnboarding {
+                            state.vehicleStepDone = true
+                            onFinished()
+                        } == true
+                    if (!opened) {
+                        state.vehicleStepDone = true
+                        onFinished()
+                    }
                 } catch (t: Throwable) {
                     Log.w("VehicleWizardCoach", "open vehicle dialog failed: ${t.message}")
+                    state.vehicleStepDone = true
+                    onFinished()
                 }
-                onFinished()
             },
             secondaryText = activity.getString(R.string.onboarding_skip),
             onSecondary = { state.vehicleStepDone = true; onFinished() },

--- a/app/src/main/java/com/overdrive/app/server/ModelsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/ModelsApiHandler.java
@@ -1,6 +1,7 @@
 package com.overdrive.app.server;
 
 import com.overdrive.app.config.UnifiedConfigManager;
+import com.overdrive.app.config.VehicleModelSelection;
 import com.overdrive.app.daemon.CameraDaemon;
 import com.overdrive.app.logging.DaemonLogger;
 
@@ -263,12 +264,23 @@ public class ModelsApiHandler {
         // returning a dead id that will fail at load time.
         JSONObject manifest = readManifest();
         String defaultId = manifest != null ? manifest.optString("default", "seal") : "seal";
-        String modelId = vehicle.optString("modelId", defaultId);
-        if (manifest != null && findModel(manifest, modelId) == null) {
-            modelId = defaultId;
+        String rawModelId = vehicle.optString("modelId", "");
+        String modelSource = VehicleModelSelection.normalizeSource(
+                vehicle.optString("modelSource", ""), rawModelId);
+        String selectedModelId = VehicleModelSelection.resolvedModelId(
+                rawModelId, modelSource);
+        if (selectedModelId != null
+                && manifest != null
+                && findModel(manifest, selectedModelId) == null) {
+            selectedModelId = null;
+            modelSource = VehicleModelSelection.SOURCE_UNSET;
         }
+        String modelId = selectedModelId != null ? selectedModelId : defaultId;
         JSONObject response = new JSONObject();
         response.put("modelId", modelId);
+        response.put("selectedModelId",
+                selectedModelId != null ? selectedModelId : JSONObject.NULL);
+        response.put("modelSource", modelSource);
         response.put("color", vehicle.optString("color", "#E8E8EC"));
         // driveSide controls which front-axis door each BYD HAL area code
         // labels as "Front-left" vs "Front-right" in notifications. The
@@ -290,6 +302,7 @@ public class ModelsApiHandler {
             return;
         }
         JSONObject patch = new JSONObject();
+        boolean modelSelectionChanged = false;
         if (incoming.has("modelId")) {
             String id = incoming.optString("modelId");
             // Validate against manifest so a typo or stale client can't poison the config.
@@ -299,6 +312,16 @@ public class ModelsApiHandler {
                 return;
             }
             patch.put("modelId", id);
+            patch.put("modelSource", VehicleModelSelection.SOURCE_USER);
+            modelSelectionChanged = true;
+        } else if (incoming.optBoolean("clearModelSelection", false)) {
+            JSONObject manifest = readManifest();
+            String defaultId = manifest != null
+                    ? manifest.optString("default", "seal")
+                    : "seal";
+            patch.put("modelId", defaultId);
+            patch.put("modelSource", VehicleModelSelection.SOURCE_UNSET);
+            modelSelectionChanged = true;
         }
         if (incoming.has("color")) {
             String color = incoming.optString("color", "");
@@ -334,7 +357,7 @@ public class ModelsApiHandler {
         // SOH so the displayed health value reflects the new pack rather
         // than carrying stale calibration from the previous selection.
         // Skipped when only color changed — that has no SOH bearing.
-        if (incoming.has("modelId")) {
+        if (modelSelectionChanged) {
             try {
                 com.overdrive.app.monitor.SocHistoryDatabase socDb =
                     com.overdrive.app.monitor.SocHistoryDatabase.getInstance();
@@ -379,8 +402,8 @@ public class ModelsApiHandler {
      */
     public static double nominalKwhForSelectedModel() {
         try {
-            String modelId = UnifiedConfigManager.getVehicle().optString("modelId", "");
-            if (modelId.isEmpty()) return 0;
+            String modelId = UnifiedConfigManager.getSelectedVehicleModelId();
+            if (modelId == null || modelId.isEmpty()) return 0;
             JSONObject manifest = readManifest();
             if (manifest == null) return 0;
             JSONObject m = findModel(manifest, modelId);
@@ -400,8 +423,8 @@ public class ModelsApiHandler {
      */
     public static double grossNameplateKwhForSelectedModel() {
         try {
-            String modelId = UnifiedConfigManager.getVehicle().optString("modelId", "");
-            if (modelId.isEmpty()) return 0;
+            String modelId = UnifiedConfigManager.getSelectedVehicleModelId();
+            if (modelId == null || modelId.isEmpty()) return 0;
             JSONObject manifest = readManifest();
             if (manifest == null) return 0;
             JSONObject m = findModel(manifest, modelId);

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -3535,13 +3535,18 @@ class MainActivity : AppCompatActivity() {
      */
     fun restartCameraDaemonForOnboarding() = restartCameraDaemonForCameraSettings()
 
-    /** Open the real vehicle capacity/model dialog for the vehicle chapter. */
-    fun openVehicleProfileForOnboarding() {
+    /**
+     * Open the real vehicle capacity/model dialog for the vehicle chapter.
+     * Completion waits for the user's save/reset/cancel action so the camera
+     * chapter cannot resolve against the old renderer fallback model.
+     */
+    fun openVehicleProfileForOnboarding(onFinished: () -> Unit): Boolean {
         val nav = supportFragmentManager.findFragmentById(R.id.navHostFragment)
                 as? androidx.navigation.fragment.NavHostFragment
         val dash = nav?.childFragmentManager?.primaryNavigationFragment
                 as? com.overdrive.app.ui.fragment.DashboardFragment
-        dash?.showVehicleCapacityDialog()
+                ?: return false
+        return dash.showVehicleCapacityDialog(onFinished)
     }
 
     /** Live DashboardFragment root for the orientation tour anchors (null if not current). */

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
@@ -904,7 +904,15 @@ class DashboardFragment : Fragment() {
                 if (conn.responseCode == 200) {
                     val body = conn.inputStream.bufferedReader().use { it.readText() }
                     val json = org.json.JSONObject(body)
-                    val m = json.optString("modelId", "")
+                    val m = when {
+                        json.has("selectedModelId") && !json.isNull("selectedModelId") ->
+                            json.optString("selectedModelId", "")
+                        json.has("modelSource")
+                                && json.optString("modelSource", "unset") == "unset" -> ""
+                        // Backward compatibility with an older daemon that does
+                        // not expose selection provenance yet.
+                        else -> json.optString("modelId", "")
+                    }
                     if (m.isNotEmpty()) modelId = m
                 }
                 conn.disconnect()
@@ -932,8 +940,8 @@ class DashboardFragment : Fragment() {
      * `internal` so the onboarding vehicle chapter can launch the real dialog via
      * MainActivity.openVehicleProfileForOnboarding() rather than reimplementing it.
      */
-    internal fun showVehicleCapacityDialog() {
-        val ctx = context ?: return
+    internal fun showVehicleCapacityDialog(onFinished: (() -> Unit)? = null): Boolean {
+        val ctx = context ?: return false
 
         // Inflate the M3 layout (outlined inputs + ExposedDropdownMenu).
         val dialogView = layoutInflater.inflate(
@@ -1068,7 +1076,13 @@ class DashboardFragment : Fragment() {
                 if (conn.responseCode == 200) {
                     val body = conn.inputStream.bufferedReader().use { it.readText() }
                     val json = org.json.JSONObject(body)
-                    val m = json.optString("modelId", "")
+                    val m = when {
+                        json.has("selectedModelId") && !json.isNull("selectedModelId") ->
+                            json.optString("selectedModelId", "")
+                        json.has("modelSource")
+                                && json.optString("modelSource", "unset") == "unset" -> ""
+                        else -> json.optString("modelId", "")
+                    }
                     if (m.isNotEmpty()) initialModelId = m
                 }
                 conn.disconnect()
@@ -1157,26 +1171,64 @@ class DashboardFragment : Fragment() {
             }
         }
 
-        com.google.android.material.dialog.MaterialAlertDialogBuilder(ctx, R.style.Theme_Overdrive_M3_Dialog)
+        var completionDeferred = false
+        var completionSent = false
+        fun finishOnce() {
+            if (!completionSent) {
+                completionSent = true
+                onFinished?.invoke()
+            }
+        }
+
+        val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(
+            ctx, R.style.Theme_Overdrive_M3_Dialog)
             .setTitle(getString(R.string.vehicle_dialog_title))
             .setView(dialogView)
-            .setPositiveButton(getString(R.string.vehicle_dialog_save)) { _, _ ->
+            // Install button listeners after show so invalid capacity does not
+            // trigger AlertDialog's default auto-dismiss behavior.
+            .setPositiveButton(getString(R.string.vehicle_dialog_save), null)
+            .setNeutralButton(getString(R.string.vehicle_dialog_reset), null)
+            .setNegativeButton(getString(R.string.action_cancel), null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE).setOnClickListener {
                 val raw = capInput.text?.toString()?.trim().orEmpty()
                 val kwh = raw.toDoubleOrNull()
                 if (kwh == null || kwh < 15.0 || kwh > 120.0) {
                     Toast.makeText(ctx, getString(R.string.vehicle_dialog_invalid_capacity), Toast.LENGTH_SHORT).show()
-                    return@setPositiveButton
+                    return@setOnClickListener
                 }
-                postNominalAndModel(kwh, selectedModelId)
+                completionDeferred = true
+                postNominalAndModel(kwh, selectedModelId) { finishOnce() }
+                dialog.dismiss()
             }
-            .setNeutralButton(getString(R.string.vehicle_dialog_reset)) { _, _ ->
-                postNominal(null)
+            dialog.getButton(android.content.DialogInterface.BUTTON_NEUTRAL).setOnClickListener {
+                completionDeferred = true
+                postNominal(
+                    kwh = null,
+                    clearModelSelection = true,
+                    onComplete = { finishOnce() },
+                )
+                dialog.dismiss()
             }
-            .setNegativeButton(getString(R.string.action_cancel), null)
-            .show()
+            dialog.getButton(android.content.DialogInterface.BUTTON_NEGATIVE).setOnClickListener {
+                dialog.dismiss()
+            }
+        }
+        dialog.setOnDismissListener {
+            // Save/reset wait for both daemon writes. Cancel, back, and
+            // outside-tap complete the optional onboarding chapter immediately.
+            if (!completionDeferred) finishOnce()
+        }
+        dialog.show()
+        return true
     }
 
-    private fun postNominal(kwh: Double?) {
+    private fun postNominal(
+        kwh: Double?,
+        clearModelSelection: Boolean = false,
+        onComplete: (() -> Unit)? = null,
+    ) {
         val executor = metricsExecutor ?: Executors.newSingleThreadExecutor()
             .also { metricsExecutor = it }
         executor.execute {
@@ -1190,11 +1242,33 @@ class DashboardFragment : Fragment() {
                 conn.responseCode
                 conn.disconnect()
             } catch (_: Throwable) {}
-            mainHandler.post { refreshVehicleTile() }
+
+            if (clearModelSelection) {
+                try {
+                    val conn = com.overdrive.app.util.DaemonHttpClient.open(
+                        "/api/models/selected", "POST", 3000, 5000)
+                    conn.doOutput = true
+                    conn.setRequestProperty("Content-Type", "application/json")
+                    conn.outputStream.use {
+                        it.write("{\"clearModelSelection\":true}".toByteArray())
+                    }
+                    conn.responseCode
+                    conn.disconnect()
+                } catch (_: Throwable) {}
+            }
+
+            mainHandler.post {
+                refreshVehicleTile()
+                onComplete?.invoke()
+            }
         }
     }
 
-    private fun postNominalAndModel(kwh: Double, modelId: String?) {
+    private fun postNominalAndModel(
+        kwh: Double,
+        modelId: String?,
+        onComplete: (() -> Unit)? = null,
+    ) {
         val executor = metricsExecutor ?: Executors.newSingleThreadExecutor()
             .also { metricsExecutor = it }
         executor.execute {
@@ -1220,7 +1294,10 @@ class DashboardFragment : Fragment() {
                 } catch (_: Throwable) {}
             }
 
-            mainHandler.post { refreshVehicleTile() }
+            mainHandler.post {
+                refreshVehicleTile()
+                onComplete?.invoke()
+            }
         }
     }
 

--- a/app/src/test/java/com/overdrive/app/camera/CameraProfilesTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/CameraProfilesTest.java
@@ -1,0 +1,47 @@
+package com.overdrive.app.camera;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CameraProfilesTest {
+
+    @Test
+    public void atto3SelectedModelUsesFieldVerifiedCameraZero() {
+        CameraProfile profile = CameraProfiles.infer("atto3");
+
+        assertEquals(CameraProfiles.PROFILE_ATTO_3, profile.getId());
+        assertEquals(0, profile.getPanoCameraId());
+        assertEquals(5120, profile.getPanoWidth());
+        assertEquals(960, profile.getPanoHeight());
+        assertEquals(0, profile.getPanoSurfaceMode());
+    }
+
+    @Test
+    public void atto3AliasesResolveToSameProfile() {
+        assertEquals(CameraProfiles.PROFILE_ATTO_3,
+                CameraProfiles.infer("BYD Atto 3").getId());
+        assertEquals(CameraProfiles.PROFILE_ATTO_3,
+                CameraProfiles.infer("atto-3").getId());
+        assertEquals(CameraProfiles.PROFILE_ATTO_3,
+                CameraProfiles.infer("Yuan Plus").getId());
+    }
+
+    @Test
+    public void unknownSystemModelKeepsConservativeLegacyDefault() {
+        CameraProfile profile = CameraProfiles.infer("BYD AUTO");
+
+        assertEquals(CameraProfiles.PROFILE_LEGACY_SEAL_ATTO, profile.getId());
+        assertEquals(1, profile.getPanoCameraId());
+    }
+
+    @Test
+    public void selectedVehicleModelWinsOverGenericSystemModel() {
+        assertEquals("atto3",
+                CameraConfigResolver.preferSelectedVehicleModel("atto3", "BYD AUTO"));
+        assertEquals("BYD AUTO",
+                CameraConfigResolver.preferSelectedVehicleModel("", "BYD AUTO"));
+        assertEquals("unknown",
+                CameraConfigResolver.preferSelectedVehicleModel(null, null));
+    }
+}

--- a/app/src/test/java/com/overdrive/app/config/VehicleModelSelectionTest.java
+++ b/app/src/test/java/com/overdrive/app/config/VehicleModelSelectionTest.java
@@ -1,0 +1,42 @@
+package com.overdrive.app.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class VehicleModelSelectionTest {
+
+    @Test
+    public void rendererFallbackIsNotASelectedPhysicalVehicle() {
+        assertFalse(VehicleModelSelection.isResolvedSelection(
+                "seal", VehicleModelSelection.SOURCE_UNSET));
+        assertNull(VehicleModelSelection.resolvedModelId(
+                "seal", VehicleModelSelection.SOURCE_UNSET));
+    }
+
+    @Test
+    public void explicitAndAutoSelectionsAreResolved() {
+        assertTrue(VehicleModelSelection.isResolvedSelection(
+                "atto3", VehicleModelSelection.SOURCE_USER));
+        assertEquals("atto3", VehicleModelSelection.resolvedModelId(
+                " atto3 ", VehicleModelSelection.SOURCE_AUTO));
+    }
+
+    @Test
+    public void preProvenanceConfigsRemainCompatible() {
+        assertEquals(VehicleModelSelection.SOURCE_LEGACY,
+                VehicleModelSelection.normalizeSource(null, "atto3"));
+        assertTrue(VehicleModelSelection.isResolvedSelection("atto3", null));
+    }
+
+    @Test
+    public void missingModelCannotBecomeASelection() {
+        assertEquals(VehicleModelSelection.SOURCE_UNSET,
+                VehicleModelSelection.normalizeSource(null, ""));
+        assertFalse(VehicleModelSelection.isResolvedSelection(
+                " ", VehicleModelSelection.SOURCE_USER));
+    }
+}

--- a/app/src/test/java/com/overdrive/app/onboarding/OnboardingConfigPolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/onboarding/OnboardingConfigPolicyTest.java
@@ -1,0 +1,45 @@
+package com.overdrive.app.onboarding;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.overdrive.app.config.VehicleModelSelection;
+
+import org.junit.Test;
+
+public class OnboardingConfigPolicyTest {
+
+    @Test
+    public void vehicleSetupRunsBeforeCameraSetup() {
+        assertEquals(OnboardingConfigPolicy.Step.VEHICLE,
+                OnboardingConfigPolicy.nextStep(true, true, false, false, false));
+        assertEquals(OnboardingConfigPolicy.Step.CAMERA,
+                OnboardingConfigPolicy.nextStep(true, true, true, false, false));
+    }
+
+    @Test
+    public void restoredVehicleAndCameraAdvanceToDashboard() {
+        assertEquals(OnboardingConfigPolicy.Step.DASHBOARD,
+                OnboardingConfigPolicy.nextStep(true, true, true, true, false));
+        assertEquals(OnboardingConfigPolicy.Step.DONE,
+                OnboardingConfigPolicy.nextStep(true, true, true, true, true));
+    }
+
+    @Test
+    public void restoredManualOrValidatedCameraSkipsPreviewWalk() {
+        assertTrue(OnboardingConfigPolicy.hasConfiguredCamera(0, true, false));
+        assertTrue(OnboardingConfigPolicy.hasConfiguredCamera(3, false, true));
+        assertFalse(OnboardingConfigPolicy.hasConfiguredCamera(0, false, false));
+        assertFalse(OnboardingConfigPolicy.hasConfiguredCamera(-1, true, true));
+        assertFalse(OnboardingConfigPolicy.hasConfiguredCamera(6, true, true));
+    }
+
+    @Test
+    public void rendererFallbackDoesNotSkipVehicleQuestion() {
+        assertFalse(OnboardingConfigPolicy.hasConfiguredVehicle(
+                "seal", VehicleModelSelection.SOURCE_UNSET));
+        assertTrue(OnboardingConfigPolicy.hasConfiguredVehicle(
+                "atto3", VehicleModelSelection.SOURCE_USER));
+    }
+}


### PR DESCRIPTION
## Summary

- Persist the selected physical vehicle with user, auto-detected, restored, or unset provenance.
- Place vehicle selection before camera configuration in fresh onboarding.
- Preserve validated or manually overridden camera settings on restored installs.
- Add Atto 3/Yuan Plus aliases and the field-tested 5120x960 camera profile.

## Why

The renderer fallback model could be mistaken for the real vehicle, causing camera setup to use the wrong profile or rerun destructively after a restore.

## Impact

All vehicle models gain an explicit setup source, while unknown vehicles retain the conservative legacy fallback.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Tested in the combined build on a 2024 BYD Atto 3 running firmware 2602.

## Visual evidence

Vehicle profile configuration:

![Vehicle profile configuration on a BYD Atto 3](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/185-onboarding-vehicle-profile.png)

Vehicle selection:

![Vehicle selection including the BYD Atto 3](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/185-onboarding-vehicle-selection.png)