### PR TITLE
fix: restore the selected Live camera after app resume

### DIFF
--- a/app/src/main/assets/web/shared/stream.js
+++ b/app/src/main/assets/web/shared/stream.js
@@ -40,6 +40,11 @@ BYD.stream = {
     latencyCheckInterval: null,
     streamStarted: false,
     selectedQuality: 'MEDIUM',
+    // A stream paused because the app was backgrounded should resume the
+    // same camera. Manual stops intentionally clear this state.
+    _backgroundResumeMode: null,
+    _backgroundResumeTimer: null,
+    _backgroundResumeInFlight: false,
     
     // WebSocket connects to /ws on same port as HTTP server (optimized endpoint)
     // Old raw stream port 8887 is deprecated - bypasses SOTA optimizations
@@ -682,7 +687,16 @@ BYD.stream = {
     /**
      * Stop streaming
      */
-    stopStream() {
+    stopStream(options) {
+        const preserveBackgroundResume = options && options.preserveBackgroundResume === true;
+        if (!preserveBackgroundResume) {
+            this._backgroundResumeMode = null;
+            if (this._backgroundResumeTimer) {
+                clearTimeout(this._backgroundResumeTimer);
+                this._backgroundResumeTimer = null;
+            }
+        }
+
         this.streamStarted = false;
         
         if (this.reconnectTimer) {
@@ -726,6 +740,68 @@ BYD.stream = {
         
         this.decoderMode = null;
         console.log('[Stream] Stopped');
+    },
+
+    /**
+     * Pause an active stream while preserving enough intent to restore the
+     * same camera when Android brings the WebView back to the foreground.
+     */
+    pauseForBackground() {
+        if (!this.streamStarted || this.currentViewMode < 0) return;
+
+        const mode = this.currentViewMode;
+        console.log('[Stream] Backgrounded - pausing camera:', mode);
+        this.stopStream({ preserveBackgroundResume: true });
+        this._backgroundResumeMode = mode;
+
+        // Do not leave a stale "Live" badge over the blank decoder while the
+        // WebView is being restored.
+        this.updateStreamStatus(BYD.i18n.t('stream.connecting'), false);
+    },
+
+    /**
+     * Resume a lifecycle-paused stream. Android onResume and the Page
+     * Visibility API can both signal the foreground transition, so the short
+     * timer and in-flight guard ensure only one decoder/socket is created.
+     */
+    resumeAfterBackground(forceForeground) {
+        const foregroundIsAuthoritative = forceForeground === true;
+        if (foregroundIsAuthoritative && this._backgroundResumeTimer) {
+            clearTimeout(this._backgroundResumeTimer);
+            this._backgroundResumeTimer = null;
+        }
+        if (this._backgroundResumeMode === null ||
+            this._backgroundResumeMode < 0 ||
+            this.streamStarted ||
+            this._backgroundResumeInFlight ||
+            this._backgroundResumeTimer) {
+            return;
+        }
+
+        this._backgroundResumeTimer = setTimeout(async () => {
+            this._backgroundResumeTimer = null;
+            if ((!foregroundIsAuthoritative && document.hidden) ||
+                this._backgroundResumeMode === null ||
+                this.streamStarted ||
+                this._backgroundResumeInFlight) {
+                return;
+            }
+
+            const mode = this._backgroundResumeMode;
+            this._backgroundResumeMode = null;
+            this._backgroundResumeInFlight = true;
+            console.log('[Stream] Foregrounded - resuming camera:', mode);
+            try {
+                await this.selectCamera(mode);
+            } catch (e) {
+                console.error('[Stream] Resume failed:', e);
+                if (!document.hidden && !this.streamStarted) {
+                    this._backgroundResumeMode = mode;
+                }
+            } finally {
+                this._backgroundResumeInFlight = false;
+            }
+        }, 250);
     },
     
     /**
@@ -869,11 +945,13 @@ BYD.stream = {
         
         // Status polling is handled by core.js - no duplicate polling here
         
-        // Page Visibility API
+        // Pause expensive decoding in the background and restore the same
+        // selection when the page becomes visible again.
         document.addEventListener("visibilitychange", () => {
-            if (document.hidden && this.streamStarted) {
-                console.log("[Stream] Backgrounded - pausing");
-                this.stopStream();
+            if (document.hidden) {
+                this.pauseForBackground();
+            } else {
+                this.resumeAfterBackground();
             }
         });
         

--- a/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
@@ -1455,6 +1455,15 @@ class WebViewFragment : Fragment() {
         // Re-apply theme on resume so a user toggle while the page was
         // backgrounded is reflected without requiring a full reload.
         webView?.let { it.evaluateJavascript(buildThemeInjectJs(), null) }
+        // Android WebView versions used by older BYD head units do not always
+        // deliver a reliable visible-side Page Visibility event. Give pages an
+        // explicit lifecycle signal as well; stream.js deduplicates this with
+        // visibilitychange so only one decoder/socket is created.
+        webView?.evaluateJavascript(
+            "(function(){if(window.BYD&&BYD.stream&&BYD.stream.resumeAfterBackground){" +
+                "BYD.stream.resumeAfterBackground(true);}})();",
+            null
+        )
     }
 
     /**

--- a/app/src/test/java/com/overdrive/app/camera/LiveViewBackgroundResumeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveViewBackgroundResumeAssetTest.java
@@ -1,0 +1,62 @@
+package com.overdrive.app.camera;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/**
+ * Guards the WebView lifecycle contract for Live camera streaming.
+ */
+public class LiveViewBackgroundResumeAssetTest {
+
+    @Test
+    public void visibilityLifecyclePreservesAndRestoresSelectedCamera() throws IOException {
+        String stream = readRepositoryFile("app/src/main/assets/web/shared/stream.js");
+
+        assertTrue(stream.contains("pauseForBackground()"));
+        assertTrue(stream.contains("this.stopStream({ preserveBackgroundResume: true })"));
+        assertTrue(stream.contains("this._backgroundResumeMode = mode"));
+        assertTrue(stream.contains("resumeAfterBackground()"));
+        assertTrue(stream.contains("await this.selectCamera(mode)"));
+        assertTrue(stream.contains("if (document.hidden)"));
+        assertTrue(stream.contains("this.pauseForBackground()"));
+        assertTrue(stream.contains("this.resumeAfterBackground()"));
+    }
+
+    @Test
+    public void manualStopClearsPendingLifecycleResume() throws IOException {
+        String stream = readRepositoryFile("app/src/main/assets/web/shared/stream.js");
+
+        assertTrue(stream.contains(
+            "const preserveBackgroundResume = options && options.preserveBackgroundResume === true"));
+        assertTrue(stream.contains("if (!preserveBackgroundResume)"));
+        assertTrue(stream.contains("this._backgroundResumeMode = null"));
+        assertTrue(stream.contains("clearTimeout(this._backgroundResumeTimer)"));
+    }
+
+    @Test
+    public void androidResumeSignalsStreamFallback() throws IOException {
+        String fragment = readRepositoryFile(
+            "app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt");
+
+        assertTrue(fragment.contains("BYD.stream.resumeAfterBackground(true)"));
+        assertTrue(fragment.contains("webView?.onResume()"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get("").toAbsolutePath();
+        for (int i = 0; i < 6 && current != null; i++) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve the selected camera mode when Live is paused.
- Reselect and reconnect that mode when the app returns to the foreground.
- Clear pending automatic resumes after a manual stop.
- Use visibility events plus the Android onResume signal as a fallback.

## Why

The WebView and native activity lifecycle could pause the stream without issuing a matching reconnect, leaving a black Live screen after backgrounding.

## Impact

Returning to OverDrive restores the same selected camera instead of requiring manual recovery.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Verified on a 2024 BYD Atto 3 running firmware 2602: backgrounding and returning to OverDrive restored the selected mode and decoded Live frames.