### PR TITLE
fix: improve Live camera selector contrast

### DIFF
--- a/app/src/main/assets/web/local/live-view.html
+++ b/app/src/main/assets/web/local/live-view.html
@@ -233,8 +233,16 @@
             --lv-quality-option-color: #ffffff;
             --lv-idle-icon-bg: rgba(255,255,255,0.03);
             --lv-idle-icon-border: rgba(255,255,255,0.06);
-            --lv-hotspot-ring-border: rgba(255,255,255,0.4);
-            --lv-hotspot-ring-bg: rgba(255,255,255,0.08);
+            /* Camera controls sit over user-selected vehicle paint, so their
+               contrast must not depend on either paint colour or app theme.
+               A light edge + dark halo remains visible on white and black. */
+            --lv-hotspot-ring-border: rgba(255,255,255,0.96);
+            --lv-hotspot-ring-bg: rgba(5,10,12,0.82);
+            --lv-hotspot-ring-halo: rgba(0,0,0,0.88);
+            --lv-hotspot-label-bg: rgba(5,9,12,0.92);
+            --lv-hotspot-label-border: rgba(255,255,255,0.24);
+            --lv-hotspot-label-text: #ffffff;
+            --lv-hotspot-active-text: #72f4d9;
             --lv-floor-spotlight: rgba(255,255,255,0.12);
             --lv-shadow-strong: rgba(0,0,0,0.6);
             --lv-shadow-soft: rgba(0,0,0,0.7);
@@ -265,8 +273,6 @@
             --lv-quality-option-color: #181C1A;
             --lv-idle-icon-bg: rgba(0,0,0,0.04);
             --lv-idle-icon-border: rgba(0,0,0,0.08);
-            --lv-hotspot-ring-border: rgba(24,28,26,0.45);
-            --lv-hotspot-ring-bg: rgba(24,28,26,0.06);
             --lv-floor-spotlight: rgba(0,0,0,0.10);
             --lv-shadow-strong: rgba(0,0,0,0.18);
             --lv-shadow-soft: rgba(0,0,0,0.22);
@@ -612,16 +618,20 @@
         .cam-hotspot[data-cam="6"] { top: 18px; left: 62%; transform: translateX(-50%); }
         
         .hotspot-ring {
-            width: 20px; height: 20px;
+            width: 22px; height: 22px;
+            box-sizing: border-box;
             border: 2px solid var(--lv-hotspot-ring-border);
             border-radius: 50%;
             background: var(--lv-hotspot-ring-bg);
+            box-shadow:
+                0 0 0 2px var(--lv-hotspot-ring-halo),
+                0 2px 6px rgba(0,0,0,0.72);
             transition: all 0.3s;
         }
         
         .hotspot-pulse {
             position: absolute;
-            width: 20px; height: 20px;
+            width: 22px; height: 22px;
             border-radius: 50%;
             background: transparent;
             pointer-events: none;
@@ -630,25 +640,31 @@
         /* Labels positioned outside hotspots */
         .hotspot-label {
             position: absolute;
-            font-size: 10px;
-            font-weight: 700;
+            font-size: 11px;
+            line-height: 1;
+            font-weight: 800;
             letter-spacing: 0.08em;
-            color: var(--lv-overlay-text);
-            text-shadow: var(--lv-overlay-shadow);
+            color: var(--lv-hotspot-label-text);
+            background: var(--lv-hotspot-label-bg);
+            border: 1px solid var(--lv-hotspot-label-border);
+            border-radius: 999px;
+            padding: 4px 6px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.62);
+            text-shadow: none;
             white-space: nowrap;
             transition: all 0.3s;
         }
         
         /* Front label - above */
-        .cam-hotspot[data-cam="1"] .hotspot-label { top: -20px; left: 50%; transform: translateX(-50%); bottom: auto; }
+        .cam-hotspot[data-cam="1"] .hotspot-label { bottom: calc(100% + 2px); left: 50%; transform: translateX(-50%); top: auto; }
         /* Rear label - below with more clearance */
