### PR TITLE
perf: load Live camera selector artwork immediately

### DIFF
--- a/app/src/main/assets/web/local/live-view.html
+++ b/app/src/main/assets/web/local/live-view.html
@@ -11,7 +11,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="theme-color" content="#00876C">
     <script src="../shared/theme.js?v=5"></script>
-    <script src="../shared/app-shell.js?v=2"></script>
+    <script src="../shared/app-shell.js?v=3"></script>
     <link rel="stylesheet" href="../shared/styles.css?v=18">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
@@ -154,6 +154,10 @@
                             <!-- Bottom Car Image Selector — flips to a right-rail in landscape -->
                             <div class="car-selector-bottom">
                                 <div class="car-image-container">
+                                    <img class="car-image-fallback"
+                                         src="../shared/car-icon.webp"
+                                         alt=""
+                                         aria-hidden="true">
                                     <canvas id="liveCarCanvas" class="car-image" aria-hidden="true"></canvas>
                                     
                                     <!-- Camera Hotspots with Pulse Animation -->
@@ -573,14 +577,39 @@
             pointer-events: none;
         }
         
+        .car-image-fallback,
         .car-image {
             width: 72px;
             height: 150px;
             display: block;
-            position: relative;
+        }
+
+        .car-image-fallback {
+            position: absolute;
+            inset: 0;
             z-index: 2;
+            object-fit: contain;
+            opacity: 0.72;
             filter: drop-shadow(0 8px 16px var(--lv-shadow-soft));
-            transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+            transition: opacity 0.18s ease;
+        }
+
+        .car-image {
+            position: relative;
+            z-index: 3;
+            opacity: 0;
+            filter: drop-shadow(0 8px 16px var(--lv-shadow-soft));
+            transition:
+                opacity 0.18s ease,
+                transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+
+        .car-image-container.vehicle-render-ready .car-image-fallback {
+            opacity: 0;
+        }
+
+        .car-image-container.vehicle-render-ready .car-image {
+            opacity: 1;
         }
         
         /* Camera Hotspots */
@@ -721,7 +750,7 @@
             .top-bar-btn { width: 34px; height: 34px; }
             .car-selector-bottom { padding: 10px; padding-bottom: calc(14px + 60px + var(--safe-bottom)); }
             .car-image-container { width: 60px; height: 125px; margin: 20px auto 30px auto; }
-            .car-image { width: 60px; height: 125px; }
+            .car-image-fallback, .car-image { width: 60px; height: 125px; }
             .cam-hotspot { width: 32px; height: 32px; }
             .hotspot-ring { width: 18px; height: 18px; }
             .hotspot-pulse { width: 18px; height: 18px; }
@@ -1654,7 +1683,13 @@
             if (!canvas) return;
             const shell = window.OverdriveAppShell;
             if (!shell || typeof shell.mountVehicleCanvas !== 'function') return;
-            shell.mountVehicleCanvas(canvas, { view: 'top' });
+            const container = canvas.parentElement;
+            shell.mountVehicleCanvas(canvas, {
+                view: 'top',
+                onReady: function () {
+                    if (container) container.classList.add('vehicle-render-ready');
+                }
+            });
         }
         // app-shell.js exposes mountVehicleCanvas after it renders the
         // sidebar and dispatches `app-shell:ready`. Listen for that

--- a/app/src/main/assets/web/shared/app-shell.js
+++ b/app/src/main/assets/web/shared/app-shell.js
@@ -610,6 +610,13 @@
     // share the same model/colour as the sidebar card and stay in sync
     // when the user changes their selection on vehicle-control.html.
     var auxEv3dInstances = [];
+    // Aux canvases can mount as soon as app-shell:ready fires, while the
+    // selected vehicle is still being fetched asynchronously. Treating
+    // that short "unknown selection" window as a sprite-cache miss forces
+    // every page visit through three.js + the full GLB, even when a cached
+    // sprite exists. Hold those mounts until setEvCardAppearance resolves
+    // either the saved selection or the normal fallback.
+    var vehicleSelectionWaiters = [];
     var FALLBACK_MODEL_ID = 'seal';
     var FALLBACK_MODEL_COLOR = '#E8E8EC';
 
