### PR TITLE
fix: improve vehicle screen layout and in-car rendering

### DIFF
--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -12,8 +12,8 @@
     <meta name="theme-color" content="#00876C">
     <script src="../shared/theme.js?v=5"></script>
     <script src="../shared/app-shell.js?v=2"></script>
-    <link rel="stylesheet" href="../shared/styles.css?v=18">
-    <link rel="stylesheet" href="../shared/vehicle-control.css?v=15">
+    <link rel="stylesheet" href="../shared/styles.css?v=20">
+    <link rel="stylesheet" href="../shared/vehicle-control.css?v=16">
     <!-- Web fonts loaded async + non-blocking. WebView falls back to system sans-serif if offline. -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" media="print" onload="this.media='all'">
 </head>
@@ -70,25 +70,25 @@
 
                     <div class="vc-tyre-overlay" id="vcTyreOverlay">
                         <div class="vc-tyre-callout" data-corner="fl" id="tyreFL">
-                            <div class="vc-tyre-head"><span class="vc-tyre-dot"></span><span class="vc-tyre-label">FL</span><span class="vc-tyre-state">--</span></div>
+                            <div class="vc-tyre-head compact-status-pill"><span class="vc-tyre-dot compact-status-pill__dot"></span><span class="vc-tyre-label">FL</span><span class="vc-tyre-state">--</span></div>
                             <div class="vc-tyre-psi"><span class="vc-tyre-psi-val">--</span><span class="vc-tyre-psi-unit">PSI</span></div>
                             <div class="vc-tyre-sub"><span class="vc-tyre-kpa">-- kPa</span></div>
                             <div class="vc-tyre-temp"><span class="vc-tyre-temp-val">--</span><span class="vc-tyre-temp-unit">°C</span></div>
                         </div>
                         <div class="vc-tyre-callout" data-corner="fr" id="tyreFR">
-                            <div class="vc-tyre-head"><span class="vc-tyre-dot"></span><span class="vc-tyre-label">FR</span><span class="vc-tyre-state">--</span></div>
+                            <div class="vc-tyre-head compact-status-pill"><span class="vc-tyre-dot compact-status-pill__dot"></span><span class="vc-tyre-label">FR</span><span class="vc-tyre-state">--</span></div>
                             <div class="vc-tyre-psi"><span class="vc-tyre-psi-val">--</span><span class="vc-tyre-psi-unit">PSI</span></div>
                             <div class="vc-tyre-sub"><span class="vc-tyre-kpa">-- kPa</span></div>
                             <div class="vc-tyre-temp"><span class="vc-tyre-temp-val">--</span><span class="vc-tyre-temp-unit">°C</span></div>
                         </div>
                         <div class="vc-tyre-callout" data-corner="rl" id="tyreRL">
-                            <div class="vc-tyre-head"><span class="vc-tyre-dot"></span><span class="vc-tyre-label">RL</span><span class="vc-tyre-state">--</span></div>
+                            <div class="vc-tyre-head compact-status-pill"><span class="vc-tyre-dot compact-status-pill__dot"></span><span class="vc-tyre-label">RL</span><span class="vc-tyre-state">--</span></div>
                             <div class="vc-tyre-psi"><span class="vc-tyre-psi-val">--</span><span class="vc-tyre-psi-unit">PSI</span></div>
                             <div class="vc-tyre-sub"><span class="vc-tyre-kpa">-- kPa</span></div>
                             <div class="vc-tyre-temp"><span class="vc-tyre-temp-val">--</span><span class="vc-tyre-temp-unit">°C</span></div>
                         </div>
                         <div class="vc-tyre-callout" data-corner="rr" id="tyreRR">
-                            <div class="vc-tyre-head"><span class="vc-tyre-dot"></span><span class="vc-tyre-label">RR</span><span class="vc-tyre-state">--</span></div>
+                            <div class="vc-tyre-head compact-status-pill"><span class="vc-tyre-dot compact-status-pill__dot"></span><span class="vc-tyre-label">RR</span><span class="vc-tyre-state">--</span></div>
                             <div class="vc-tyre-psi"><span class="vc-tyre-psi-val">--</span><span class="vc-tyre-psi-unit">PSI</span></div>
                             <div class="vc-tyre-sub"><span class="vc-tyre-kpa">-- kPa</span></div>
                             <div class="vc-tyre-temp"><span class="vc-tyre-temp-val">--</span><span class="vc-tyre-temp-unit">°C</span></div>
@@ -531,7 +531,7 @@
     <script src="../shared/vendor/GLTFLoader.js?v=12"></script>
     <script src="../shared/vendor/OrbitControls.js?v=12"></script>
     <script src="../shared/vendor/gsap.min.js?v=12"></script>
-    <script src="../shared/vehicle-control.js?v=19"></script>
+    <script src="../shared/vehicle-control.js?v=21"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -531,7 +531,7 @@
     <script src="../shared/vendor/GLTFLoader.js?v=12"></script>
     <script src="../shared/vendor/OrbitControls.js?v=12"></script>
     <script src="../shared/vendor/gsap.min.js?v=12"></script>