-        .cam-hotspot[data-cam="3"] .hotspot-label { bottom: -22px; left: 50%; transform: translateX(-50%); top: auto; }
+        .cam-hotspot[data-cam="3"] .hotspot-label { top: calc(100% + 2px); left: 50%; transform: translateX(-50%); bottom: auto; }
         /* Left label - to the left */
-        .cam-hotspot[data-cam="4"] .hotspot-label { left: -36px; top: 50%; transform: translateY(-50%); bottom: auto; }
+        .cam-hotspot[data-cam="4"] .hotspot-label { right: calc(100% + 4px); left: auto; top: 50%; transform: translateY(-50%); bottom: auto; }
         /* Right label - to the right */
-        .cam-hotspot[data-cam="2"] .hotspot-label { right: -40px; left: auto; top: 50%; transform: translateY(-50%); bottom: auto; }
+        .cam-hotspot[data-cam="2"] .hotspot-label { left: calc(100% + 4px); right: auto; top: 50%; transform: translateY(-50%); bottom: auto; }
         /* All label - below center */
-        .cam-hotspot.cam-all .hotspot-label { bottom: -20px; left: 50%; transform: translateX(-50%); top: auto; }
+        .cam-hotspot.cam-all .hotspot-label { top: calc(50% + 14px); left: 50%; transform: translateX(-50%); bottom: auto; }
         /* OEM Dashcam label — anchored to the right of the ring so it
            floats outside the car silhouette and never overlaps the FRONT
            label that sits directly above the centre column. */
@@ -661,17 +677,22 @@
         
         .cam-hotspot:hover .hotspot-ring {
             border-color: var(--brand-primary);
-            background: rgba(0,212,170,0.15);
-            box-shadow: 0 0 20px rgba(0,212,170,0.3);
+            background: rgba(0,42,36,0.9);
+            box-shadow:
+                0 0 0 2px var(--lv-hotspot-ring-halo),
+                0 0 0 4px rgba(0,212,170,0.2),
+                0 0 16px rgba(0,212,170,0.42);
         }
         
-        .cam-hotspot:hover .hotspot-label { color: var(--brand-primary); }
+        .cam-hotspot:hover .hotspot-label {
+            color: var(--lv-hotspot-active-text);
+            border-color: rgba(0,212,170,0.62);
+        }
         
         /* Active State with Animation */
         .cam-hotspot.active .hotspot-ring {
             border-color: var(--brand-primary);
-            background: rgba(0,212,170,0.25);
-            box-shadow: 0 0 25px rgba(0,212,170,0.5);
+            background: rgba(0,48,40,0.94);
             animation: ringPulse 2s ease-in-out infinite;
         }
         
@@ -681,8 +702,12 @@
         }
         
         .cam-hotspot.active .hotspot-label {
-            color: var(--brand-primary);
-            text-shadow: 0 0 10px rgba(0,212,170,0.5);
+            color: var(--lv-hotspot-active-text);
+            background: rgba(0,35,31,0.96);
+            border-color: rgba(0,212,170,0.72);
+            box-shadow:
+                0 2px 6px rgba(0,0,0,0.68),
+                0 0 8px rgba(0,212,170,0.28);
         }
         
         @keyframes hotspotPulse {
@@ -691,8 +716,18 @@
         }
         
         @keyframes ringPulse {
-            0%, 100% { box-shadow: 0 0 20px rgba(0,212,170,0.4); }
-            50% { box-shadow: 0 0 35px rgba(0,212,170,0.7); }
+            0%, 100% {
+                box-shadow:
+                    0 0 0 2px var(--lv-hotspot-ring-halo),
+                    0 0 0 4px rgba(0,212,170,0.2),
+                    0 0 12px rgba(0,212,170,0.42);
+            }
+            50% {
+                box-shadow:
+                    0 0 0 2px var(--lv-hotspot-ring-halo),
+                    0 0 0 5px rgba(0,212,170,0.28),
+                    0 0 20px rgba(0,212,170,0.68);
+            }
         }
         
         /* Fullscreen */
