### PR TITLE
fix: make tunnel status badge reflect actual daemon state

### DIFF
--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import com.overdrive.app.storage.StorageSetup
 import com.overdrive.app.ui.daemon.DaemonStartupManager
 import com.overdrive.app.ui.model.DaemonStatus
 import com.overdrive.app.ui.model.DaemonType
+import com.overdrive.app.ui.model.TunnelDisplayPolicy
 import com.overdrive.app.ui.viewmodel.DaemonsViewModel
 import com.overdrive.app.ui.viewmodel.LogsViewModel
 import com.overdrive.app.ui.viewmodel.MainViewModel
@@ -80,6 +81,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var navigationRail: LinearLayout
     private lateinit var tvCurrentUrl: TextView
     private lateinit var urlBar: View
+    private lateinit var statusPill: View
     private lateinit var statusIndicator: View
     private lateinit var urlStatusDot: View
     private lateinit var btnCopyUrl: ImageButton
@@ -1301,6 +1303,7 @@ class MainActivity : AppCompatActivity() {
         navigationRail = findViewById(R.id.navigationRail)
         tvCurrentUrl = findViewById(R.id.tvCurrentUrl)
         urlBar = findViewById(R.id.urlBar)
+        statusPill = findViewById(R.id.statusPill)
         statusIndicator = findViewById(R.id.statusIndicator)
         urlStatusDot = findViewById(R.id.urlStatusDot)
         btnCopyUrl = findViewById(R.id.btnCopyUrl)
@@ -1484,13 +1487,11 @@ class MainActivity : AppCompatActivity() {
     
     private fun setupCopyButton() {
         btnCopyUrl.setOnClickListener {
-            val url = tvCurrentUrl.text.toString()
-            if (url.isNotEmpty() && !url.startsWith("No tunnel") && !url.startsWith("Waiting") && !url.startsWith("Starting") && url != "Connecting...") {
-                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clip = ClipData.newPlainText(getString(R.string.clip_label_url), url)
-                clipboard.setPrimaryClip(clip)
-                Toast.makeText(this, getString(R.string.toast_url_copied_short), Toast.LENGTH_SHORT).show()
-            }
+            val url = mainViewModel.currentUrl.value ?: return@setOnClickListener
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clip = ClipData.newPlainText(getString(R.string.clip_label_url), url)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(this, getString(R.string.toast_url_copied_short), Toast.LENGTH_SHORT).show()
         }
     }
     
@@ -1539,70 +1540,53 @@ class MainActivity : AppCompatActivity() {
         
         // Observe daemon states for tunnel status (cloudflared, zrok or tailscale)
         daemonsViewModel.daemonStates.observe(this) { states ->
-            val cloudflaredState = states[DaemonType.CLOUDFLARED_TUNNEL]
-            val zrokState = states[DaemonType.ZROK_TUNNEL]
-            val tailscaleState = states[DaemonType.TAILSCALE_TUNNEL]
-            // Show online if either tunnel is running
-            val tunnelStatus = when {
-                zrokState?.status == DaemonStatus.RUNNING -> DaemonStatus.RUNNING
-                cloudflaredState?.status == DaemonStatus.RUNNING -> DaemonStatus.RUNNING
-                tailscaleState?.status == DaemonStatus.RUNNING -> DaemonStatus.RUNNING
-                zrokState?.status == DaemonStatus.STARTING -> DaemonStatus.STARTING
-                cloudflaredState?.status == DaemonStatus.STARTING -> DaemonStatus.STARTING
-                tailscaleState?.status == DaemonStatus.STARTING -> DaemonStatus.STARTING
-                else -> DaemonStatus.STOPPED
-            }
-            updateStatusIndicator(tunnelStatus)
+            // A daemon transition must update the label as well as the dot.
+            // Previously STOPPED initial state changed only the dot, leaving
+            // the XML placeholder "Connecting..." visible indefinitely.
+            updateUrlDisplay()
         }
+        updateUrlDisplay()
     }
     
     private fun updateUrlDisplay() {
-        // Check both tunnel URLs - prefer zrok if available
         val zrokUrl = daemonsViewModel.zrokController.tunnelUrl.value
         val cloudflaredUrl = daemonsViewModel.cloudflaredController.tunnelUrl.value
         val tailscaleUrl = daemonsViewModel.tailscaleController.tunnelUrl.value
-        val tunnelUrl = zrokUrl?.takeIf { it.isNotEmpty() } ?: cloudflaredUrl?.takeIf { it.isNotEmpty() } ?: tailscaleUrl
-        
-        // Both modes now use tunnel URL
-        if (tunnelUrl.isNullOrEmpty()) {
-            // Show context-aware message based on tunnel state
-            val states = daemonsViewModel.daemonStates.value
-            val cfState = states?.get(DaemonType.CLOUDFLARED_TUNNEL)
-            val zrokState = states?.get(DaemonType.ZROK_TUNNEL)
-            val tailscaleState = states?.get(DaemonType.TAILSCALE_TUNNEL)
-            val message = when {
-                zrokState?.status == DaemonStatus.STARTING -> "Starting Zrok tunnel..."
-                cfState?.status == DaemonStatus.STARTING -> "Starting Cloudflared tunnel..."
-                tailscaleState?.status == DaemonStatus.STARTING -> "Starting Tailscale tunnel..."
-                zrokState?.status == DaemonStatus.RUNNING -> "Waiting for tunnel URL..."
-                cfState?.status == DaemonStatus.RUNNING -> "Waiting for tunnel URL..."
-                tailscaleState?.status == DaemonStatus.RUNNING -> "Waiting for tailscale URL..."
-                else -> "No tunnel running"
-            }
-            tvCurrentUrl.text = message
-            urlStatusDot.setBackgroundResource(R.drawable.status_dot_offline)
-            mainViewModel.setCurrentUrl(null)
-        } else {
-            tvCurrentUrl.text = tunnelUrl
-            urlStatusDot.setBackgroundResource(R.drawable.status_dot_online)
-            mainViewModel.setCurrentUrl(tunnelUrl)
+        val states = daemonsViewModel.daemonStates.value
+        val display = TunnelDisplayPolicy.resolve(
+            zrokUrl,
+            cloudflaredUrl,
+            tailscaleUrl,
+            states?.get(DaemonType.ZROK_TUNNEL)?.status,
+            states?.get(DaemonType.CLOUDFLARED_TUNNEL)?.status,
+            states?.get(DaemonType.TAILSCALE_TUNNEL)?.status,
+        )
+
+        statusPill.visibility = if (display.isVisible) View.VISIBLE else View.GONE
+        btnCopyUrl.visibility = if (display.isOnline) View.VISIBLE else View.GONE
+        tvCurrentUrl.text = when (display.kind) {
+            TunnelDisplayPolicy.Kind.STARTING_ZROK ->
+                getString(R.string.dashboard_starting_zrok)
+            TunnelDisplayPolicy.Kind.STARTING_CLOUDFLARED ->
+                getString(R.string.dashboard_starting_cloudflared)
+            TunnelDisplayPolicy.Kind.STARTING_TAILSCALE ->
+                getString(R.string.dashboard_starting_tailscale)
+            TunnelDisplayPolicy.Kind.WAITING_FOR_URL ->
+                getString(R.string.dashboard_waiting_url)
+            TunnelDisplayPolicy.Kind.ONLINE -> display.url
+            TunnelDisplayPolicy.Kind.HIDDEN -> getString(R.string.dashboard_no_tunnel)
         }
-    }
-    
-    private fun updateStatusIndicator(status: DaemonStatus?) {
-        // Single status pill replaced the standalone toolbar dot. Both the
-        // legacy `statusIndicator` and the in-pill `urlStatusDot` IDs are
-        // updated for safety: the legacy dot is now a 0×0 invisible View
-        // (so updates are no-ops visually) and the pill dot is what users
-        // actually see. Keeping both write paths means future layout swaps
-        // don't need MainActivity edits.
-        val drawableRes = when (status) {
-            DaemonStatus.RUNNING -> R.drawable.status_dot_online
-            DaemonStatus.STARTING, DaemonStatus.STOPPING -> R.drawable.status_dot_starting
-            else -> R.drawable.status_dot_offline
+        val drawableRes = when (display.kind) {
+            TunnelDisplayPolicy.Kind.ONLINE -> R.drawable.status_dot_online
+            TunnelDisplayPolicy.Kind.STARTING_ZROK,
+            TunnelDisplayPolicy.Kind.STARTING_CLOUDFLARED,
+            TunnelDisplayPolicy.Kind.STARTING_TAILSCALE,
+            TunnelDisplayPolicy.Kind.WAITING_FOR_URL -> R.drawable.status_dot_starting
+            TunnelDisplayPolicy.Kind.HIDDEN -> R.drawable.status_dot_offline
         }
         statusIndicator.setBackgroundResource(drawableRes)
         urlStatusDot.setBackgroundResource(drawableRes)
+        mainViewModel.setCurrentUrl(display.url)
     }
     
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
@@ -282,6 +282,7 @@ class DashboardFragment : Fragment() {
             // moment a daemon is being launched, without waiting for RUNNING.
             updateHeroSubtitle(running, total, computeCoreHealth(states))
             rebuildTunnelChips()
+            updateTunnelTile()
             refreshHeroChips()
         }
 
@@ -598,30 +599,29 @@ class DashboardFragment : Fragment() {
     }
 
     private fun updateTunnelTile() {
-        val anyUrl = listOf(
-            daemonsViewModel.cloudflaredController.tunnelUrl.value,
-            daemonsViewModel.zrokController.tunnelUrl.value,
-            daemonsViewModel.tailscaleController.tunnelUrl.value
-        ).any { !it.isNullOrEmpty() }
-
         val states = daemonsViewModel.daemonStates.value
-        val anyStarting = states?.values?.any {
-            (it.type == DaemonType.CLOUDFLARED_TUNNEL ||
-                it.type == DaemonType.ZROK_TUNNEL ||
-                it.type == DaemonType.TAILSCALE_TUNNEL) &&
-                it.status == DaemonStatus.STARTING
-        } == true
+        val display = com.overdrive.app.ui.model.TunnelDisplayPolicy.resolve(
+            daemonsViewModel.zrokController.tunnelUrl.value,
+            daemonsViewModel.cloudflaredController.tunnelUrl.value,
+            daemonsViewModel.tailscaleController.tunnelUrl.value,
+            states?.get(DaemonType.ZROK_TUNNEL)?.status,
+            states?.get(DaemonType.CLOUDFLARED_TUNNEL)?.status,
+            states?.get(DaemonType.TAILSCALE_TUNNEL)?.status,
+        )
 
-        when {
-            anyUrl -> {
+        when (display.kind) {
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.ONLINE -> {
                 metricTunnelValue.text = getString(R.string.dashboard_tunnel_online)
                 tunnelStateDot.setBackgroundResource(R.drawable.status_dot_online)
             }
-            anyStarting -> {
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.STARTING_ZROK,
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.STARTING_CLOUDFLARED,
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.STARTING_TAILSCALE,
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.WAITING_FOR_URL -> {
                 metricTunnelValue.text = getString(R.string.dashboard_tunnel_connecting)
                 tunnelStateDot.setBackgroundResource(R.drawable.status_dot_offline)
             }
-            else -> {
+            com.overdrive.app.ui.model.TunnelDisplayPolicy.Kind.HIDDEN -> {
                 metricTunnelValue.text = getString(R.string.dashboard_tunnel_offline)
                 tunnelStateDot.setBackgroundResource(R.drawable.status_dot_offline)
             }
@@ -683,14 +683,24 @@ class DashboardFragment : Fragment() {
 
     private fun collectAvailableTunnels(): List<Pair<DaemonType, String>> {
         val list = mutableListOf<Pair<DaemonType, String>>()
+        val states = daemonsViewModel.daemonStates.value
         daemonsViewModel.cloudflaredController.tunnelUrl.value
-            ?.takeIf { it.isNotEmpty() }
+            ?.takeIf {
+                com.overdrive.app.ui.model.TunnelDisplayPolicy.isActiveUrl(
+                    it, states?.get(DaemonType.CLOUDFLARED_TUNNEL)?.status)
+            }
             ?.let { list.add(DaemonType.CLOUDFLARED_TUNNEL to it) }
         daemonsViewModel.zrokController.tunnelUrl.value
-            ?.takeIf { it.isNotEmpty() }
+            ?.takeIf {
+                com.overdrive.app.ui.model.TunnelDisplayPolicy.isActiveUrl(
+                    it, states?.get(DaemonType.ZROK_TUNNEL)?.status)
+            }
             ?.let { list.add(DaemonType.ZROK_TUNNEL to it) }
         daemonsViewModel.tailscaleController.tunnelUrl.value
-            ?.takeIf { it.isNotEmpty() }
+            ?.takeIf {
+                com.overdrive.app.ui.model.TunnelDisplayPolicy.isActiveUrl(
+                    it, states?.get(DaemonType.TAILSCALE_TUNNEL)?.status)
+            }
             ?.let { list.add(DaemonType.TAILSCALE_TUNNEL to it) }
         return list
     }

--- a/app/src/main/java/com/overdrive/app/ui/model/TunnelDisplayPolicy.java
+++ b/app/src/main/java/com/overdrive/app/ui/model/TunnelDisplayPolicy.java
@@ -1,0 +1,87 @@
+package com.overdrive.app.ui.model;
+
+/**
+ * Truthful toolbar/dashboard state derived from tunnel process state and URL.
+ *
+ * <p>Controller URL values may contain a last-known URL restored from
+ * preferences, so a URL alone is not proof that its tunnel is online.
+ */
+public final class TunnelDisplayPolicy {
+    public enum Kind {
+        HIDDEN,
+        STARTING_ZROK,
+        STARTING_CLOUDFLARED,
+        STARTING_TAILSCALE,
+        WAITING_FOR_URL,
+        ONLINE
+    }
+
+    public static final class Result {
+        private final Kind kind;
+        private final String url;
+
+        private Result(Kind kind, String url) {
+            this.kind = kind;
+            this.url = url;
+        }
+
+        public Kind getKind() {
+            return kind;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public boolean isVisible() {
+            return kind != Kind.HIDDEN;
+        }
+
+        public boolean isOnline() {
+            return kind == Kind.ONLINE && url != null;
+        }
+    }
+
+    private TunnelDisplayPolicy() {
+    }
+
+    public static Result resolve(String zrokUrl,
+                                 String cloudflaredUrl,
+                                 String tailscaleUrl,
+                                 DaemonStatus zrokStatus,
+                                 DaemonStatus cloudflaredStatus,
+                                 DaemonStatus tailscaleStatus) {
+        if (isActiveUrl(zrokUrl, zrokStatus)) {
+            return new Result(Kind.ONLINE, zrokUrl);
+        }
+        if (isActiveUrl(cloudflaredUrl, cloudflaredStatus)) {
+            return new Result(Kind.ONLINE, cloudflaredUrl);
+        }
+        if (isActiveUrl(tailscaleUrl, tailscaleStatus)) {
+            return new Result(Kind.ONLINE, tailscaleUrl);
+        }
+
+        if (zrokStatus == DaemonStatus.STARTING) {
+            return new Result(Kind.STARTING_ZROK, null);
+        }
+        if (cloudflaredStatus == DaemonStatus.STARTING) {
+            return new Result(Kind.STARTING_CLOUDFLARED, null);
+        }
+        if (tailscaleStatus == DaemonStatus.STARTING) {
+            return new Result(Kind.STARTING_TAILSCALE, null);
+        }
+
+        if (zrokStatus == DaemonStatus.RUNNING
+                || cloudflaredStatus == DaemonStatus.RUNNING
+                || tailscaleStatus == DaemonStatus.RUNNING) {
+            return new Result(Kind.WAITING_FOR_URL, null);
+        }
+        return new Result(Kind.HIDDEN, null);
+    }
+
+    public static boolean isActiveUrl(String url, DaemonStatus status) {
+        return status == DaemonStatus.RUNNING
+                && url != null
+                && !url.trim().isEmpty();
+    }
+}

--- a/app/src/main/res/layout-land/activity_main_new.xml
+++ b/app/src/main/res/layout-land/activity_main_new.xml
@@ -182,10 +182,11 @@
                     app:titleTextAppearance="@style/TextAppearance.Material3.TitleMedium">
 
                     <!--
-                      Status pill (landscape variant). Same DOM shape as the
+                      Status pill (landscape variant). Same view shape as the
                       portrait toolbar so MainActivity bindings (urlBar,
                       statusIndicator, urlStatusDot, tvCurrentUrl, btnCopyUrl)
-                      all resolve identically. The bottom URL strip is gone.
+                      all resolve identically. It starts hidden until a tunnel
+                      is genuinely starting or running.
                     -->
                     <LinearLayout
                         android:id="@+id/urlBar"
@@ -206,7 +207,8 @@
                             android:gravity="center_vertical"
                             android:orientation="horizontal"
                             android:paddingHorizontal="14dp"
-                            android:paddingVertical="6dp">
+                            android:paddingVertical="6dp"
+                            android:visibility="gone">
 
                             <View
                                 android:id="@+id/urlStatusDot"
@@ -229,7 +231,7 @@
                                 android:fontFamily="monospace"
                                 android:maxWidth="320dp"
                                 android:singleLine="true"
-                                android:text="@string/url_connecting"
+                                android:text="@string/dashboard_no_tunnel"
                                 android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
                                 android:textColor="?attr/colorPrimary"
                                 android:textIsSelectable="true" />

--- a/app/src/main/res/layout/activity_main_new.xml
+++ b/app/src/main/res/layout/activity_main_new.xml
@@ -186,9 +186,10 @@
                       `btnCopyUrl`, `urlBar` IDs are preserved here even though
                       the bottom URL strip is gone — MainActivity reads them
                       to update tunnel state. `urlStatusDot` is the dot inside
-                      the pill (same drawable swap logic). `urlBar` is now the
-                      pill's outer LinearLayout so the same visibility toggling
-                      keeps working.
+                      the pill (same drawable swap logic). The status pill
+                      starts hidden and appears only for a genuinely starting
+                      or running tunnel; the surrounding `urlBar` stays visible
+                      so the language affordance remains reachable.
                     -->
                     <LinearLayout
                         android:id="@+id/urlBar"
@@ -209,7 +210,8 @@
                             android:gravity="center_vertical"
                             android:orientation="horizontal"
                             android:paddingHorizontal="14dp"
-                            android:paddingVertical="8dp">
+                            android:paddingVertical="8dp"
+                            android:visibility="gone">
 
                             <View
                                 android:id="@+id/urlStatusDot"
@@ -232,7 +234,7 @@
                                 android:fontFamily="monospace"
                                 android:maxWidth="280dp"
                                 android:singleLine="true"
-                                android:text="@string/url_connecting"
+                                android:text="@string/dashboard_no_tunnel"
                                 android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
                                 android:textColor="?attr/colorPrimary"
                                 android:textIsSelectable="true" />

--- a/app/src/test/java/com/overdrive/app/ui/model/TunnelDisplayPolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/model/TunnelDisplayPolicyTest.java
@@ -1,0 +1,80 @@
+package com.overdrive.app.ui.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TunnelDisplayPolicyTest {
+
+    @Test
+    public void noConfiguredTunnelIsHiddenRatherThanConnecting() {
+        TunnelDisplayPolicy.Result result = resolve(
+                null, null, null,
+                DaemonStatus.STOPPED, DaemonStatus.STOPPED, DaemonStatus.STOPPED);
+
+        assertEquals(TunnelDisplayPolicy.Kind.HIDDEN, result.getKind());
+        assertFalse(result.isVisible());
+        assertNull(result.getUrl());
+    }
+
+    @Test
+    public void persistedUrlDoesNotMasqueradeAsOnline() {
+        TunnelDisplayPolicy.Result result = resolve(
+                null, "https://stale.example", null,
+                DaemonStatus.STOPPED, DaemonStatus.STOPPED, DaemonStatus.STOPPED);
+
+        assertEquals(TunnelDisplayPolicy.Kind.HIDDEN, result.getKind());
+        assertFalse(result.isOnline());
+    }
+
+    @Test
+    public void startingAndWaitingAreExplicitStates() {
+        assertEquals(TunnelDisplayPolicy.Kind.STARTING_ZROK,
+                resolve(null, null, null,
+                        DaemonStatus.STARTING, DaemonStatus.STOPPED,
+                        DaemonStatus.STOPPED).getKind());
+        assertEquals(TunnelDisplayPolicy.Kind.WAITING_FOR_URL,
+                resolve(null, null, null,
+                        DaemonStatus.STOPPED, DaemonStatus.RUNNING,
+                        DaemonStatus.STOPPED).getKind());
+    }
+
+    @Test
+    public void onlineRequiresRunningProcessAndUsesExistingPriority() {
+        TunnelDisplayPolicy.Result result = resolve(
+                "https://zrok.example",
+                "https://cloudflare.example",
+                "https://tailscale.example",
+                DaemonStatus.RUNNING, DaemonStatus.RUNNING, DaemonStatus.RUNNING);
+
+        assertEquals(TunnelDisplayPolicy.Kind.ONLINE, result.getKind());
+        assertEquals("https://zrok.example", result.getUrl());
+        assertTrue(result.isOnline());
+    }
+
+    @Test
+    public void staleHigherPriorityUrlDoesNotHideActiveTunnel() {
+        TunnelDisplayPolicy.Result result = resolve(
+                "https://stale-zrok.example",
+                "https://cloudflare.example",
+                null,
+                DaemonStatus.STOPPED, DaemonStatus.RUNNING, DaemonStatus.STOPPED);
+
+        assertEquals("https://cloudflare.example", result.getUrl());
+    }
+
+    private static TunnelDisplayPolicy.Result resolve(
+            String zrokUrl,
+            String cloudflaredUrl,
+            String tailscaleUrl,
+            DaemonStatus zrokStatus,
+            DaemonStatus cloudflaredStatus,
+            DaemonStatus tailscaleStatus) {
+        return TunnelDisplayPolicy.resolve(
+                zrokUrl, cloudflaredUrl, tailscaleUrl,
+                zrokStatus, cloudflaredStatus, tailscaleStatus);
+    }
+}


### PR DESCRIPTION
## Summary

- Hide the tunnel badge when no tunnel daemon is active.
- Require a running process and a current URL before displaying Online.
- Distinguish starting, waiting, online, and inactive states for zrok, cloudflared, and Tailscale.
- Prevent stale saved URLs from masking the active daemon state.

## Why

Persisted URLs could make the dashboard report a connection after the corresponding daemon had stopped.

## Impact

Remote-access status is truthful and no longer remains indefinitely at Connecting or Waiting.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Tunnel display policy is covered by unit tests.

## Visual evidence

![Online tunnel status without exposing the private address](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/187-tunnel-online.png)