### PR TITLE
fix(ui): unify compact status indicator spacing

### DIFF
--- a/app/src/main/assets/web/local/live-view.html
+++ b/app/src/main/assets/web/local/live-view.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#00876C">
     <script src="../shared/theme.js?v=5"></script>
     <script src="../shared/app-shell.js?v=2"></script>
-    <link rel="stylesheet" href="../shared/styles.css?v=18">
+    <link rel="stylesheet" href="../shared/styles.css?v=19">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../shared/leaflet.css" />
@@ -77,8 +77,8 @@
                             <!-- Top Bar -->
                             <div class="camera-top-bar">
                                 <div class="top-bar-left">
-                                    <div class="connection-status" id="connectionStatus">
-                                        <span class="conn-dot"></span>
+                                    <div class="connection-status compact-status-pill" id="connectionStatus">
+                                        <span class="conn-dot compact-status-pill__dot"></span>
                                         <span class="status-text" data-i18n="pip.select_camera">Select Camera</span>
                                     </div>
                                     <div class="decoder-chip" id="decoderChip" style="display:none;">GPU</div>
@@ -300,7 +300,6 @@
         .connection-status {
             display: inline-flex;
             align-items: center;
-            gap: 10px;
             padding: 8px 16px;
             background: var(--lv-pill-bg);
             backdrop-filter: blur(20px);

--- a/app/src/main/assets/web/local/performance.html
+++ b/app/src/main/assets/web/local/performance.html
@@ -27,7 +27,7 @@
         ];
     </script>
     <script src="../shared/app-tabs.js"></script>
-    <link rel="stylesheet" href="../shared/styles.css?v=18">
+    <link rel="stylesheet" href="../shared/styles.css?v=19">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
     <style>
@@ -274,7 +274,6 @@
         .monitoring-status {
             display: flex;
             align-items: center;
-            gap: 8px;
             padding: 8px 16px;
             background: var(--bg-elevated);
             border-radius: var(--radius-full);
@@ -526,8 +525,8 @@
             <header class="page-header">
                 <h1 class="page-title" data-i18n="performance.page_title">Performance Monitor</h1>
                 <div class="header-actions">
-                    <div class="monitoring-status">
-                        <span class="monitoring-dot" id="monitoringDot"></span>
+                    <div class="monitoring-status compact-status-pill">
+                        <span class="monitoring-dot compact-status-pill__dot" id="monitoringDot"></span>
                         <span id="monitoringText" data-i18n="performance.monitoring">Monitoring</span>
                     </div>
                     <div class="header-badge">

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#00876C">
     <script src="../shared/theme.js?v=5"></script>
     <script src="../shared/app-shell.js?v=2"></script>
-    <link rel="stylesheet" href="../shared/styles.css?v=18">
+    <link rel="stylesheet" href="../shared/styles.css?v=19">
     <link rel="stylesheet" href="../shared/vehicle-control.css?v=15">
     <!-- Web fonts loaded async + non-blocking. WebView falls back to system sans-serif if offline. -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" media="print" onload="this.media='all'">
@@ -45,11 +45,11 @@
 
                     <!-- Floating status — row 1: connection state pills only -->
                     <div class="vc-status-bar">
-                        <div class="vc-pill">
-                            <span class="dot green"></span><span id="lockStatus" data-i18n="vehicle.locked">Locked</span>
+                        <div class="vc-pill compact-status-pill">
+                            <span class="dot green compact-status-pill__dot"></span><span id="lockStatus" data-i18n="vehicle.locked">Locked</span>
                         </div>
-                        <div class="vc-pill" id="cloudStatus">
-                            <span class="dot amber"></span><span id="cloudStatusText" data-i18n="vehicle.checking">Checking...</span>
+                        <div class="vc-pill compact-status-pill" id="cloudStatus">
+                            <span class="dot amber compact-status-pill__dot"></span><span id="cloudStatusText" data-i18n="vehicle.checking">Checking...</span>
                         </div>
                     </div>
                     <!-- Floating status — row 2: vehicle appearance controls.

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -531,7 +531,7 @@
     <script src="../shared/vendor/GLTFLoader.js?v=12"></script>
     <script src="../shared/vendor/OrbitControls.js?v=12"></script>
     <script src="../shared/vendor/gsap.min.js?v=12"></script>
-    <script src="../shared/vehicle-control.js?v=19"></script>
+    <script src="../shared/vehicle-control.js?v=20"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/shared/styles.css
+++ b/app/src/main/assets/web/shared/styles.css
@@ -447,6 +447,29 @@ input, select { font-family: inherit; }
     animation: none;
 }
 