@@ -723,9 +758,9 @@
             .car-image-container { width: 60px; height: 125px; margin: 20px auto 30px auto; }
             .car-image { width: 60px; height: 125px; }
             .cam-hotspot { width: 32px; height: 32px; }
-            .hotspot-ring { width: 18px; height: 18px; }
-            .hotspot-pulse { width: 18px; height: 18px; }
-            .hotspot-label { font-size: 9px; }
+            .hotspot-ring { width: 20px; height: 20px; }
+            .hotspot-pulse { width: 20px; height: 20px; }
+            .hotspot-label { font-size: 9px; padding: 3px 5px; }
             /* DVR sits a touch closer to FRONT on the smaller silhouette. */
             .cam-hotspot[data-cam="6"] { top: 14px; left: 62%; }
             .idle-icon { width: 48px; height: 48px; }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
@@ -234,14 +234,18 @@ class WebViewFragment : Fragment() {
         '[data-app-shell="1"] #panelMap .map-overlay-actions { top: 14px !important; right: 14px !important; gap: 10px !important; }',
         '[data-app-shell="1"] .btn-map-float { width: 44px !important; height: 44px !important; }',
         '[data-app-shell="1"] .btn-map-float svg { width: 20px !important; height: 20px !important; }',
-        // Camera hotspot labels — clamp width and slightly shrink the
-        // negative offsets so labels don't clip the .seamless-camera-view
-        // when the WebView is in landscape windowed mode.
+        // Camera hotspot labels — keep a generous translated-label clamp,
+        // but preserve the page's paint-independent pill size and opposing
+        // left/right anchors. The former negative-offset rules set both
+        // horizontal edges after the page moved to right:/left: anchoring,
+        // squeezing LEFT/RIGHT down to an ellipsis on the head unit.
         '[data-app-shell="1"] .cam-hotspot .hotspot-label {',
-        '   max-width: 64px; white-space: nowrap; overflow: hidden;',
-        '   text-overflow: ellipsis; padding: 3px 7px; font-size: 9px; }',
-        '[data-app-shell="1"] .cam-hotspot[data-cam="4"] .hotspot-label { left: -34px !important; }',
-        '[data-app-shell="1"] .cam-hotspot[data-cam="2"] .hotspot-label { right: -34px !important; }',
+        '   max-width: 74px; white-space: nowrap; overflow: hidden;',
+        '   text-overflow: ellipsis; padding: 4px 6px; font-size: 11px; }',
+        '[data-app-shell="1"] .cam-hotspot[data-cam="4"] .hotspot-label {',
+        '   left: auto !important; right: calc(100% + 4px) !important; }',
+        '[data-app-shell="1"] .cam-hotspot[data-cam="2"] .hotspot-label {',
+        '   right: auto !important; left: calc(100% + 4px) !important; }',
 
         // === Page-specific carry-overs (kept from previous behaviour) ===
         '#safeLocMap { z-index: 1 !important; position: relative !important; overflow: hidden !important; }',

--- a/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorContrastAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorContrastAssetTest.java
@@ -52,6 +52,25 @@ public class LiveCameraSelectorContrastAssetTest {
         assertTrue(liveView.contains("color: var(--lv-hotspot-active-text)"));
     }
 
+    @Test
+    public void appShellKeepsReadableSizeAndOpposingSideAnchors() throws IOException {
+        String fragment = readRepositoryFile(
+            "app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt");
+
+        assertTrue(fragment.contains(
+            "max-width: 74px; white-space: nowrap; overflow: hidden;"));
+        assertTrue(fragment.contains(
+            "text-overflow: ellipsis; padding: 4px 6px; font-size: 11px;"));
+        assertTrue(fragment.contains(
+            "left: auto !important; right: calc(100% + 4px) !important;"));
+        assertTrue(fragment.contains(
+            "right: auto !important; left: calc(100% + 4px) !important;"));
+        assertFalse(fragment.contains(
+            ".cam-hotspot[data-cam=\"4\"] .hotspot-label { left: -34px"));
+        assertFalse(fragment.contains(
+            ".cam-hotspot[data-cam=\"2\"] .hotspot-label { right: -34px"));
+    }
+
     private static String between(String value, String start, String end) {
         int startIndex = value.indexOf(start);
         int endIndex = value.indexOf(end, startIndex + start.length());

--- a/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorContrastAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/LiveCameraSelectorContrastAssetTest.java
@@ -1,0 +1,74 @@
+package com.overdrive.app.camera;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/**
+ * Guards the paint-independent contrast treatment used by the Live selector.
+ */
+public class LiveCameraSelectorContrastAssetTest {
+
+    @Test
+    public void ringsUseLightEdgeDarkFillAndDarkHalo() throws IOException {
+        String liveView = readRepositoryFile(
+            "app/src/main/assets/web/local/live-view.html");
+
+        assertTrue(liveView.contains(
+            "--lv-hotspot-ring-border: rgba(255,255,255,0.96)"));
+        assertTrue(liveView.contains(
+            "--lv-hotspot-ring-bg: rgba(5,10,12,0.82)"));
+        assertTrue(liveView.contains(
+            "--lv-hotspot-ring-halo: rgba(0,0,0,0.88)"));
+        assertTrue(liveView.contains(
+            "0 0 0 2px var(--lv-hotspot-ring-halo)"));
+
+        // Light theme must not replace the paint-independent ring tokens.
+        String lightTheme = between(
+            liveView,
+            ":root[data-theme=\"light\"] .live-view-page {",
+            "/* SOTA Seamless Camera View */");
+        assertFalse(lightTheme.contains("--lv-hotspot-ring-border"));
+        assertFalse(lightTheme.contains("--lv-hotspot-ring-bg"));
+    }
+
+    @Test
+    public void labelsHaveTheirOwnHighContrastSurface() throws IOException {
+        String liveView = readRepositoryFile(
+            "app/src/main/assets/web/local/live-view.html");
+
+        assertTrue(liveView.contains("--lv-hotspot-label-bg: rgba(5,9,12,0.92)"));
+        assertTrue(liveView.contains("--lv-hotspot-label-text: #ffffff"));
+        assertTrue(liveView.contains("background: var(--lv-hotspot-label-bg)"));
+        assertTrue(liveView.contains("border: 1px solid var(--lv-hotspot-label-border)"));
+        assertTrue(liveView.contains("border-radius: 999px"));
+        assertTrue(liveView.contains("font-size: 11px"));
+        assertTrue(liveView.contains("color: var(--lv-hotspot-active-text)"));
+    }
+
+    private static String between(String value, String start, String end) {
+        int startIndex = value.indexOf(start);
+        int endIndex = value.indexOf(end, startIndex + start.length());
+        assertTrue("Missing start marker", startIndex >= 0);
+        assertTrue("Missing end marker", endIndex > startIndex);
+        return value.substring(startIndex, endIndex);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get("").toAbsolutePath();
+        for (int i = 0; i < 6 && current != null; i++) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Give camera hotspots a light edge, dark translucent fill, and dark halo.
- Put labels in high-contrast dark pills with white text.
- Preserve readable left/right label sizing and anchors in the Android app shell.

## Why

Camera targets and labels disappeared or collapsed over white and other light vehicle paint colours.

## Impact

Every camera target remains readable regardless of model paint or the older WebView CSS path.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Paint-independent contrast and app-shell label contracts are covered by tests.

## Visual evidence

![Improved selector contrast](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/193-selector-contrast.png)