@@ -701,6 +708,20 @@
                 continue;
             }
             applyToAux(aux, modelId, hexColor);
+        }
+
+        // Drain deferred aux mounts only after the existing aux iteration.
+        // A callback can add a sprite-only/live entry to auxEv3dInstances;
+        // deferring the drain avoids applying the same selection twice in
+        // this pass and issuing duplicate cache lookups.
+        if (modelId && hexColor && vehicleSelectionWaiters.length) {
+            var waiters = vehicleSelectionWaiters.slice();
+            vehicleSelectionWaiters = [];
+            for (var w = 0; w < waiters.length; w++) {
+                try { waiters[w](); } catch (e) {
+                    if (window.console) console.warn('[app-shell] deferred vehicle canvas mount failed:', e);
+                }
+            }
         }
 
         // If the user actually changed their selection (vehicle-control
@@ -957,6 +978,20 @@
         var view = 'side';
         if (opts && opts.view === 'top') view = 'top';
         else if (opts && opts.view === 'three-quarter') view = 'three-quarter';
+        var readyNotified = false;
+
+        // Surfaces may keep an inexpensive placeholder visible until this
+        // callback fires. A cache hit and the first complete WebGL render
+        // both count as ready; notify at most once for the initial mount.
+        function notifyReady(source) {
+            if (readyNotified) return;
+            readyNotified = true;
+            if (opts && typeof opts.onReady === 'function') {
+                try { opts.onReady({ source: source }); } catch (e) {
+                    if (window.console) console.warn('[app-shell] vehicle canvas onReady failed:', e);
+                }
+            }
+        }
 
         // Sprite-cache fast path. If we have a webp for this
         // (model, colour, view), paint the canvas in 2D and stop.
@@ -972,14 +1007,6 @@
             tryPaintFromSpriteCache(canvasEl, lastEv3dModel, lastEv3dColor, view, cb);
         }
 
-        // ensureEv3d() is the existing loader for the sidebar canvas; it
-        // injects ../shared/ev-card-3d.js on first call and is idempotent
-        // for subsequent ones. Calling it here guarantees the script tag
-        // is in flight even if the sidebar's #evCardCanvas isn't on this
-        // page (defensive — index.html does mount the sidebar so this
-        // path runs anyway, but keep the contract honest).
-        ensureEv3d();
-
         var instance = null;
         function instantiate() {
             if (instance) return instance;
@@ -990,6 +1017,7 @@
                 if (lastEv3dColor) instance.setColor(lastEv3dColor);
                 if (lastEv3dModel) instance.setModel(lastEv3dModel);
                 if (lastEv3dModel && lastEv3dColor) {
+                    instance.onceAfterRender(function () { notifyReady('render'); });
                     scheduleSpriteSnapshot(instance, canvasEl,
                                            lastEv3dModel, lastEv3dColor, view);
                 }
@@ -1051,29 +1079,40 @@
             instantiate();
         }
 
-        // Try cache first; on miss go straight to the live 3D mount.
-        tryCache(function (hit) {
-            if (hit) {
-                makeSpriteOnlyAux();
-                return;
-            }
-            if (typeof window.OverdriveEvCard3D === 'function') {
-                instantiate();
-                return;
-            }
-            // Vendor still in flight — poll for the global the same way
-            // ensureEv3d() does for its own canvas.
-            var tries = 0;
-            var iv = setInterval(function () {
-                tries++;
-                if (typeof window.OverdriveEvCard3D === 'function') {
-                    clearInterval(iv);
-                    instantiate();
-                } else if (tries > 80) {
-                    clearInterval(iv);
+        // Wait for vehicle selection, then try the cache before loading
+        // the renderer. This makes warm navigations a sprite-only path.
+        function mountResolvedSelection() {
+            tryCache(function (hit) {
+                if (hit) {
+                    makeSpriteOnlyAux();
+                    notifyReady('cache');
+                    return;
                 }
-            }, 100);
-        });
+                ensureEv3d();
+                if (typeof window.OverdriveEvCard3D === 'function') {
+                    instantiate();
+                    return;
+                }
+                // Vendor still in flight — poll for the global the same way
+                // ensureEv3d() does for its own canvas.
+                var tries = 0;
+                var iv = setInterval(function () {
+                    tries++;
+                    if (typeof window.OverdriveEvCard3D === 'function') {
+                        clearInterval(iv);
+                        instantiate();
+                    } else if (tries > 80) {
+                        clearInterval(iv);
+                    }
+                }, 100);
+            });
+        }
+
+        if (lastEv3dModel && lastEv3dColor) {
+            mountResolvedSelection();
+        } else {
+            vehicleSelectionWaiters.push(mountResolvedSelection);
+        }
 
         return null;
     };

