### PR TITLE
fix: clear Live connecting state when frames arrive

### DIFF
--- a/app/src/main/assets/web/local/live-view.html
+++ b/app/src/main/assets/web/local/live-view.html
@@ -946,7 +946,7 @@
             // UI state on rejection — leaving the user staring at "select
             // camera" while frames continue from the previous view is the
             // exact UX glitch the Round 3 audit flagged.
-            if (this.sotaPlayer && this.sotaPlayer.isRunning()) {
+            if (sotaLive || legacyLive) {
                 console.log("[Stream] Switching view to:", mode);
                 const ok = await applyView(mode);
                 if (!ok) {
@@ -957,6 +957,12 @@
                     }
                     this.currentViewMode = priorMode;
                     if (labelEl) labelEl.textContent = priorLabelText;
+                } else {
+                    // The BYD WebView fallback reuses its open WebSocket, so
+                    // switching cameras does not emit another onopen event.
+                    // Mark this transition pending; the first frame from the
+                    // newly-selected view promotes the badge back to Live.
+                    this.markStreamConnecting();
                 }
                 return;
             }
@@ -971,7 +977,7 @@
             const idleState = document.getElementById('videoIdleState');
             if (idleState) idleState.classList.add('hidden');
             
-            this.updateConnectionStatus('connecting');
+            this.markStreamConnecting();
             
             // 1. Set quality
             var _qSel = document.getElementById('qualitySelector');
@@ -1065,9 +1071,10 @@
                 this.sotaPlayer = new SotaPlayer(canvas, url);
                 this.sotaPlayer.onConnected = () => {
                     console.log("[Stream] Connected, view mode:", targetViewMode);
-                    this.updateConnectionStatus('live');
+                    this.markStreamConnecting();
                 };
