### PR TITLE
fix: synchronise RoadSense overlay with its master switch

### DIFF
--- a/app/src/main/assets/web/shared/road-sense.js
+++ b/app/src/main/assets/web/shared/road-sense.js
@@ -471,6 +471,13 @@ BYD.roadSense = {
             // Live-update the dependent-card gate so toggling the master on/off
             // immediately enables/dims Warnings/Crowdsource/Data.
             this._applyMasterGate(on);
+            // The floating overlay is a separate app-process service. Reconcile it
+            // after either master transition, not only when the overlay preference
+            // itself changes, so master OFF removes the pill immediately.
+            if (typeof window.AndroidBridge !== 'undefined'
+                    && typeof AndroidBridge.syncRoadSenseOverlay === 'function') {
+                try { AndroidBridge.syncRoadSenseOverlay(); } catch (e) { /* best-effort */ }
+            }
             this._toastSaved();
         } else {
             el.checked = !on;

--- a/app/src/main/java/com/overdrive/app/roadsense/RoadSenseController.kt
+++ b/app/src/main/java/com/overdrive/app/roadsense/RoadSenseController.kt
@@ -491,6 +491,14 @@ class RoadSenseController @JvmOverloads constructor(
     fun stop() {
         if (!started) return
         started = false
+        featureEnabled = false
+        // The overlay is an app-process service, independent of this daemon-side
+        // detector. The master-disable reconcile stops the ticker immediately, so no
+        // later vehicle-state edge exists to tear the overlay down for us.
+        com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.stopFromDaemon()
+        // A later re-enable must begin from a real OFF edge. Leaving this at DRIVING
+        // made the first poll after restart return early and skip sidecar/overlay start.
+        regime = VehicleStateGate.Regime.OFF
         ticker?.shutdownNow()
         ticker = null
         // Tear down the sync executor too. shutdownNow() interrupts any in-flight

--- a/app/src/main/java/com/overdrive/app/roadsense/config/RoadSenseConfig.kt
+++ b/app/src/main/java/com/overdrive/app/roadsense/config/RoadSenseConfig.kt
@@ -128,7 +128,11 @@ object RoadSenseConfig {
          *  master feature ON (nothing to render otherwise) AND the user not to have hidden
          *  it. The single gate every start site + the service's own poll consult, so the
          *  start/keep-warm/regime-edge paths can't disagree about visibility. */
-        fun overlayShouldShow(): Boolean = enabled && overlayVisible
+        fun overlayShouldShow(): Boolean =
+            com.overdrive.app.roadsense.overlay.RoadSenseOverlayPolicy.shouldShow(
+                enabled,
+                overlayVisible
+            )
         /** Should a hazard of [severityLevel] (1=minor,2=moderate,3=severe) with
          *  [confidence] produce a warning at all, per the gates? (Distance is the
          *  WarningCoordinator's separate job.) */
@@ -209,7 +213,18 @@ object RoadSenseConfig {
         )
     }
 
-    // NOTE: writes to the roadSense section go through UnifiedConfigManager.updateSection
-    // directly (web settings page via RoadSenseApiHandler, daemon via RoadSenseController).
-    // The old typed update()/setX() writers here had no callers and were removed.
+    /**
+     * Persist the user's display-only overlay preference. Both the RoadSense page and
+     * Settings -> Status overlay write this same key, so the two controls cannot drift.
+     * This does not change the RoadSense master switch.
+     */
+    fun setOverlayVisible(visible: Boolean): Boolean =
+        UnifiedConfigManager.updateSection(
+            SECTION,
+            JSONObject().put(K_OVERLAY_VISIBLE, visible)
+        )
+
+    // Other writes to the roadSense section go through
+    // UnifiedConfigManager.updateSection directly (web settings page via
+    // RoadSenseApiHandler, daemon via RoadSenseController).
 }

--- a/app/src/main/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayPolicy.java
+++ b/app/src/main/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayPolicy.java
@@ -1,0 +1,16 @@
+package com.overdrive.app.roadsense.overlay;
+
+/**
+ * Pure visibility policy for the RoadSense floating overlay.
+ *
+ * Keeping this predicate Android-free makes the lifecycle invariant explicit and
+ * unit-testable: a remembered overlay preference never overrides the RoadSense
+ * master switch.
+ */
+public final class RoadSenseOverlayPolicy {
+    private RoadSenseOverlayPolicy() {}
+
+    public static boolean shouldShow(boolean roadSenseEnabled, boolean overlayVisible) {
+        return roadSenseEnabled && overlayVisible;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayService.kt
+++ b/app/src/main/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayService.kt
@@ -108,12 +108,23 @@ class RoadSenseOverlayService : Service() {
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
         ioThread = android.os.HandlerThread("roadsense-overlay-io").also { it.start() }
         ioHandler = Handler(ioThread!!.looper)
-        createOverlay()
-        startPolling()
-        instance = this
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // The daemon can launch us via `am`, and START_STICKY can recreate us later.
+        // Check the complete lifecycle policy before creating the window so a stale
+        // overlay cannot flash between onCreate and onStartCommand.
+        val shouldShow = try {
+            RoadSenseConfig.snapshot(forceReload = true).overlayShouldShow()
+        } catch (t: Throwable) {
+            Log.w(TAG, "visibility config unavailable - stopping: ${t.message}")
+            false
+        }
+        if (!shouldShow) {
+            Log.i(TAG, "RoadSense disabled or overlay hidden - stopping")
+            stopSelf()
+            return START_NOT_STICKY
+        }
         // Self-guard the overlay permission here too (not only at the app-side
         // startIfPermitted call site): the daemon launches us via `am` (startFromDaemon)
         // on ACC-on + feature-on, which bypasses the app-side canDrawOverlays gate. If
@@ -123,6 +134,11 @@ class RoadSenseOverlayService : Service() {
             Log.w(TAG, "overlay permission not granted — stopping")
             stopSelf()
             return START_NOT_STICKY
+        }
+        if (overlayView == null) {
+            createOverlay()
+            startPolling()
+            instance = this
         }
         return START_STICKY
     }
@@ -426,16 +442,10 @@ class RoadSenseOverlayService : Service() {
         // off the UI looper (audit UI #3).
         val r = object : Runnable {
             override fun run() {
-                // Visibility self-guard: the user can hide the overlay (roadSense.
-                // overlayVisible=false) while we're already running — e.g. the daemon
-                // launched us on ACC-on and the user then flips the toggle, or a remote
-                // (tunnel/browser) write lands. The app-side onResume/keepalive gate only
-                // runs when the Activity is touched, so without this a daemon-launched
-                // overlay would linger on screen after being hidden. readState() already
-                // refreshed the UCM cache this tick, so this is a cache-fresh read (no
-                // extra disk hit). Stop cleanly — startFromDaemon/startIfPermitted will
-                // bring us back if the user re-enables.
-                if (!RoadSenseConfig.snapshot().overlayVisible) {
+                // Lifecycle self-guard: either the RoadSense master switch or the
+                // overlay preference can turn this window off while it is running.
+                // This also covers remote/tunnel writes when no Activity callback runs.
+                if (!RoadSenseConfig.snapshot().overlayShouldShow()) {
                     handler.post { stopSelf() }
                     return
                 }
@@ -861,9 +871,19 @@ class RoadSenseOverlayService : Service() {
         // day/night theme via themeColor()/colorDim() (R.color.status_*), matching
         // StatusOverlayService so the overlay tracks the active theme.
 
-        /** Start only if overlay permission is granted (StatusOverlayService gate).
+        /** Start only if RoadSense wants the overlay and permission is granted.
          *  This is the APP-process path (MainActivity / DaemonKeepaliveService). */
         fun startIfPermitted(context: Context): Boolean {
+            val shouldShow = try {
+                RoadSenseConfig.snapshot(forceReload = true).overlayShouldShow()
+            } catch (t: Throwable) {
+                Log.w(TAG, "visibility config unavailable - not starting: ${t.message}")
+                false
+            }
+            if (!shouldShow) {
+                Log.i(TAG, "RoadSense disabled or overlay hidden - not starting")
+                return false
+            }
             if (!Settings.canDrawOverlays(context)) {
                 Log.w(TAG, "no overlay permission — not starting")
                 return false
@@ -874,6 +894,25 @@ class RoadSenseOverlayService : Service() {
 
         fun stop(context: Context) {
             context.stopService(Intent(context, RoadSenseOverlayService::class.java))
+        }
+
+        /**
+         * Reconcile the app-side service with the persisted master + visibility flags.
+         * Native UI entry points use this so they cannot disagree about lifecycle.
+         */
+        fun syncWithConfig(context: Context): Boolean {
+            val shouldShow = try {
+                RoadSenseConfig.snapshot(forceReload = true).overlayShouldShow()
+            } catch (t: Throwable) {
+                Log.w(TAG, "visibility config unavailable - stopping: ${t.message}")
+                false
+            }
+            return if (shouldShow) {
+                startIfPermitted(context)
+            } else {
+                stop(context)
+                false
+            }
         }
 
         /** Fully-qualified component for the daemon's `am` launch. */

--- a/app/src/main/java/com/overdrive/app/services/DaemonKeepaliveService.kt
+++ b/app/src/main/java/com/overdrive/app/services/DaemonKeepaliveService.kt
@@ -180,12 +180,10 @@ class DaemonKeepaliveService : Service() {
         // disabled feature stays silent. The overlay itself only renders daemon-
         // published state, so showing it early just yields the idle/scanning pill.
         try {
-            // overlayShouldShow() also honours the user's overlayVisible opt-out (default
-            // ON) — a hidden overlay must stay hidden across a process respawn, not pop
-            // back just because the feature is enabled.
-            if (com.overdrive.app.roadsense.config.RoadSenseConfig.snapshot(forceReload = true).overlayShouldShow()) {
-                com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.startIfPermitted(applicationContext)
-            }
+            // The shared lifecycle policy also honours the user's overlayVisible
+            // opt-out, and actively stops a stale service when the master is off.
+            com.overdrive.app.roadsense.overlay.RoadSenseOverlayService
+                .syncWithConfig(applicationContext)
         } catch (e: Exception) {
             Log.w(TAG, "Failed to kick RoadSense overlay: ${e.message}")
         }

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -639,17 +639,10 @@ class MainActivity : AppCompatActivity() {
      */
     private fun syncRoadSenseOverlay() {
         try {
-            // overlayShouldShow() = feature ENABLED and the user hasn't hidden the overlay
-            // (roadSense.overlayVisible, default ON). Hiding it is an on-screen-only opt-out
-            // — detection/audio/crowdsource keep running daemon-side — so we just stop the
-            // app-side window without touching the master enable.
-            val shouldShow = com.overdrive.app.roadsense.config.RoadSenseConfig
-                .snapshot(forceReload = true).overlayShouldShow()
-            if (shouldShow) {
-                com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.startIfPermitted(this)
-            } else {
-                com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.stop(this)
-            }
+            // One policy owns both the RoadSense master gate and the user's
+            // display-only overlay preference.
+            com.overdrive.app.roadsense.overlay.RoadSenseOverlayService
+                .syncWithConfig(this)
         } catch (t: Throwable) {
             android.util.Log.w("MainActivity", "syncRoadSenseOverlay failed: ${t.message}")
         }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/SettingsFragment.kt
@@ -19,6 +19,8 @@ import com.google.android.material.switchmaterial.SwitchMaterial
 import com.overdrive.app.BuildConfig
 import com.overdrive.app.R
 import com.overdrive.app.config.UnifiedConfigManager
+import com.overdrive.app.roadsense.config.RoadSenseConfig
+import com.overdrive.app.roadsense.overlay.RoadSenseOverlayService
 import com.overdrive.app.ui.MainActivity
 import org.json.JSONObject
 import com.overdrive.app.updater.AppUpdater
@@ -52,6 +54,8 @@ import java.util.Locale
  * set of views — the union of IDs would not exist in any single layout.
  */
 class SettingsFragment : Fragment() {
+    private var portraitRoadSenseSwitch: SwitchMaterial? = null
+    private var applyingPortraitRoadSenseConfig = false
 
     /**
      * Sub-rail sections. The order here is the visual order in the rail
@@ -136,6 +140,16 @@ class SettingsFragment : Fragment() {
             setupResetRow(view)
             setupFooter(view)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshPortraitRoadSenseSwitch(forceReload = true)
+    }
+
+    override fun onDestroyView() {
+        portraitRoadSenseSwitch = null
+        super.onDestroyView()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -335,15 +349,23 @@ class SettingsFragment : Fragment() {
     private fun setupOverlayToggles(view: View) {
         val swCamera = view.findViewById<SwitchMaterial>(R.id.swOverlayCamera) ?: return
         val swTrip = view.findViewById<SwitchMaterial>(R.id.swOverlayTrip) ?: return
+        val swRoadSense =
+            view.findViewById<SwitchMaterial>(R.id.swOverlayRoadSense) ?: return
+        portraitRoadSenseSwitch = swRoadSense
         val rowCamera = view.findViewById<View>(R.id.rowOverlayCamera)
         val rowTrip = view.findViewById<View>(R.id.rowOverlayTrip)
+        val rowRoadSense = view.findViewById<View>(R.id.rowOverlayRoadSense)
 
         val cfg = UnifiedConfigManager.getStatusOverlay()
         swCamera.isChecked = cfg.optBoolean("cameraVisible", true)
         swTrip.isChecked = cfg.optBoolean("tripVisible", true)
+        refreshPortraitRoadSenseSwitch(forceReload = true)
 
         rowCamera?.setOnClickListener { swCamera.isChecked = !swCamera.isChecked }
         rowTrip?.setOnClickListener { swTrip.isChecked = !swTrip.isChecked }
+        rowRoadSense?.setOnClickListener {
+            swRoadSense.isChecked = !swRoadSense.isChecked
+        }
 
         swCamera.setOnCheckedChangeListener { _, checked ->
             UnifiedConfigManager.setStatusOverlay(JSONObject().put("cameraVisible", checked))
@@ -353,6 +375,28 @@ class SettingsFragment : Fragment() {
             UnifiedConfigManager.setStatusOverlay(JSONObject().put("tripVisible", checked))
             kickOverlayRefresh()
         }
+        swRoadSense.setOnCheckedChangeListener { button, checked ->
+            if (applyingPortraitRoadSenseConfig) return@setOnCheckedChangeListener
+            if (RoadSenseConfig.setOverlayVisible(checked)) {
+                context?.let { RoadSenseOverlayService.syncWithConfig(it) }
+            } else {
+                applyingPortraitRoadSenseConfig = true
+                button.isChecked = !checked
+                applyingPortraitRoadSenseConfig = false
+            }
+        }
+    }
+
+    private fun refreshPortraitRoadSenseSwitch(forceReload: Boolean) {
+        val toggle = portraitRoadSenseSwitch ?: return
+        val visible = try {
+            RoadSenseConfig.snapshot(forceReload).overlayVisible
+        } catch (_: Throwable) {
+            return
+        }
+        applyingPortraitRoadSenseConfig = true
+        toggle.isChecked = visible
+        applyingPortraitRoadSenseConfig = false
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
@@ -1156,15 +1156,10 @@ class WebViewFragment : Fragment() {
         fun syncRoadSenseOverlay(): String {
             return try {
                 val ctx = context ?: return "no_context"
-                val shouldShow = com.overdrive.app.roadsense.config.RoadSenseConfig
-                    .snapshot(forceReload = true).overlayShouldShow()
                 ctx.mainExecutor.execute {
                     try {
-                        if (shouldShow) {
-                            com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.startIfPermitted(ctx)
-                        } else {
-                            com.overdrive.app.roadsense.overlay.RoadSenseOverlayService.stop(ctx)
-                        }
+                        com.overdrive.app.roadsense.overlay.RoadSenseOverlayService
+                            .syncWithConfig(ctx)
                     } catch (e: Exception) {
                         android.util.Log.w("WebViewFragment", "syncRoadSenseOverlay apply failed: ${e.message}")
                     }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/settings/SettingsOverlayFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/settings/SettingsOverlayFragment.kt
@@ -8,24 +8,26 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.overdrive.app.R
 import com.overdrive.app.config.UnifiedConfigManager
+import com.overdrive.app.roadsense.config.RoadSenseConfig
+import com.overdrive.app.roadsense.overlay.RoadSenseOverlayService
 import org.json.JSONObject
 
 /**
  * Settings → Status overlay pane.
  *
- * Three switches that gate the segments of the floating status pill
- * ([com.overdrive.app.overlay.StatusOverlayService]):
+ * Four switches for the app's floating status surfaces:
  *  - Camera/recording indicator (REC / PROX)
  *  - Instant replay indicator (CLIP)
  *  - Trip indicator (TRIP)
+ *  - RoadSense pill / hazard card
  *
- * The flags live in [UnifiedConfigManager]'s `statusOverlay` section so
- * both the app UID and the daemon UID see the same value (SharedPreferences
- * are per-UID and would split-brain). The service polls the unified config
- * on every tick, so a flip here takes effect within the next poll interval
- * (≤3s with ACC on) without restarting the service.
+ * The three status-pill flags live in [UnifiedConfigManager]'s `statusOverlay`
+ * section; RoadSense uses its existing `roadSense.overlayVisible` flag. Both
+ * sections are file-backed so the app and daemon UIDs see one shared value.
  */
 class SettingsOverlayFragment : Fragment() {
+    private var roadSenseSwitch: SwitchMaterial? = null
+    private var applyingRoadSenseConfig = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -39,11 +41,15 @@ class SettingsOverlayFragment : Fragment() {
         val swCamera = view.findViewById<SwitchMaterial>(R.id.swOverlayCamera) ?: return
         val swReplay = view.findViewById<SwitchMaterial>(R.id.swOverlayReplay) ?: return
         val swTrip = view.findViewById<SwitchMaterial>(R.id.swOverlayTrip) ?: return
+        val swRoadSense =
+            view.findViewById<SwitchMaterial>(R.id.swOverlayRoadSense) ?: return
+        roadSenseSwitch = swRoadSense
 
         val cfg = UnifiedConfigManager.getStatusOverlay()
         swCamera.isChecked = cfg.optBoolean("cameraVisible", true)
         swReplay.isChecked = cfg.optBoolean("replayVisible", true)
         swTrip.isChecked = cfg.optBoolean("tripVisible", true)
+        refreshRoadSenseSwitch(forceReload = true)
 
         // Make the whole row clickable as well for forgiveness on a wide
         // head-unit (toggling via the row, not just the thumb, is the BYD
@@ -57,10 +63,28 @@ class SettingsOverlayFragment : Fragment() {
         view.findViewById<View>(R.id.rowOverlayTrip).setOnClickListener {
             swTrip.isChecked = !swTrip.isChecked
         }
+        view.findViewById<View>(R.id.rowOverlayRoadSense).setOnClickListener {
+            swRoadSense.isChecked = !swRoadSense.isChecked
+        }
 
         swCamera.setOnCheckedChangeListener { _, checked -> persist("cameraVisible", checked) }
         swReplay.setOnCheckedChangeListener { _, checked -> persist("replayVisible", checked) }
         swTrip.setOnCheckedChangeListener { _, checked -> persist("tripVisible", checked) }
+        swRoadSense.setOnCheckedChangeListener { _, checked ->
+            if (!applyingRoadSenseConfig) persistRoadSense(checked)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // This preference is also exposed on the RoadSense page. Refresh when the
+        // user returns so both entry points always display the same stored value.
+        refreshRoadSenseSwitch(forceReload = true)
+    }
+
+    override fun onDestroyView() {
+        roadSenseSwitch = null
+        super.onDestroyView()
     }
 
     /**
@@ -72,5 +96,25 @@ class SettingsOverlayFragment : Fragment() {
     private fun persist(key: String, value: Boolean) {
         UnifiedConfigManager.setStatusOverlay(JSONObject().put(key, value))
         context?.let { com.overdrive.app.overlay.StatusOverlayService.startIfPermitted(it) }
+    }
+
+    private fun persistRoadSense(visible: Boolean) {
+        if (RoadSenseConfig.setOverlayVisible(visible)) {
+            context?.let { RoadSenseOverlayService.syncWithConfig(it) }
+        } else {
+            refreshRoadSenseSwitch(forceReload = true)
+        }
+    }
+
+    private fun refreshRoadSenseSwitch(forceReload: Boolean) {
+        val toggle = roadSenseSwitch ?: return
+        val visible = try {
+            RoadSenseConfig.snapshot(forceReload).overlayVisible
+        } catch (_: Throwable) {
+            return
+        }
+        applyingRoadSenseConfig = true
+        toggle.isChecked = visible
+        applyingRoadSenseConfig = false
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -423,6 +423,32 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
                 </LinearLayout>
+
+                <!-- RoadSense overlay toggle row -->
+                <LinearLayout
+                    android:id="@+id/rowOverlayRoadSense"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/settings_overlay_roadsense_title"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                        android:textColor="?attr/colorOnSurface" />
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/swOverlayRoadSense"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_settings_overlay.xml
+++ b/app/src/main/res/layout/fragment_settings_overlay.xml
@@ -2,16 +2,17 @@
 <!--
   Settings → Status overlay pane.
 
-  Three switch rows in a single MaterialCardView, each gating a segment of
-  the floating status pill:
+  Four switch rows in a single MaterialCardView for floating status surfaces:
     1. Camera / recording indicator (REC / PROX)
     2. Instant replay indicator (CLIP)
     3. Trip indicator (TRIP)
+    4. RoadSense pill / hazard card
 
   IDs the Kotlin driver (SettingsOverlayFragment) reads:
     rowOverlayCamera, swOverlayCamera
     rowOverlayReplay, swOverlayReplay
     rowOverlayTrip,   swOverlayTrip
+    rowOverlayRoadSense, swOverlayRoadSense
 -->
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -217,6 +218,63 @@
 
                     <com.google.android.material.switchmaterial.SwitchMaterial
                         android:id="@+id/swOverlayTrip"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="true"
+                        android:focusable="true" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="@dimen/card_padding_standard"
+                    android:background="?attr/colorOutlineVariant"
+                    android:alpha="0.5" />
+
+                <!-- RoadSense pill / hazard card -->
+                <LinearLayout
+                    android:id="@+id/rowOverlayRoadSense"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_padding_standard">
+
+                    <ImageView
+                        android:layout_width="@dimen/card_icon_standard"
+                        android:layout_height="@dimen/card_icon_standard"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_roadsense"
+                        app:tint="?attr/colorPrimary" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_overlay_roadsense_title"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/settings_overlay_roadsense_subtitle"
+                            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/swOverlayRoadSense"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:clickable="true"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -632,11 +632,13 @@
     <string name="settings_section_privacy">Privacy &amp; data</string>
     <string name="settings_section_overlay">Status overlay</string>
     <string name="settings_section_security">Security</string>
-    <string name="settings_overlay_subtitle">Choose which segments of the floating status pill stay visible.</string>
+    <string name="settings_overlay_subtitle">Choose which floating status indicators stay visible.</string>
     <string name="settings_overlay_camera_title">Camera indicator</string>
     <string name="settings_overlay_camera_subtitle">Show the REC / PROX badge while recording is active.</string>
     <string name="settings_overlay_trip_title">Trip indicator</string>
     <string name="settings_overlay_trip_subtitle">Show the TRIP badge while trip detection is running.</string>
+    <string name="settings_overlay_roadsense_title">RoadSense overlay</string>
+    <string name="settings_overlay_roadsense_subtitle">Show the floating RoadSense pill and hazard card while RoadSense is enabled.</string>
     <!-- Was "About & updates" — Check for Updates row was removed from
          the About page, so the menu / rail label is now just "About". -->
     <string name="settings_section_about">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -876,13 +876,15 @@
     <string name="settings_section_privacy">Privacy &amp; data</string>
     <string name="settings_section_overlay">Status overlay</string>
     <string name="settings_section_security">Security</string>
-    <string name="settings_overlay_subtitle">Choose which segments of the floating status pill stay visible.</string>
+    <string name="settings_overlay_subtitle">Choose which floating status indicators stay visible.</string>
     <string name="settings_overlay_camera_title">Camera indicator</string>
     <string name="settings_overlay_camera_subtitle">Show the REC / PROX badge while recording is active.</string>
     <string name="settings_overlay_trip_title">Trip indicator</string>
     <string name="settings_overlay_trip_subtitle">Show the TRIP badge while trip detection is running.</string>
     <string name="settings_overlay_replay_title">Instant replay indicator</string>
     <string name="settings_overlay_replay_subtitle">Show the CLIP badge: green while a replay records, blue for 5s once saved, red when it fails. Appears only when a replay binding or automation exists.</string>
+    <string name="settings_overlay_roadsense_title">RoadSense overlay</string>
+    <string name="settings_overlay_roadsense_subtitle">Show the floating RoadSense pill and hazard card while RoadSense is enabled.</string>
     <!-- Was "About & updates" — Check for Updates row was removed from
          the About page, so the menu / rail label is now just "About". -->
     <string name="settings_section_about">About</string>

--- a/app/src/test/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayPolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/roadsense/overlay/RoadSenseOverlayPolicyTest.java
@@ -1,0 +1,29 @@
+package com.overdrive.app.roadsense.overlay;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RoadSenseOverlayPolicyTest {
+
+    @Test
+    public void enabledAndVisible_showsOverlay() {
+        assertTrue(RoadSenseOverlayPolicy.shouldShow(true, true));
+    }
+
+    @Test
+    public void masterDisabled_hidesOverlayEvenWhenPreferenceRemainsOn() {
+        assertFalse(RoadSenseOverlayPolicy.shouldShow(false, true));
+    }
+
+    @Test
+    public void visibilityDisabled_hidesOverlayWithoutDisablingRoadSense() {
+        assertFalse(RoadSenseOverlayPolicy.shouldShow(true, false));
+    }
+
+    @Test
+    public void bothDisabled_hidesOverlay() {
+        assertFalse(RoadSenseOverlayPolicy.shouldShow(false, false));
+    }
+}


### PR DESCRIPTION
## Summary

- Remove the floating RoadSense overlay and hazard card immediately when RoadSense is disabled.
- Keep overlay visibility subordinate to the RoadSense master switch.
- Expose the same persisted overlay preference in General Settings and Settings > Status overlay.
- Clarify the dependency in the settings copy.

## Why

The service, controller, keepalive path, WebView bridge, and settings screens could disagree about whether the overlay should remain visible.

## Impact

RoadSense can run without its overlay, but the overlay can never remain visible after RoadSense itself is disabled.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- RoadSense overlay policy is covered by unit tests.

## Visual evidence

RoadSense master switch:

![RoadSense master switch](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/188-roadsense-master-switch.png)

Status overlay:

![RoadSense status overlay](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/188-roadsense-status-overlay.png)