-    <script src="../shared/vehicle-control.js?v=21"></script>
+    <script src="../shared/vehicle-control.js?v=23"></script>
     <script>
         function toggleSidebar() {
             document.getElementById('sidebar').classList.toggle('open');

--- a/app/src/main/assets/web/shared/models/manifest.json
+++ b/app/src/main/assets/web/shared/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 8,
+  "version": 7,
   "default": "seal",
   "baseUrl": "https://github.com/yash-srivastava/Overdrive-release/releases/download/models-v1/",
   "paintPresets": [
@@ -73,7 +73,6 @@
       "sizeBytes": 1642648,
       "sha256": "6e08a0223fb2a4c229a8ed323b6d748930491b583cb595b38a0e372314c028a1",
       "bundled": false,
-      "displayScale": [0.9, 1.0, 1.0],
       "nominalKwh": 60.48
     },
     {

--- a/app/src/main/assets/web/shared/models/manifest.json
+++ b/app/src/main/assets/web/shared/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "default": "seal",
   "baseUrl": "https://github.com/yash-srivastava/Overdrive-release/releases/download/models-v1/",
   "paintPresets": [
@@ -73,6 +73,7 @@
       "sizeBytes": 1642648,
       "sha256": "6e08a0223fb2a4c229a8ed323b6d748930491b583cb595b38a0e372314c028a1",
       "bundled": false,
+      "displayScale": [0.9, 1.0, 1.0],
       "nominalKwh": 60.48
     },
     {

--- a/app/src/main/assets/web/shared/styles.css
+++ b/app/src/main/assets/web/shared/styles.css
@@ -447,6 +447,31 @@ input, select { font-family: inherit; }
     animation: none;
 }
 
+/* Compact status pills (for example Live, vehicle lock, and monitoring).
+   Android System WebView 58 does not support flex `gap`, so the dot owns the
+   spacing. Keep that compatibility detail here instead of reimplementing it
+   in every page-specific pill. */
+.compact-status-pill {
+    display: -webkit-inline-flex;
+    display: inline-flex;
+    -webkit-align-items: center;
+    align-items: center;
+}
+
+.compact-status-pill > .compact-status-pill__dot {
+    display: inline-block;
+    -webkit-flex: 0 0 auto;
+    flex: 0 0 auto;
+    margin-right: 6px;
+    margin-right: var(--compact-status-pill-dot-gap, 6px);
+}
+
+[dir="rtl"] .compact-status-pill > .compact-status-pill__dot {
+    margin-right: 0;
+    margin-left: 6px;
+    margin-left: var(--compact-status-pill-dot-gap, 6px);
+}
+
 @keyframes pulse {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }

--- a/app/src/main/assets/web/shared/vehicle-control.css
+++ b/app/src/main/assets/web/shared/vehicle-control.css
@@ -122,10 +122,17 @@
     -webkit-align-items: center; align-items: center;
     -webkit-flex-wrap: wrap; flex-wrap: wrap;
     -webkit-justify-content: flex-start; justify-content: flex-start;
-    gap: 6px;
     z-index: 10; pointer-events: none;
 }
-.vc-status-bar-secondary > * { pointer-events: auto; }
+.vc-status-bar-secondary > * {
+    pointer-events: auto;
+    margin-right: 6px;
+    margin-bottom: 6px;
+}
+[dir="rtl"] .vc-status-bar-secondary > * {
+    margin-right: 0;
+    margin-left: 6px;
+}
 .vc-pill {
     display: -webkit-inline-flex; display: inline-flex;
     -webkit-align-items: center; align-items: center;
@@ -256,12 +263,15 @@
    of canvas backing-buffer size. FRONT pair on the bottom, REAR on top. */
 .vc-tyre-callout {
     position: absolute;
-    min-width: 92px;
-    padding: 7px 10px 8px;
-    background: var(--vc-pill-bg);
-    -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px);
+    box-sizing: border-box;
+    width: 168px;
+    min-width: 168px;
+    padding: 11px 13px 12px;
+    background: var(--vc-pill-bg-strong);
+    -webkit-backdrop-filter: blur(12px); backdrop-filter: blur(12px);
     border: 1px solid var(--vc-border);
-    border-radius: 10px;
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.14);
     color: var(--vc-text-strong);
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     pointer-events: auto;
@@ -286,96 +296,106 @@
 .vc-tyre-callout[data-corner="rl"] { right: 22px; }
 @media (min-width: 1200px) {
     .vc-tyre-callout[data-corner="fr"],
-    .vc-tyre-callout[data-corner="rr"] { left: 80px; }
+    .vc-tyre-callout[data-corner="rr"] { left: 6%; }
     .vc-tyre-callout[data-corner="fl"],
-    .vc-tyre-callout[data-corner="rl"] { right: 80px; }
+    .vc-tyre-callout[data-corner="rl"] { right: 6%; }
 }
 /* No accent strip — the box itself carries the state colour via the
    border + dot + state label. Cleaner read with no leader lines. */
 
 .vc-tyre-head {
+    --compact-status-pill-dot-gap: 8px;
     display: -webkit-flex; display: flex;
     -webkit-align-items: center; align-items: center;
-    gap: 5px;
-    font-size: 9px;
+    width: 100%;
+    font-size: 11px;
     font-weight: 700;
-    letter-spacing: .8px;
+    letter-spacing: .7px;
     text-transform: uppercase;
     color: var(--vc-text-secondary);
 }
 .vc-tyre-dot {
-    width: 6px; height: 6px;
+    width: 8px; height: 8px;
     border-radius: 50%;
-    background: #22C55E;
-    box-shadow: 0 0 5px #22C55E;
+    background: #00D4AA;
+    box-shadow: 0 0 7px rgba(0,212,170,0.82);
     -webkit-flex-shrink: 0; flex-shrink: 0;
     -webkit-transition: background .2s, box-shadow .2s;
     transition: background .2s, box-shadow .2s;
 }
-.vc-tyre-label { color: var(--vc-text-soft); }
+.vc-tyre-label { color: var(--vc-text-strong); }
 .vc-tyre-state {
     margin-left: auto;
-    font-size: 8px;
+    font-size: 10px;
     font-weight: 700;
     letter-spacing: .6px;
-    color: #22C55E;
+    color: #00D4AA;
     -webkit-transition: color .2s; transition: color .2s;
 }
 .vc-tyre-psi {
     display: -webkit-flex; display: flex;
     -webkit-align-items: baseline; align-items: baseline;
-    gap: 4px;
-    margin-top: 2px;
+    margin-top: 7px;
 }
 .vc-tyre-psi-val {
-    font-size: 18px;
+    font-size: 28px;
     font-weight: 700;
     color: var(--vc-text-primary);
     line-height: 1;
 }
 .vc-tyre-psi-unit {
-    font-size: 9px;
+    margin-left: 7px;
+    font-size: 11px;
     font-weight: 600;
     color: var(--vc-text-muted);
     letter-spacing: .8px;
+}
+[dir="rtl"] .vc-tyre-psi-unit {
+    margin-left: 0;
+    margin-right: 7px;
 }
 .vc-tyre-sub {
     display: -webkit-flex; display: flex;
     -webkit-justify-content: space-between; justify-content: space-between;
     -webkit-align-items: center; align-items: center;
-    margin-top: 4px;
-    font-size: 9px;
+    margin-top: 7px;
+    font-size: 11px;
     color: var(--vc-text-muted);
 }
 .vc-tyre-kpa { letter-spacing: .3px; }
 .vc-tyre-temp {
     display: -webkit-flex; display: flex;
     -webkit-align-items: baseline; align-items: baseline;
-    gap: 3px;
-    margin-top: 3px;
-    font-size: 10px;
+    margin-top: 6px;
+    font-size: 12px;
     color: var(--vc-text-secondary);
 }
 .vc-tyre-temp-val {
-    font-size: 12px;
+    font-size: 16px;
     font-weight: 600;
     color: var(--vc-text-strong);
     line-height: 1;
 }
 .vc-tyre-temp-unit {
-    font-size: 9px;
+    margin-left: 3px;
+    font-size: 11px;
     font-weight: 600;
     color: var(--vc-text-muted);
     letter-spacing: .6px;
 }
+[dir="rtl"] .vc-tyre-temp-unit {
+    margin-left: 0;
+    margin-right: 3px;
+}
 
-/* State colour scale — same 4 tiers as the engine chips so the page
-   reads as one consistent system. Both the dot AND the PSI value
+/* State colour scale — healthy values use the OverDrive teal while
+   attention states retain the familiar amber/red escalation. Both dot and PSI
    colour shift so a low-pressure tyre is unmistakable from across
    the cabin without reading the state label. */
-.vc-tyre-callout[data-state="normal"]  .vc-tyre-dot     { background: #22C55E; box-shadow: 0 0 5px #22C55E; }
-.vc-tyre-callout[data-state="normal"]  .vc-tyre-state   { color: #22C55E; }
-.vc-tyre-callout[data-state="normal"]  .vc-tyre-psi-val { color: #22C55E; }
+.vc-tyre-callout[data-state="normal"]                   { border-color: rgba(0, 212, 170, 0.28); }
+.vc-tyre-callout[data-state="normal"]  .vc-tyre-dot     { background: #00D4AA; box-shadow: 0 0 7px rgba(0,212,170,0.82); }
+.vc-tyre-callout[data-state="normal"]  .vc-tyre-state   { color: #00D4AA; }
+.vc-tyre-callout[data-state="normal"]  .vc-tyre-psi-val { color: #00D4AA; }
 
 .vc-tyre-callout[data-state="caution"] .vc-tyre-dot     { background: #FBBF24; box-shadow: 0 0 6px #FBBF24; }
 .vc-tyre-callout[data-state="caution"] .vc-tyre-state   { color: #FBBF24; }
@@ -410,12 +430,16 @@
 /* Compact on small screens — same min-width tightening pattern as the rest
    of the floating UI. */
 @media (max-width: 768px) {
-    .vc-tyre-callout { min-width: 80px; padding: 5px 8px 6px; }
-    .vc-tyre-psi-val { font-size: 16px; }
-    .vc-tyre-head { font-size: 8px; gap: 4px; }
-    .vc-tyre-sub { font-size: 8px; }
-    .vc-tyre-temp { font-size: 9px; margin-top: 2px; }
-    .vc-tyre-temp-val { font-size: 11px; }
+    .vc-tyre-callout { width: 156px; min-width: 156px; padding: 10px 12px 11px; border-radius: 13px; }
+    .vc-tyre-dot { width: 8px; height: 8px; }
+    .vc-tyre-psi-val { font-size: 26px; }
+    .vc-tyre-psi-unit { margin-left: 6px; font-size: 10px; }
+    .vc-tyre-head { font-size: 10px; }
+    .vc-tyre-state { font-size: 9px; }
+    .vc-tyre-sub { margin-top: 6px; font-size: 10px; }
+    .vc-tyre-temp { font-size: 11px; margin-top: 5px; }
+    .vc-tyre-temp-val { font-size: 15px; }
+    .vc-tyre-temp-unit { font-size: 10px; }
     /* Rear pair on top (below the mobile engine row at top:102),
        front pair on the bottom. Mirror: car-left → screen-right. */
     .vc-tyre-callout[data-corner="rl"],
@@ -428,12 +452,12 @@
     .vc-tyre-callout[data-corner="fr"] { bottom: 120px; top: auto; }
 }
 @media (max-width: 480px) {
-    .vc-tyre-callout { min-width: 72px; padding: 4px 7px 5px; border-radius: 8px; }
-    .vc-tyre-psi-val { font-size: 14px; }
-    .vc-tyre-head { font-size: 7px; }
-    .vc-tyre-sub { font-size: 7px; }
-    .vc-tyre-temp { font-size: 8px; margin-top: 2px; }
-    .vc-tyre-temp-val { font-size: 10px; }
+    .vc-tyre-callout { width: 104px; min-width: 104px; padding: 7px 8px 8px; border-radius: 9px; }
+    .vc-tyre-psi-val { font-size: 19px; }
+    .vc-tyre-head { font-size: 8px; }
+    .vc-tyre-sub { font-size: 8px; }
+    .vc-tyre-temp { font-size: 9px; margin-top: 3px; }
+    .vc-tyre-temp-val { font-size: 12px; }
     .vc-tyre-callout[data-corner="rl"],
     .vc-tyre-callout[data-corner="rr"] { top: 152px; bottom: auto; }
     .vc-tyre-callout[data-corner="fr"],

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -206,13 +206,13 @@ var VC = {
 
         this.scene = new THREE.Scene();
 
-        // Pull camera further back on narrow screens so the car renders
-        // smaller — leaves headroom on the canvas for the four tyre
-        // callouts (and future engine/coolant/oil overlays) without them
-        // colliding with the rendered body. Wider FOV on mobile too, so
-        // the same body fits in less screen height.
+        // Compact screens keep a wider lens so the car leaves room for
+        // overlays. Wide in-car displays use a calmer showroom perspective.
         var isMobile = window.innerWidth < 768;
-        var fov = isMobile ? 50 : 50;
+        var isCompact = isMobile && !window.AndroidBridge;
+        // A slightly narrower showroom lens on wide in-car displays makes
+        // three-quarter views easier to read and reduces near-side distortion.
+        var fov = isCompact ? 50 : 45;
         // Size the renderer to the CANVAS box, not the full window — the
         // sidebar (260px on desktop) eats the left edge, and rendering at
         // window-width pushes the car's visual centre off to the left of
@@ -225,7 +225,11 @@ var VC = {
         this.camera = new THREE.PerspectiveCamera(
             fov, renderW / renderH, 0.1, 1000
         );
-        this.camera.position.set(isMobile ? 5.0 : 4, isMobile ? 3.0 : 2.5, isMobile ? 6.5 : 5);
+        if (window.AndroidBridge) {
+            this.camera.position.set(4.6, 2.8, 6.0);
+        } else {
+            this.camera.position.set(isCompact ? 5.0 : 4, isCompact ? 3.0 : 2.5, isCompact ? 6.5 : 5);
+        }
 
         this.renderer = new THREE.WebGLRenderer({
             canvas: canvasEl,
@@ -481,7 +485,59 @@ var VC = {
         });
         if (this.scene) this.scene.remove(this.carModel);
         this.carModel = null;
+        this._modelSourceScale = null;
         this.bodyPaintMeshes = [];
+    },
+
+    /**
+     * Prepare any manifest model for the shared Vehicle stage.
+     *
+     * `displayScale` is optional per-asset calibration metadata. The renderer
+     * does not special-case vehicle ids: a source mesh with a distorted axis
+     * can declare [x,y,z], while every other model falls back to [1,1,1].
+     * A final uniform fit keeps different vehicles similarly readable.
+     */
+    _fitLoadedCarModel: function() {
+        if (!this.carModel || typeof THREE === 'undefined') return;
+
+        var entry = this.ModelStore.findEntry(this.manifest, this.activeModelId);
+        var correction = [1, 1, 1];
+        if (entry && entry.displayScale && entry.displayScale.length === 3) {
+            for (var i = 0; i < 3; i++) {
+                var value = parseFloat(entry.displayScale[i]);
+                if (isFinite(value) && value > 0) correction[i] = value;
+            }
+        }
+
+        var source = this._modelSourceScale || new THREE.Vector3(1, 1, 1);
+        this.carModel.scale.set(
+            source.x * correction[0],
+            source.y * correction[1],
+            source.z * correction[2]
+        );
+        this.carModel.position.set(0, 0, 0);
+
+        var box = new THREE.Box3().setFromObject(this.carModel);
+        var size = box.getSize(new THREE.Vector3());
+        var longestFootprint = Math.max(size.x, size.z);
+        var rect = this.renderer && this.renderer.domElement
+            ? this.renderer.domElement.getBoundingClientRect()
+            : { width: window.innerWidth };
+        var compactViewport = rect.width < 768 && !window.AndroidBridge;
+        var targetLength = compactViewport ? 4.65 : 5.25;
+
+        if (longestFootprint > 0.0001) {
+            this.carModel.scale.multiplyScalar(targetLength / longestFootprint);
+        }
+
+        // Centre only after applying both correction and fit. Scaling an
+        // already-centred group can reintroduce an offset when its source
+        // origin is asymmetric.
+        this.carModel.position.set(0, 0, 0);
+        box.setFromObject(this.carModel);
+        var center = box.getCenter(new THREE.Vector3());
+        this.carModel.position.sub(center);
+        this.carModel.position.y += 0.1;
     },
 
     _loadModelFromPath: function(modelPath, gen) {
@@ -549,19 +605,8 @@ var VC = {
                     }
                 });
 
-                var box = new THREE.Box3().setFromObject(self.carModel);
-                var center = box.getCenter(new THREE.Vector3());
-                self.carModel.position.sub(center);
-                self.carModel.position.y += 0.1;
-
-                // Slight bump on the Android WebView (BYD head unit) since
-                // its effective canvas is smaller than mobile browsers.
-                // Kept conservative (1.10) so the four tyre callouts and
-                // the planned engine/coolant/oil overlays have room around
-                // the rendered car without overlapping the body.
-                if (window.AndroidBridge) {
-                    self.carModel.scale.multiplyScalar(1.10);
-                }
+                self._modelSourceScale = self.carModel.scale.clone();
+                self._fitLoadedCarModel();
 
                 self.scene.add(self.carModel);
 
@@ -622,11 +667,8 @@ var VC = {
     },
 
     onResize: function() {
-        // Match the FOV used at init() — we don't shrink the FOV on mobile
-        // anymore (the car was rendering too big and clipping into the
-        // tyre callouts). 50° is a comfortable garage-floor look at all
-        // screen widths.
-        this.camera.fov = 50;
+        // Match the responsive lens used at initialisation.
+        this.camera.fov = window.innerWidth < 768 && !window.AndroidBridge ? 50 : 45;
         // Re-measure the canvas's CSS box, not the window — the sidebar
         // takes 260px on desktop. Without this, the car visually shifts
         // off-centre toward the right edge of the visible area.
@@ -4304,21 +4346,26 @@ var VC = {
     _updateTyreCalloutPositions: function() { /* no-op — CSS handles it */ },
 
     /** Map raw BYD enums + raw PSI to a 3-tier visual-state scale:
-     *    'alert'  → red     leak (airLeakState>=1) or PSI < 22 (deflated)
-     *    'warn'   → orange  pressureState UNDER/OVER, or PSI < 34, or PSI > 45
-     *    'normal' → green   34-45 PSI, no leak, signal OK
+     *    'alert'  → red     leak (airLeakState>=1) or fallback PSI < 22
+     *    'warn'   → orange  pressureState UNDER/OVER, or fallback PSI < 28 / > 50
+     *    'normal' → teal    explicit SDK normal state, or plausible fallback PSI
      *    'muted'  → grey    no signal / no data
-     *  SDK enums are checked first so we still flag alert/warn when the
-     *  TPMS itself has detected a problem even if the raw PSI looks fine.
+     *  An explicit SDK state is authoritative. Raw PSI is only a conservative
+     *  fallback for vehicles that do not expose pressureState; this avoids
+     *  painting manufacturer-normal pressures (for example 31.9 PSI) as a
+     *  warning while the same card says OK.
      */
     _tyreStateToken: function(corner) {
         if (!corner || corner.available === false) return 'muted';
         if (corner.signalState === 1) return 'muted';
         if (corner.airLeakState && corner.airLeakState >= 1) return 'alert';
-        if (corner.pressureState && corner.pressureState >= 1) return 'warn';
+        if (typeof corner.pressureState === 'number') {
+            if (corner.pressureState >= 1) return 'warn';
+            return 'normal';
+        }
         if (typeof corner.psi === 'number') {
             if (corner.psi < 22) return 'alert';
-            if (corner.psi < 34 || corner.psi > 45) return 'warn';
+            if (corner.psi < 28 || corner.psi > 50) return 'warn';
         }
         return 'normal';
     },

--- a/app/src/main/assets/web/shared/vehicle-control.js
+++ b/app/src/main/assets/web/shared/vehicle-control.js
@@ -234,10 +234,22 @@ var VC = {
         this.renderer = new THREE.WebGLRenderer({
             canvas: canvasEl,
             antialias: true,
-            alpha: true
+            alpha: true,
+            powerPreference: 'high-performance'
         });
+        // The AVN stretches the native WebView to the physical display after
+        // page layout. Rendering at its reported devicePixelRatio wastes GPU
+        // fill-rate without adding visible detail; phones retain high DPI.
+        this.renderer.setPixelRatio(window.AndroidBridge
+            ? 1
+            : Math.min(window.devicePixelRatio, 2));
         this.renderer.setSize(renderW, renderH, false);
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 3));
+        if (window.AndroidBridge && window.console) {
+            console.log('[VC perf] canvas css=' + renderW + 'x' + renderH
+                + ' buffer=' + canvasEl.width + 'x' + canvasEl.height
+                + ' dpr=' + window.devicePixelRatio
+                + ' cameraAspect=' + this.camera.aspect.toFixed(4));
+        }
         // Read the clear colour from the active theme so the 3D viewport
         // matches the surrounding chrome under both light and dark themes.
         // Was previously hardcoded #0F0F12 which left the car silhouette
@@ -268,6 +280,7 @@ var VC = {
         this.addGroundGrid();
 
         window.addEventListener('resize', function() { self.onResize(); });
+        this._watchCanvasSize();
 
         // React to theme changes so the renderer's clear colour stays in
         // sync with the rest of the UI. The Android shell sets data-theme
@@ -311,6 +324,53 @@ var VC = {
             }
         } catch (e) { /* fall through */ }
         return 0x0F0F12;
+    },
+
+    /**
+     * The native shell hides the web sidebar after onPageFinished, after this
+     * page has already initialised Three.js. That expands the canvas without a
+     * window resize, so the old backing buffer was stretched across the new
+     * box. Observe the real content box and keep renderer + camera in sync.
+     * A short poll covers WebViews older than ResizeObserver.
+     */
+    _watchCanvasSize: function() {
+        var self = this;
+        var canvas = this.renderer && this.renderer.domElement;
+        if (!canvas) return;
+
+        var sync = function() {
+            if (!self.renderer || !self.camera) return;
+            var rect = canvas.getBoundingClientRect();
+            var w = Math.round(rect.width);
+            var h = Math.round(rect.height);
+            if (w < 1 || h < 1) return;
+            if (w !== self._canvasCssW || h !== self._canvasCssH) {
+                self._canvasCssW = w;
+                self._canvasCssH = h;
+                self.onResize();
+                if (window.AndroidBridge && window.console) {
+                    console.log('[VC perf] resized css=' + w + 'x' + h
+                        + ' buffer=' + canvas.width + 'x' + canvas.height
+                        + ' cameraAspect=' + self.camera.aspect.toFixed(4));
+                }
+            }
+        };
+
+        this._canvasCssW = Math.round(canvas.getBoundingClientRect().width);
+        this._canvasCssH = Math.round(canvas.getBoundingClientRect().height);
+
+        if (window.ResizeObserver) {
+            this._canvasResizeObserver = new ResizeObserver(sync);
+            this._canvasResizeObserver.observe(canvas);
+        }
+
+        var checksLeft = 30;
+        var poll = function() {
+            sync();
+            checksLeft--;
+            if (checksLeft > 0) setTimeout(poll, 100);
+        };
+        setTimeout(poll, 0);
     },
 
     addLighting: function() {
@@ -393,6 +453,7 @@ var VC = {
         var self = this;
         modelId = modelId || this.activeModelId || 'seal';
         this.activeModelId = modelId;
+        this._modelLoadStartedAt = Date.now();
         var gen = ++this._loadGen;
 
         // Sanity check — if Three.js failed to load (e.g. local extraction failed),
@@ -546,11 +607,14 @@ var VC = {
 
         // Draco decoder — the GLB uses Draco mesh compression.
         // Local path: assets/web/shared/vendor/draco/ (extracted to /data/local/tmp/web/shared/vendor/draco/).
-        // We force the JS decoder (no WASM) for Chrome 58 compatibility and to avoid the
-        // wasm MIME quirks on some BYD WebViews.
+        // WebAssembly is materially faster on the head unit and the local
+        // server serves .wasm as application/wasm. Keep JS as a fallback for
+        // WebViews without WebAssembly.
         var dracoLoader = new THREE.DRACOLoader();
         dracoLoader.setDecoderPath('../shared/vendor/draco/');
-        dracoLoader.setDecoderConfig({ type: 'js' });
+        dracoLoader.setDecoderConfig({
+            type: typeof WebAssembly === 'object' ? 'wasm' : 'js'
+        });
         loader.setDRACOLoader(dracoLoader);
 
         loader.load(
@@ -607,6 +671,10 @@ var VC = {
 
                 self._modelSourceScale = self.carModel.scale.clone();
                 self._fitLoadedCarModel();
+                if (window.AndroidBridge && window.console) {
+                    console.log('[VC perf] model=' + self.activeModelId
+                        + ' readyMs=' + (Date.now() - self._modelLoadStartedAt));
+                }
 
                 self.scene.add(self.carModel);
 
@@ -684,9 +752,20 @@ var VC = {
         this._tyreLastW = 0; this._tyreLastH = 0;
     },
 
-    animate: function() {
+    animate: function(frameTime) {
         var self = this;
-        requestAnimationFrame(function() { self.animate(); });
+        requestAnimationFrame(function(nextFrameTime) { self.animate(nextFrameTime); });
+        // 30fps is smooth for this fixed automotive display. Together with
+        // the 1x backing buffer it removes most continuous AVN GPU load;
+        // standalone phone/browser clients retain their native refresh rate.
+        if (window.AndroidBridge) {
+            var now = typeof frameTime === 'number'
+                ? frameTime
+                : (window.performance && performance.now ? performance.now() : Date.now());
+            if (this._lastRenderFrame
+                    && now - this._lastRenderFrame < 32) return;
+            this._lastRenderFrame = now;
+        }
         if (this.controls) this.controls.update();
         // Update canvas texture each frame when 3D view is active
         if (this._3dViewActive && this._videoTexture) {
@@ -4348,21 +4427,18 @@ var VC = {
     /** Map raw BYD enums + raw PSI to a 3-tier visual-state scale:
      *    'alert'  → red     leak (airLeakState>=1) or fallback PSI < 22
      *    'warn'   → orange  pressureState UNDER/OVER, or fallback PSI < 28 / > 50
-     *    'normal' → teal    explicit SDK normal state, or plausible fallback PSI
+     *    'normal' → teal    plausible PSI with no SDK warning
      *    'muted'  → grey    no signal / no data
-     *  An explicit SDK state is authoritative. Raw PSI is only a conservative
-     *  fallback for vehicles that do not expose pressureState; this avoids
-     *  painting manufacturer-normal pressures (for example 31.9 PSI) as a
-     *  warning while the same card says OK.
+     *  SDK warnings are authoritative, while conservative raw limits catch a
+     *  genuinely low/high reading even when a vehicle reports state=normal.
+     *  Manufacturer-normal pressures such as 31.9 PSI remain teal.
      */
     _tyreStateToken: function(corner) {
         if (!corner || corner.available === false) return 'muted';
         if (corner.signalState === 1) return 'muted';
         if (corner.airLeakState && corner.airLeakState >= 1) return 'alert';
-        if (typeof corner.pressureState === 'number') {
-            if (corner.pressureState >= 1) return 'warn';
-            return 'normal';
-        }
+        if (typeof corner.pressureState === 'number'
+                && corner.pressureState >= 1) return 'warn';
         if (typeof corner.psi === 'number') {
             if (corner.psi < 22) return 'alert';
             if (corner.psi < 28 || corner.psi > 50) return 'warn';

--- a/app/src/test/java/com/overdrive/app/ui/VehicleControlAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/VehicleControlAssetTest.java
@@ -37,12 +37,12 @@ public class VehicleControlAssetTest {
     }
 
     @Test
-    public void modelCorrectionIsManifestDrivenRatherThanVehicleBranched() throws IOException {
+    public void modelFitIsGenericRatherThanVehicleBranched() throws IOException {
         String script = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
         String manifest = readRepositoryFile(
                 "app/src/main/assets/web/shared/models/manifest.json");
 
-        assertTrue(manifest.contains("\"displayScale\": [0.9, 1.0, 1.0]"));
+        assertFalse(manifest.contains("\"displayScale\""));
         assertTrue(script.contains("entry.displayScale"));
         assertTrue(script.contains("_fitLoadedCarModel"));
         assertFalse(script.contains("activeModelId === 'atto3'"));
@@ -50,13 +50,26 @@ public class VehicleControlAssetTest {
     }
 
     @Test
-    public void explicitNormalTpmsStateWinsOverGenericPressureFallback() throws IOException {
+    public void rawLimitsStillCatchLowPressureWhenSdkSaysNormal() throws IOException {
         String script = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
 
         assertTrue(script.contains("typeof corner.pressureState === 'number'"));
-        assertTrue(script.contains("if (corner.pressureState >= 1) return 'warn'"));
-        assertTrue(script.contains("return 'normal';"));
+        assertTrue(script.contains("&& corner.pressureState >= 1) return 'warn'"));
+        assertTrue(script.contains("corner.psi < 28 || corner.psi > 50"));
+        assertFalse(script.contains(
+                "corner.pressureState >= 1) return 'warn';\n            return 'normal'"));
         assertFalse(script.contains("corner.psi < 34"));
+    }
+
+    @Test
+    public void inCarRendererResizesAndUsesBoundedGpuWork() throws IOException {
+        String script = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
+
+        assertTrue(script.contains("_watchCanvasSize"));
+        assertTrue(script.contains("new ResizeObserver(sync)"));
+        assertTrue(script.contains("this.renderer.setPixelRatio(window.AndroidBridge"));
+        assertTrue(script.contains("type: typeof WebAssembly === 'object' ? 'wasm' : 'js'"));
+        assertTrue(script.contains("now - this._lastRenderFrame < 32"));
     }
 
     private static int count(String text, String needle) {

--- a/app/src/test/java/com/overdrive/app/ui/VehicleControlAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/VehicleControlAssetTest.java
@@ -1,0 +1,95 @@
+package com.overdrive.app.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Guards the Vehicle screen's old-WebView spacing and model-fit behaviour. */
+public class VehicleControlAssetTest {
+
+    @Test
+    public void tyreHeadersReuseSharedLegacyWebViewSpacing() throws IOException {
+        String html = readRepositoryFile("app/src/main/assets/web/local/vehicle-control.html");
+        String css = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.css");
+
+        assertEquals(4, count(html, "vc-tyre-head compact-status-pill"));
+        assertEquals(4, count(html, "vc-tyre-dot compact-status-pill__dot"));
+        assertFalse(ruleFor(css, ".vc-tyre-head").contains("\n    gap:"));
+        assertTrue(ruleFor(css, ".vc-tyre-head")
+                .contains("--compact-status-pill-dot-gap: 8px"));
+        assertTrue(ruleFor(css, ".vc-tyre-psi-unit").contains("margin-left: 7px"));
+    }
+
+    @Test
+    public void tyreCardsHaveReadableDashboardSizingAndHealthyState() throws IOException {
+        String css = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.css");
+
+        assertTrue(ruleFor(css, ".vc-tyre-callout").contains("width: 168px"));
+        assertTrue(ruleFor(css, ".vc-tyre-psi-val").contains("font-size: 28px"));
+        assertTrue(css.contains("rgba(0, 212, 170, 0.28)"));
+    }
+
+    @Test
+    public void modelCorrectionIsManifestDrivenRatherThanVehicleBranched() throws IOException {
+        String script = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
+        String manifest = readRepositoryFile(
+                "app/src/main/assets/web/shared/models/manifest.json");
+
+        assertTrue(manifest.contains("\"displayScale\": [0.9, 1.0, 1.0]"));
+        assertTrue(script.contains("entry.displayScale"));
+        assertTrue(script.contains("_fitLoadedCarModel"));
+        assertFalse(script.contains("activeModelId === 'atto3'"));
+        assertFalse(script.contains("activeModelId == 'atto3'"));
+    }
+
+    @Test
+    public void explicitNormalTpmsStateWinsOverGenericPressureFallback() throws IOException {
+        String script = readRepositoryFile("app/src/main/assets/web/shared/vehicle-control.js");
+
+        assertTrue(script.contains("typeof corner.pressureState === 'number'"));
+        assertTrue(script.contains("if (corner.pressureState >= 1) return 'warn'"));
+        assertTrue(script.contains("return 'normal';"));
+        assertFalse(script.contains("corner.psi < 34"));
+    }
+
+    private static int count(String text, String needle) {
+        int result = 0;
+        int from = 0;
+        while ((from = text.indexOf(needle, from)) >= 0) {
+            result++;
+            from += needle.length();
+        }
+        return result;
+    }
+
+    private static String ruleFor(String css, String selector) {
+        int start = css.indexOf(selector);
+        if (start < 0) return "";
+        int end = css.indexOf('}', start);
+        return end < 0 ? css.substring(start) : css.substring(start, end + 1);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Improve tyre-card sizing, spacing, typography, and semantic pressure colours.
- Keep SDK warning states authoritative while applying raw low/high pressure limits.
- Fix stretched vehicle models by observing the real canvas size after native-shell layout changes.
- Bound in-car rendering to pixel ratio 1 and approximately 30 FPS, with Draco WASM where available.

## Why

The native shell hides the web sidebar after Three.js initialises. The canvas widened without a resize event, stretching the existing render buffer and wasting GPU work.

## Impact

The Atto 3 model keeps the correct aspect ratio, tyre data is easier to scan, and model-ready time on the tested unit fell from roughly 10.9 seconds to 3.1-3.5 seconds.

## Validation

- Full debug unit-test suite passes on this clean two-commit branch.
- Verified on a 2024 BYD Atto 3 running Chrome 74 WebView at 1920x1080.

## Integration note

This draft includes the minimal compact-status helper needed by the tyre headers. Rebase after the shared status-spacing PR merges so that duplicate helper hunk disappears.

## Visual evidence

![Responsive Vehicle screen layout on a BYD Atto 3](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/ceef472ba9d23da7e5e23a4984f38aa2c12acd6c/pr-media/195-vehicle-layout.png)