-                this.sotaPlayer.onDisconnected = () => this.updateConnectionStatus('connecting');
+                this.sotaPlayer.onDisconnected = () => this.markStreamConnecting();
+                this.sotaPlayer.onFrame = (count) => this.noteFrameReceived(count);
                 this.sotaPlayer.start();
                 
             } else {

--- a/app/src/main/assets/web/shared/stream.js
+++ b/app/src/main/assets/web/shared/stream.js
@@ -36,6 +36,11 @@ BYD.stream = {
     reconnectTimer: null,
     frameCount: 0,
     lastFrameTime: 0,
+    // True only after the current connection/view has produced a frame.
+    // Socket-open alone is not enough: the BYD WebView reuses an existing
+    // WebSocket when switching cameras, so no second onopen event fires.
+    _frameStatusLive: false,
+    _pendingConnectedToast: null,
     decoderMode: null,     // 'webcodecs', 'jmuxer', or 'broadway'
     latencyCheckInterval: null,
     streamStarted: false,
@@ -213,6 +218,32 @@ BYD.stream = {
             return false;
         }
     },
+
+    /**
+     * Record actual frame delivery and converge every live-view status surface.
+     * This is intentionally idempotent so legacy WebSocket onmessage can call it
+     * for every packet without repainting the status DOM at camera frame rate.
+     */
+    noteFrameReceived(count) {
+        this.frameCount = Number.isFinite(count) ? count : this.frameCount + 1;
+        this.lastFrameTime = Date.now();
+        if (!this._frameStatusLive) {
+            this._frameStatusLive = true;
+            this.updateStreamStatus(BYD.i18n.t('stream.live'), true);
+            if (this._pendingConnectedToast && BYD.utils && BYD.utils.toast) {
+                BYD.utils.toast(BYD.i18n.t(this._pendingConnectedToast), 'success');
+            }
+            this._pendingConnectedToast = null;
+        }
+    },
+
+    /**
+     * Reset frame-backed live state for a fresh connection or camera switch.
+     */
+    markStreamConnecting() {
+        this._frameStatusLive = false;
+        this.updateStreamStatus(BYD.i18n.t('stream.connecting'), false);
+    },
     
     /**
      * Initialize decoder based on device capabilities
@@ -278,18 +309,19 @@ BYD.stream = {
             // Set up callbacks
             this.sotaPlayer.onConnected = () => {
                 console.log('[Stream] WebCodecs connected');
-                this.updateStreamStatus(BYD.i18n.t('stream.live'), true);
-                if (BYD.utils && BYD.utils.toast) BYD.utils.toast(BYD.i18n.t('stream.connected_webcodecs'), 'success');
+                // Wait for a decoded frame before claiming the camera is live.
+                this._pendingConnectedToast = 'stream.connected_webcodecs';
+                this.markStreamConnecting();
             };
 
             this.sotaPlayer.onDisconnected = (code) => {
                 console.log('[Stream] WebCodecs disconnected:', code);
-                this.updateStreamStatus(BYD.i18n.t('stream.disconnected'), false);
+                this._pendingConnectedToast = null;
+                this.markStreamConnecting();
             };
             
             this.sotaPlayer.onFrame = (count) => {
-                this.frameCount = count;
-                this.lastFrameTime = Date.now();
+                this.noteFrameReceived(count);
             };
             
             this.sotaPlayer.onError = (e) => {
@@ -492,8 +524,10 @@ BYD.stream = {
             this.ws.onopen = () => {
                 console.log('[Stream] Connected');
                 this.frameCount = 0;
-                this.updateStreamStatus(BYD.i18n.t('stream.live'), true);
-                if (BYD.utils && BYD.utils.toast) BYD.utils.toast(BYD.i18n.t('stream.connected'), 'success');
+                // A connected socket can still have no camera frames. The
+                // first onmessage below promotes the UI to Live.
+                this._pendingConnectedToast = 'stream.connected';
+                this.markStreamConnecting();
             };
             
             this.ws.onmessage = (event) => {
@@ -506,14 +540,14 @@ BYD.stream = {
                     this.jmuxer.feed({ video: data });
                 }
                 
-                this.frameCount++;
-                this.lastFrameTime = Date.now();
+                this.noteFrameReceived();
             };
             
             this.ws.onclose = (event) => {
                 console.log('[Stream] Closed:', event.code);
                 this.ws = null;
-                this.updateStreamStatus(BYD.i18n.t('stream.disconnected'), false);
+                this._pendingConnectedToast = null;
+                this.markStreamConnecting();
                 
                 if (!this.reconnectTimer && this.streamStarted) {
                     this.reconnectTimer = setTimeout(() => {
@@ -581,7 +615,7 @@ BYD.stream = {
         if (overlay) overlay.style.display = 'flex';
 
         // Show connecting state immediately
-        this.updateStreamStatus(BYD.i18n.t('stream.connecting'), false);
+        this.markStreamConnecting();
 
         // Update view label
         const viewLabel = document.getElementById('viewLabel');
@@ -684,6 +718,8 @@ BYD.stream = {
      */
     stopStream() {
         this.streamStarted = false;
+        this._frameStatusLive = false;
+        this._pendingConnectedToast = null;
         
         if (this.reconnectTimer) {
             clearTimeout(this.reconnectTimer);

--- a/app/src/test/java/com/overdrive/app/camera/LiveViewConnectionStateAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveViewConnectionStateAssetTest.java
@@ -1,0 +1,45 @@
+package com.overdrive.app.camera;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Guards the BYD WebView camera-switch regression where an already-open
+ * WebSocket continued delivering video but the top-left badge stayed on
+ * "Connecting..." because no second onopen event was emitted.
+ */
+public class LiveViewConnectionStateAssetTest {
+
+    @Test
+    public void frameDeliveryPromotesBothDecoderPathsToLive() throws Exception {
+        String stream = readAsset("shared/stream.js");
+        String liveView = readAsset("local/live-view.html");
+
+        assertTrue(stream.contains("noteFrameReceived(count)"));
+        assertTrue(stream.contains("this.noteFrameReceived();"));
+        assertTrue(stream.contains("this.noteFrameReceived(count);"));
+        assertTrue(liveView.contains("if (sotaLive || legacyLive)"));
+        assertTrue(liveView.contains(
+                "this.sotaPlayer.onFrame = (count) => this.noteFrameReceived(count);"));
+        assertTrue(liveView.contains("this.markStreamConnecting();"));
+    }
+
+    private static String readAsset(String relativePath) throws Exception {
+        Path current = Paths.get("").toAbsolutePath();
+        Path fromModule = current.resolve("src/main/assets/web").resolve(relativePath);
+        if (Files.exists(fromModule)) {
+            return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+        }
+        Path fromRepository = current.resolve("app/src/main/assets/web").resolve(relativePath);
+        if (Files.exists(fromRepository)) {
+            return new String(Files.readAllBytes(fromRepository), StandardCharsets.UTF_8);
+        }
+        throw new AssertionError("Could not locate web asset: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Promote the stream from Connecting to Live when a decoded frame is actually delivered.
- Cover both SOTA and legacy decoder paths.
- Re-enter Connecting explicitly when the selected camera changes.

## Why

An already-open WebSocket may not emit another open event, leaving the banner at Connecting even while video frames are visible.

## Impact

The status now reflects the stream the driver can actually see.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Verified on a 2024 BYD Atto 3 running firmware 2602.

## Visual evidence

Connecting state:

![Live camera connecting state](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/186-live-connecting.png)

Active state:

![Live camera active state](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/186-live-active.png)