--- a/app/src/main/assets/web/shared/app-shell.js
+++ b/app/src/main/assets/web/shared/app-shell.js
@@ -25,6 +25,14 @@
 (function () {
     'use strict';
 
+    // The Android app supplies its own navigation rail and injects
+    // AndroidBridge before the page starts loading. Its post-load CSS hides
+    // this web sidebar, so rendering the sidebar's 3D vehicle there wastes a
+    // full GLB parse and can race the visible aux canvas. Standalone/tunnel
+    // pages have no bridge and keep the normal sidebar renderer.
+    var embeddedInNativeApp =
+        typeof window.AndroidBridge !== 'undefined';
+
     /*
      * Sidebar nav layout MIRRORS rail_menu.xml exactly:
      *   Dashboard → Live → Recordings → Vehicle → Trips → Integrations cluster →
@@ -523,6 +531,10 @@
         function instantiate() {
             if (ev3dInstance) return;
             if (typeof window.OverdriveEvCard3D !== 'function') return;
+            // The native shell hides #sidebar after page load. The script may
+            // still be needed by a visible aux canvas, but never bind WebGL
+            // to the hidden sidebar canvas in that environment.
+            if (embeddedInNativeApp) return;
             try {
                 ev3dInstance = new window.OverdriveEvCard3D(canvas);
                 // Replay the most recent (model, colour) pair. SOC +
@@ -633,7 +645,9 @@
         // injects the 3D pipeline on a miss, so subsequent page loads
         // paint the EV card from a ~30KB webp instead of a 600KB
         // three.js + 1.6MB GLB cold parse.
-        var sidebarCanvas = document.getElementById('evCardCanvas');
+        var sidebarCanvas = embeddedInNativeApp
+            ? null
+            : document.getElementById('evCardCanvas');
         if (sidebarCanvas && modelId && hexColor) {
             tryPaintFromSpriteCache(sidebarCanvas, modelId, hexColor, 'side', function (hit) {
                 if (hit) {
@@ -684,7 +698,7 @@
                     pendingSidebarSnapshot = { modelId: modelId, color: hexColor };
                 }
             });
-        } else {
+        } else if (!embeddedInNativeApp) {
             // Fallback for callers that don't have the canvas or only
             // have one of (model, colour) — preserve the original
             // behaviour so login.html and friends still work.

--- a/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
@@ -1,0 +1,62 @@
+package com.overdrive.app.camera;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+public class LiveCameraSelectorLoadingAssetTest {
+
+    @Test
+    public void liveSelectorShowsImmediateFallbackUntilVehicleRenderIsReady() throws Exception {
+        String liveView = readWebAsset("local/live-view.html");
+
+        assertTrue(liveView.contains("class=\"car-image-fallback\""));
+        assertTrue(liveView.contains("src=\"../shared/car-icon.webp\""));
+        assertTrue(liveView.contains("onReady: function ()"));
+        assertTrue(liveView.contains("classList.add('vehicle-render-ready')"));
+    }
+
+    @Test
+    public void auxiliaryCanvasWaitsForSelectionBeforeCheckingSpriteCache() throws Exception {
+        String appShell = readWebAsset("shared/app-shell.js");
+        int mountStart = appShell.indexOf(
+                "window.OverdriveAppShell.mountVehicleCanvas");
+        int resolvedMount = appShell.indexOf(
+                "function mountResolvedSelection()", mountStart);
+        int cacheCheck = appShell.indexOf(
+                "tryCache(function (hit) {", resolvedMount);
+        int threeLoader = appShell.indexOf("ensureEv3d();", cacheCheck);
+        int selectionGate = appShell.indexOf(
+                "if (lastEv3dModel && lastEv3dColor) {", resolvedMount);
+
+        assertTrue("resolved-selection mount must be present", resolvedMount > mountStart);
+        assertTrue("cache check must run inside resolved-selection mount", cacheCheck > resolvedMount);
+        assertTrue("3D loader must start only after a cache miss", threeLoader > cacheCheck);
+        assertTrue("selection gate must wrap the resolved mount", selectionGate > threeLoader);
+
+        String eagerLoaderBlock = appShell.substring(mountStart, resolvedMount);
+        assertFalse("mount must not eagerly start the 3D loader",
+                eagerLoaderBlock.contains("ensureEv3d();"));
+    }
+
+    private static String readWebAsset(String relativePath) throws IOException {
+        Path current = Paths.get("").toAbsolutePath();
+        Path fromModule = current.resolve("src/main/assets/web").resolve(relativePath);
+        if (Files.exists(fromModule)) {
+            return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+        }
+
+        Path fromRepository = current.resolve("app/src/main/assets/web").resolve(relativePath);
+        if (Files.exists(fromRepository)) {
+            return new String(Files.readAllBytes(fromRepository), StandardCharsets.UTF_8);
+        }
+
+        throw new AssertionError("Could not locate web asset: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
@@ -52,9 +52,9 @@ public class LiveCameraSelectorLoadingAssetTest {
         assertTrue(appShell.contains(
                 "typeof window.AndroidBridge !== 'undefined'"));
         assertTrue(appShell.contains(
-                "var sidebarCanvas = embeddedInNativeApp\n"
-                        + "            ? null\n"
-                        + "            : document.getElementById('evCardCanvas');"));
+                "var sidebarCanvas = embeddedInNativeApp"));
+        assertTrue(appShell.contains(
+                ": document.getElementById('evCardCanvas');"));
         assertTrue(appShell.contains(
                 "if (embeddedInNativeApp) return;"));
         assertTrue(appShell.contains(

--- a/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorLoadingAssetTest.java
@@ -45,6 +45,22 @@ public class LiveCameraSelectorLoadingAssetTest {
                 eagerLoaderBlock.contains("ensureEv3d();"));
     }
 
+    @Test
+    public void embeddedAppDoesNotRenderTheHiddenWebSidebarVehicle() throws Exception {
+        String appShell = readWebAsset("shared/app-shell.js");
+
+        assertTrue(appShell.contains(
+                "typeof window.AndroidBridge !== 'undefined'"));
+        assertTrue(appShell.contains(
+                "var sidebarCanvas = embeddedInNativeApp\n"
+                        + "            ? null\n"
+                        + "            : document.getElementById('evCardCanvas');"));
+        assertTrue(appShell.contains(
+                "if (embeddedInNativeApp) return;"));
+        assertTrue(appShell.contains(
+                "} else if (!embeddedInNativeApp) {"));
+    }
+
     private static String readWebAsset(String relativePath) throws IOException {
         Path current = Paths.get("").toAbsolutePath();
         Path fromModule = current.resolve("src/main/assets/web").resolve(relativePath);


### PR DESCRIPTION
## Summary

- Show the existing static vehicle artwork immediately in the camera selector.
- Load the 3D selector only as a progressive enhancement after vehicle resolution.
- Avoid loading Three.js when cached renderer assets are unavailable.
- Skip the hidden web-sidebar vehicle renderer inside the Android app shell.

## Why

The small selector reused the full 3D renderer, producing a blank/loading state and unnecessary GPU work in the older in-car WebView.

## Impact

The camera targets are available immediately and the hidden renderer no longer consumes resources.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Asset and platform line-ending contracts are covered by tests.

## Visual evidence

![Immediate camera selector artwork](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/191-selector-immediate-artwork.png)