+/* Compact status pills (for example Live, vehicle lock, and monitoring).
+   Android System WebView 58 does not support flex `gap`, so the dot owns the
+   spacing. Keep that compatibility detail here instead of reimplementing it
+   in every page-specific pill. */
+.compact-status-pill {
+    display: -webkit-inline-flex;
+    display: inline-flex;
+    -webkit-align-items: center;
+    align-items: center;
+}
+
+.compact-status-pill > .compact-status-pill__dot {
+    display: inline-block;
+    -webkit-flex: 0 0 auto;
+    flex: 0 0 auto;
+    margin-right: 6px;
+}
+
+[dir="rtl"] .compact-status-pill > .compact-status-pill__dot {
+    margin-right: 0;
+    margin-left: 6px;
+}
+
 @keyframes pulse {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }

--- a/app/src/main/assets/web/shared/vehicle-control.css
+++ b/app/src/main/assets/web/shared/vehicle-control.css
@@ -133,7 +133,7 @@
     border-radius: 20px; padding: 5px 12px; font-size: 11px; font-weight: 500; color: var(--vc-text-primary);
     white-space: nowrap; -webkit-flex-shrink: 0; flex-shrink: 0;
 }
-.vc-pill .dot { width: 6px; height: 6px; border-radius: 50%; margin-right: 6px; }
+.vc-pill .dot { width: 6px; height: 6px; border-radius: 50%; }
 .dot.green { background: #22C55E; box-shadow: 0 0 5px #22C55E; }
 .dot.red { background: #EF4444; box-shadow: 0 0 5px #EF4444; }
 .dot.amber { background: #F59E0B; box-shadow: 0 0 5px #F59E0B; }

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -2324,7 +2324,8 @@ var VC = {
             lockStatus.textContent = locked === true ? BYD.i18n.t('vehicle.locked') : (locked === false ? BYD.i18n.t('vehicle.unlocked') : BYD.i18n.t('common.unknown'));
             var dot = lockStatus.previousElementSibling;
             if (dot) {
-                dot.className = 'dot ' + (locked === true ? 'green' : (locked === false ? 'amber' : 'grey'));
+                dot.className = 'dot compact-status-pill__dot ' +
+                    (locked === true ? 'green' : (locked === false ? 'amber' : 'grey'));
             }
         }
     },
@@ -2497,10 +2498,10 @@ var VC = {
         if (!pillEl) return;
         var dot = pillEl.querySelector('.dot');
         if (this.vehicleState.cloudConfigured) {
-            if (dot) dot.className = 'dot green';
+            if (dot) dot.className = 'dot compact-status-pill__dot green';
             if (textEl) textEl.textContent = BYD.i18n.t('vehicle.cloud_connected');
         } else {
-            if (dot) dot.className = 'dot red';
+            if (dot) dot.className = 'dot compact-status-pill__dot red';
             if (textEl) textEl.textContent = BYD.i18n.t('vehicle.cloud_not_configured');
         }
     },

--- a/app/src/test/java/com/overdrive/app/ui/StatusIndicatorAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/StatusIndicatorAssetTest.java
@@ -49,6 +49,21 @@ public class StatusIndicatorAssetTest {
         assertFalse(ruleFor(performance, ".monitoring-status").contains("gap:"));
     }
 
+    @Test
+    public void vehicleStateUpdatesPreserveTheSharedDotClass() throws IOException {
+        String vehicleScript =
+                readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
+
+        assertTrue(vehicleScript.contains(
+                "'dot compact-status-pill__dot ' +"));
+        assertTrue(vehicleScript.contains(
+                "dot.className = 'dot compact-status-pill__dot green'"));
+        assertTrue(vehicleScript.contains(
+                "dot.className = 'dot compact-status-pill__dot red'"));
+        assertFalse(vehicleScript.contains("dot.className = 'dot green'"));
+        assertFalse(vehicleScript.contains("dot.className = 'dot red'"));
+    }
+
     private static String ruleFor(String css, String selector) {
         int start = css.indexOf(selector);
         if (start < 0) return "";

--- a/app/src/test/java/com/overdrive/app/ui/StatusIndicatorAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/StatusIndicatorAssetTest.java
@@ -1,0 +1,75 @@
+package com.overdrive.app.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Guards compact dot-and-label status pills against old-WebView flex-gap regressions. */
+public class StatusIndicatorAssetTest {
+
+    @Test
+    public void sharedPillUsesExplicitDotMarginForLegacyWebView() throws IOException {
+        String styles = readRepositoryFile("app/src/main/assets/web/shared/styles.css");
+
+        assertTrue(styles.contains(".compact-status-pill > .compact-status-pill__dot"));
+        assertTrue(styles.contains("margin-right: 6px"));
+        assertTrue(styles.contains("[dir=\"rtl\"] .compact-status-pill"));
+    }
+
+    @Test
+    public void compactStatusPillsReuseTheSharedPrimitive() throws IOException {
+        String live = readRepositoryFile("app/src/main/assets/web/local/live-view.html");
+        String vehicle = readRepositoryFile("app/src/main/assets/web/local/vehicle-control.html");
+        String performance = readRepositoryFile("app/src/main/assets/web/local/performance.html");
+
+        assertTrue(live.contains("connection-status compact-status-pill"));
+        assertTrue(live.contains("conn-dot compact-status-pill__dot"));
+        assertTrue(vehicle.contains("vc-pill compact-status-pill"));
+        assertTrue(vehicle.contains("dot green compact-status-pill__dot"));
+        assertTrue(vehicle.contains("dot amber compact-status-pill__dot"));
+        assertTrue(performance.contains("monitoring-status compact-status-pill"));
+        assertTrue(performance.contains("monitoring-dot compact-status-pill__dot"));
+    }
+
+    @Test
+    public void pagesDoNotLayerFlexGapOnTopOfSharedDotSpacing() throws IOException {
+        String live = readRepositoryFile("app/src/main/assets/web/local/live-view.html");
+        String vehicleStyles =
+                readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.css");
+        String performance = readRepositoryFile("app/src/main/assets/web/local/performance.html");
+
+        assertFalse(ruleFor(live, ".connection-status").contains("gap:"));
+        assertFalse(ruleFor(vehicleStyles, ".vc-pill .dot").contains("margin-right:"));
+        assertFalse(ruleFor(performance, ".monitoring-status").contains("gap:"));
+    }
+
+    private static String ruleFor(String css, String selector) {
+        int start = css.indexOf(selector);
+        if (start < 0) return "";
+        int end = css.indexOf('}', start);
+        return end < 0 ? css.substring(start) : css.substring(start, end + 1);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce shared compact status-pill and dot classes.
- Use explicit dot margins instead of flex gap for older Android WebViews.
- Support RTL spacing.
- Preserve the shared classes during runtime status updates.

## Why

The car WebView handles flex gap inconsistently, causing coloured dots to crowd labels such as Live, Unlocked, monitoring, and tyre status.

## Impact

Compact status indicators use consistent, readable spacing throughout the app.

## Validation

- Full debug unit-test suite passes on this rebased branch.
- Shared asset and runtime-class contracts are covered by tests.
- Verified on Chrome 74 WebView at 1920x1080.

## Visual evidence

![Shared compact status spacing](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/194-shared-status-spacing.png)