### PR TITLE
Make ADB command lifecycle observable; decide daemon stop-intent locally

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
@@ -39,6 +39,30 @@ class AdbShellExecutor(private val context: Context) {
         // Dedicated polling executor (separate from command executor)
         private val pollingExecutor = Executors.newSingleThreadExecutor()
 
+        /**
+         * Process-wide lifeboat for commands whose OWNING executor has been shut down.
+         *
+         * The per-instance [executor] dies with its DaemonStartupManager, and
+         * `initializeOnAppLaunch()` shuts down the previous manager's executor during the
+         * bootManager→Activity handoff. A chain already in flight at that moment — and the
+         * daemon-start paths are chains, each ADB reply driving the next command — loses
+         * every step after the handoff. `cleanup()` clears the pending Handler queue, so a
+         * not-yet-fired task is cancelled cleanly; this covers the other case, where the
+         * task already fired and is mid-chain.
+         *
+         * Ownership transfer is NOT process teardown, which is the distinction the original
+         * "remaining commands are moot" reasoning missed. Re-submitting here keeps the chain
+         * alive across the handoff.
+         *
+         * Daemon thread, deliberately: this executor is never shut down, and a non-daemon
+         * thread would keep the JVM alive after the last Activity finishes. It shares the
+         * process-wide [sharedDadb] that `cleanup()` intentionally leaves open, so a
+         * re-submitted command uses the same live transport the new owner is using.
+         */
+        private val fallbackExecutor = Executors.newSingleThreadExecutor { r ->
+            Thread(r, "AdbShellFallback").apply { isDaemon = true }
+        }
+
         // Process-wide tiebreaker for executeScript path/delimiter nonces.
         // Per-instance was insufficient: two AdbShellExecutor instances calling
         // executeScript at the same nanoTime with seq=1 each would produce
@@ -80,43 +104,68 @@ class AdbShellExecutor(private val context: Context) {
     
     private val cmdSeq = java.util.concurrent.atomic.AtomicInteger(0)
 
+    /**
+     * Submit [task] to this instance's executor, falling back to the process-wide
+     * [fallbackExecutor] if this one has been shut down.
+     *
+     * Every submit in this class goes through here. Two reasons:
+     *
+     * 1. **Never throw at the caller.** `execute()` is chained from inside onSuccess/onError
+     *    callbacks running on a worker thread, where an uncaught RejectedExecutionException
+     *    KILLS THE PROCESS (observed: app crash on startup when the Activity finished
+     *    mid-sequence). `executeScript` previously submitted with no guard at all and had
+     *    that same crash exposed.
+     * 2. **Never silently drop.** A rejection used to end the chain with one warn line.
+     *    During the bootManager→Activity handoff that is ownership transfer, not teardown,
+     *    and the dropped step is a daemon that then never starts.
+     *
+     * Returns false only if both executors refuse, which means the process really is going
+     * away — nothing can be done then, but it is logged distinctly from a reroute.
+     */
+    private fun submit(seq: Int, command: String, task: Runnable): Boolean {
+        return when (ExecutorFallback.submit(task, executor, fallbackExecutor)) {
+            ExecutorFallback.Outcome.OWNER -> true
+            ExecutorFallback.Outcome.REROUTED -> {
+                logger.warn(TAG, "adb#$seq REROUTED to the shared executor " +
+                    "(owner's executor was shut down mid-chain): $command")
+                true
+            }
+            ExecutorFallback.Outcome.REFUSED -> {
+                logger.warn(TAG, "adb#$seq REJECTED (shared executor is down too): $command")
+                false
+            }
+        }
+    }
+
     fun execute(command: String, callback: ShellCallback) {
-        // Guard against RejectedExecutionException: if the executor is already
-        // shutting down (the owning launcher / app is tearing down), execute()
-        // throws synchronously on the CALLER's thread. ServiceLauncher chains
-        // commands by calling execute() from inside the onError/onSuccess callback,
-        // so an unguarded rejection there is uncaught on the worker thread and
-        // KILLS THE PROCESS (observed: app crash on startup when the Activity
-        // finished mid-sequence). Swallow it — a dead executor means we're shutting
-        // down and the remaining commands are moot.
         val seq = cmdSeq.incrementAndGet()
         // INFO, not DEBUG: "submitted but never ran" is invisible if the only evidence is a debug
         // line inside the runnable. Pairing SUBMIT/RUN/DONE with a correlation id makes queue
         // starvation and lock stalls directly observable instead of inferred from absent logs.
         logger.info(TAG, "adb#$seq SUBMIT [${Thread.currentThread().name}]: $command")
-        try {
-            executor.execute {
-                val t0 = System.currentTimeMillis()
-                try {
-                    logger.info(TAG, "adb#$seq RUN [${Thread.currentThread().name}]")
-                    val dadb = getOrCreateConnection()
-                    val tConn = System.currentTimeMillis() - t0
-                    val result = dadb.shell(command)
-                    logger.info(TAG, "adb#$seq DONE conn=${tConn}ms total=${System.currentTimeMillis() - t0}ms exit=${result.exitCode}")
+        // Return value deliberately ignored: on a double rejection we log and stop, we do NOT
+        // call callback.onError. ServiceLauncher chains the next command from inside onError,
+        // so an error callback raised on the CALLER's thread would re-enter execute(), be
+        // rejected again, and recurse — reintroducing the crash the guard exists to prevent.
+        // Unreachable in practice anyway: fallbackExecutor is never shut down.
+        submit(seq, command) {
+            val t0 = System.currentTimeMillis()
+            try {
+                logger.info(TAG, "adb#$seq RUN [${Thread.currentThread().name}]")
+                val dadb = getOrCreateConnection()
+                val tConn = System.currentTimeMillis() - t0
+                val result = dadb.shell(command)
+                logger.info(TAG, "adb#$seq DONE conn=${tConn}ms total=${System.currentTimeMillis() - t0}ms exit=${result.exitCode}")
 
-                    if (result.exitCode == 0) {
-                        callback.onSuccess(result.allOutput)
-                    } else {
-                        callback.onError("Exit code ${result.exitCode}: ${result.allOutput}")
-                    }
-                } catch (e: Exception) {
-                    logger.error(TAG, "adb#$seq FAILED after ${System.currentTimeMillis() - t0}ms: $command", e)
-                    callback.onError("Execution failed: ${e.message}")
+                if (result.exitCode == 0) {
+                    callback.onSuccess(result.allOutput)
+                } else {
+                    callback.onError("Exit code ${result.exitCode}: ${result.allOutput}")
                 }
+            } catch (e: Exception) {
+                logger.error(TAG, "adb#$seq FAILED after ${System.currentTimeMillis() - t0}ms: $command", e)
+                callback.onError("Execution failed: ${e.message}")
             }
-        } catch (e: java.util.concurrent.RejectedExecutionException) {
-            // Executor shut down — drop the command silently (app is tearing down).
-            logger.warn(TAG, "adb#$seq REJECTED (executor shut down): $command")
         }
     }
     
@@ -146,7 +195,11 @@ class AdbShellExecutor(private val context: Context) {
      * completion (best-effort).
      */
     fun executeScript(scriptBody: String, callback: ShellCallback) {
-        executor.execute {
+        // Routed through submit() like execute(). This path previously submitted directly,
+        // so a rejection here propagated uncaught — the same process-killing crash execute()
+        // has guarded against all along, just never fixed on this path.
+        val seq = cmdSeq.incrementAndGet()
+        submit(seq, "<script:${scriptBody.length}B>") {
             // Per-call nonce = nanoTime + atomic counter. nanoTime alone
             // is non-decreasing (not strictly increasing) so two same-nano
             // calls can collide on emulators / older hardware. The counter
@@ -175,7 +228,7 @@ class AdbShellExecutor(private val context: Context) {
                     // Best-effort cleanup of any partial write
                     try { dadb.shell("rm -f $scriptPath 2>/dev/null") } catch (ignored: Exception) {}
                     callback.onError("script-write failed: ${writeResult.allOutput}")
-                    return@execute
+                    return@submit
                 }
 
                 // Run with `trap 'rm -f path' EXIT` so the tmpfile is

--- a/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
@@ -78,6 +78,8 @@ class AdbShellExecutor(private val context: Context) {
         val output: String
     )
     
+    private val cmdSeq = java.util.concurrent.atomic.AtomicInteger(0)
+
     fun execute(command: String, callback: ShellCallback) {
         // Guard against RejectedExecutionException: if the executor is already
         // shutting down (the owning launcher / app is tearing down), execute()
@@ -87,12 +89,20 @@ class AdbShellExecutor(private val context: Context) {
         // KILLS THE PROCESS (observed: app crash on startup when the Activity
         // finished mid-sequence). Swallow it — a dead executor means we're shutting
         // down and the remaining commands are moot.
+        val seq = cmdSeq.incrementAndGet()
+        // INFO, not DEBUG: "submitted but never ran" is invisible if the only evidence is a debug
+        // line inside the runnable. Pairing SUBMIT/RUN/DONE with a correlation id makes queue
+        // starvation and lock stalls directly observable instead of inferred from absent logs.
+        logger.info(TAG, "adb#$seq SUBMIT [${Thread.currentThread().name}]: $command")
         try {
             executor.execute {
+                val t0 = System.currentTimeMillis()
                 try {
-                    logger.debug(TAG, "Executing async: $command")
+                    logger.info(TAG, "adb#$seq RUN [${Thread.currentThread().name}]")
                     val dadb = getOrCreateConnection()
+                    val tConn = System.currentTimeMillis() - t0
                     val result = dadb.shell(command)
+                    logger.info(TAG, "adb#$seq DONE conn=${tConn}ms total=${System.currentTimeMillis() - t0}ms exit=${result.exitCode}")
 
                     if (result.exitCode == 0) {
                         callback.onSuccess(result.allOutput)
@@ -100,13 +110,13 @@ class AdbShellExecutor(private val context: Context) {
                         callback.onError("Exit code ${result.exitCode}: ${result.allOutput}")
                     }
                 } catch (e: Exception) {
-                    logger.error(TAG, "Command execution failed: $command", e)
+                    logger.error(TAG, "adb#$seq FAILED after ${System.currentTimeMillis() - t0}ms: $command", e)
                     callback.onError("Execution failed: ${e.message}")
                 }
             }
         } catch (e: java.util.concurrent.RejectedExecutionException) {
             // Executor shut down — drop the command silently (app is tearing down).
-            logger.warn(TAG, "execute() rejected (executor shutting down): $command")
+            logger.warn(TAG, "adb#$seq REJECTED (executor shut down): $command")
         }
     }
     
@@ -233,11 +243,21 @@ class AdbShellExecutor(private val context: Context) {
     }
     
     fun getOrCreateConnection(): Dadb {
+        // sharedDadbLock is PROCESS-WIDE and the liveness probe below is an un-timed blocking
+        // round-trip. If that probe hangs on a half-dead connection every AdbShellExecutor in the
+        // process stalls behind this monitor — and a thread blocked on a monitor reports as
+        // S (sleeping), which is indistinguishable from idle in /proc. Time it explicitly.
+        val tWait = System.currentTimeMillis()
         synchronized(sharedDadbLock) {
+            val waited = System.currentTimeMillis() - tWait
+            if (waited > 1000) logger.warn(TAG, "getOrCreateConnection: waited ${waited}ms for sharedDadbLock")
             var dadb = sharedDadb
             if (dadb != null) {
                 try {
+                    val tProbe = System.currentTimeMillis()
                     val result = dadb.shell("echo ok")
+                    val probeMs = System.currentTimeMillis() - tProbe
+                    if (probeMs > 1000) logger.warn(TAG, "getOrCreateConnection: liveness probe took ${probeMs}ms (holding the shared lock)")
                     if (result.exitCode == 0) {
                         if (isAuthPending.getAndSet(false)) {
                             wasAuthGranted.set(true)

--- a/app/src/main/java/com/overdrive/app/launcher/ExecutorFallback.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/ExecutorFallback.kt
@@ -1,0 +1,64 @@
+package com.overdrive.app.launcher
+
+import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
+
+/**
+ * Submit policy for work whose owning executor may have been shut down under it.
+ *
+ * `AdbShellExecutor` holds a per-instance executor that dies with its owning
+ * `DaemonStartupManager`. `initializeOnAppLaunch()` shuts the previous manager's executor
+ * down during the bootManager→Activity handoff, and the daemon-start paths are *chains* —
+ * each ADB reply drives the next command — so a chain in flight at that moment loses every
+ * remaining step.
+ *
+ * The distinction the original code missed is that **ownership transfer is not process
+ * teardown**. "The executor is dead, so the remaining commands are moot" holds when the app
+ * is exiting and is wrong when a new owner has just taken over: the commands are exactly as
+ * live as they were a millisecond earlier, and dropping them is how a daemon silently fails
+ * to start.
+ *
+ * Kept as a pure function over two injected [Executor]s so the policy is unit-testable
+ * without a Context, an ADB connection, or a real thread pool — same reasoning as
+ * `DaemonStopGate`.
+ */
+object ExecutorFallback {
+
+    /** What happened to a submitted task. Named, so callers can log the cases apart. */
+    enum class Outcome {
+        /** Accepted by the owning executor — the normal path. */
+        OWNER,
+
+        /** Owner refused (shut down); the shared executor took it. */
+        REROUTED,
+
+        /** Both refused. The process really is going away. */
+        REFUSED
+    }
+
+    /**
+     * Try [owner] first, then [shared].
+     *
+     * Never throws: [RejectedExecutionException] from either executor is converted into an
+     * [Outcome]. That is load-bearing, not defensive — `AdbShellExecutor.execute()` is
+     * called from inside onSuccess/onError callbacks running on a worker thread, where an
+     * uncaught rejection kills the process.
+     *
+     * Only [RejectedExecutionException] is caught. Anything else (an executor whose
+     * thread factory throws, say) is a real defect and must not be silently rerouted.
+     */
+    fun submit(task: Runnable, owner: Executor, shared: Executor): Outcome {
+        try {
+            owner.execute(task)
+            return Outcome.OWNER
+        } catch (e: RejectedExecutionException) {
+            // Owner is gone; the work is not.
+        }
+        return try {
+            shared.execute(task)
+            Outcome.REROUTED
+        } catch (e: RejectedExecutionException) {
+            Outcome.REFUSED
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/ui/daemon/DaemonBootSchedule.kt
+++ b/app/src/main/java/com/overdrive/app/ui/daemon/DaemonBootSchedule.kt
@@ -1,0 +1,51 @@
+package com.overdrive.app.ui.daemon
+
+/**
+ * Pure boot-timing policy for the daemon startup sequence.
+ *
+ * Extracted from [DaemonStartupManager.initializeOnBoot] so the ordering rule is
+ * unit-testable without a Looper, a Context, or an ADB connection.
+ *
+ * The rule that matters is the Tailscale lead. The MQTT publisher lives inside the
+ * camera daemon, and when the tunnel is enabled a LAN broker is normally reachable
+ * ONLY through the SOCKS proxy that tailscaled exposes. Starting the camera daemon
+ * first means the publisher wakes, finds no proxy and — per issue #182 — defers.
+ *
+ * What that deferral costs is small, and NOT the 300s backoff an earlier version of
+ * this comment claimed. The #182 fix is already in this branch's history, and its
+ * whole point is that it does *not* bump `consecutiveFailures` while waiting on the
+ * proxy: `MqttConnectionManager` therefore re-probes at the min-interval floor
+ * (`DEFAULT_MIN_INTERVAL` = 5s) and connects the moment the listener binds. A few
+ * seconds of ordering slip costs a few seconds of telemetry.
+ *
+ * The lead earns its keep at the TAIL, not the average. The deferral is bounded by
+ * `PROXY_WARMUP_GRACE_MS` (60s), after which the publisher gives up waiting and falls
+ * through to a direct dial — which off Wi-Fi can never reach a LAN address, so the
+ * connection then churns until something restarts the daemon. With the core daemons
+ * first, tailscaled is only *launched* at 60s and needs a further 10–40s, while the
+ * grace window opens when MQTT first defers (~45–50s): that lands near the edge of
+ * the window, and past it the failure is the bad one. Leading with tailscaled moves
+ * the proxy up to ~40–70s, comfortably inside. Buying that margin is the point — not
+ * the handful of seconds saved on a good boot.
+ */
+object DaemonBootSchedule {
+
+    /** Tailscale goes first so its SOCKS listener is bound before MQTT starts. */
+    const val TAILSCALE_LEAD_DELAY_MS = 30_000L
+
+    /** Core daemons (camera — which owns MQTT — then the sentries). */
+    const val CORE_DELAY_MS = 45_000L
+
+    /** Remaining optional daemons/tunnels. */
+    const val OPTIONAL_DELAY_MS = 60_000L
+
+    /** Periodic liveness check that relaunches anything that died. */
+    const val HEALTH_CHECK_DELAY_MS = 90_000L
+
+    /**
+     * How much head start tailscaled gets over the core daemons. Positive by
+     * construction; asserted by [DaemonBootScheduleTest] so a future edit to the
+     * constants can't silently invert the order.
+     */
+    fun proxyLeadMs(): Long = CORE_DELAY_MS - TAILSCALE_LEAD_DELAY_MS
+}

--- a/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStartupManager.kt
+++ b/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStartupManager.kt
@@ -18,6 +18,9 @@ class DaemonStartupManager(
     private val daemonsViewModel: DaemonsViewModel? = null
 ) {
     private val log = LogManager.getInstance()
+    // Last supervised-optional-daemon set logged by this manager's health check, so the line is
+    // emitted on change rather than every 30s tick. Main-looper only; no @Volatile needed.
+    private var lastLoggedOptional: List<String>? = null
     private val handler = Handler(Looper.getMainLooper())
 
     // Dedicated looper for the 30s daemon health check. That tick does blocking
@@ -283,12 +286,67 @@ class DaemonStartupManager(
         // post-update path; missing from the cold-start launch flow.)
         clearStaleSentinels()
 
+        // Same Tailscale lead as the boot path. This path matters MORE in practice: BYD's
+        // broadcast suppression means the app is normally started by hand (`am start`) rather
+        // than by BOOT_COMPLETED, so initializeOnAppLaunch — not initializeOnBoot — is what
+        // actually runs. Hardware test 2026-07-31 with only the boot path fixed measured
+        // byd_cam_daemon at +50s and tailscaled at +65s, i.e. MQTT still came up 15s before
+        // its proxy existed.
+        scheduleTailscaleLead("App launch")
+
         // Wait 45 seconds for system to fully stabilize before starting any daemons
-        handler.postDelayed({ startCoreDaemons() }, 45000)
-        handler.postDelayed({ startOptionalDaemonsFromPreferences() }, 60000)
+        handler.postDelayed({ startCoreDaemons() }, DaemonBootSchedule.CORE_DELAY_MS)
+        handler.postDelayed({ startOptionalDaemonsFromPreferences() }, DaemonBootSchedule.OPTIONAL_DELAY_MS)
 
         // Start periodic health check after initial daemons have had time to start
-        handler.postDelayed({ startDaemonHealthCheck() }, 90000)
+        handler.postDelayed({ startDaemonHealthCheck() }, DaemonBootSchedule.HEALTH_CHECK_DELAY_MS)
+    }
+
+    /**
+     * Give tailscaled a head start over the core daemons when the tunnel is enabled.
+     *
+     * The camera daemon owns the MQTT publisher, and with the tunnel enabled the broker is
+     * normally reachable ONLY through tailscaled's SOCKS listener. Starting the camera daemon
+     * first makes the publisher defer (issue #182). That deferral is cheap — the #182 fix does
+     * not bump `consecutiveFailures` while waiting, so the publish loop re-probes every 5s and
+     * connects as soon as the listener binds — but it is bounded by `PROXY_WARMUP_GRACE_MS`
+     * (60s), and past that the publisher falls through to a direct dial that can never reach a
+     * LAN address off Wi-Fi. The lead exists to keep the proxy inside that window, not to save
+     * the few seconds of telemetry a good boot would lose anyway. See [DaemonBootSchedule].
+     *
+     * The preference is read INSIDE the callback, not at schedule time: these initializers run
+     * at t=0, when PreferencesManager may not be initialized yet. The later optional-daemon
+     * pass still starts Tailscale too; that call is idempotent (TailscaleLauncher.launchTailscale
+     * probes isTunnelRunning and no-ops), so it doubles as a retry if this early start failed.
+     */
+    private fun scheduleTailscaleLead(phase: String) {
+        handler.postDelayed({
+            // Log the decision either way. An optional daemon that isn't "enabled" is skipped
+            // by BOTH the startup pass and runHealthCheck with NO log line at all, so a
+            // preference that reads back false is invisible — the daemon simply never starts
+            // and nothing says why. That silence cost a full hardware debug cycle on
+            // 2026-07-31; make it observable.
+            val enabled = try {
+                PreferencesManager.getEnabledDaemons().map { it.name }
+            } catch (e: Exception) {
+                log.warn(TAG, "$phase: could not read enabled daemons (${e.message}) — skipping Tailscale lead")
+                return@postDelayed
+            }
+            if (DaemonType.TAILSCALE_TUNNEL.name !in enabled) {
+                log.info(TAG, "$phase: Tailscale not enabled in preferences (enabled=$enabled) — no lead scheduled")
+                return@postDelayed
+            }
+
+            // ifNotUserStopped now checks the sentinel locally (see DaemonStopGate), so it can no
+            // longer be silently disarmed by a shut-down executor — which is what stopped this
+            // lead from ever firing on hardware before that fix.
+            ifNotUserStopped(DaemonType.TAILSCALE_TUNNEL) {
+                log.info(TAG, "$phase: starting Tailscale ${DaemonBootSchedule.proxyLeadMs() / 1000}s " +
+                    "ahead of the core daemons (if the SOCKS proxy toggle is on, this is what lets " +
+                    "MQTT start into a live proxy instead of deferring)")
+                startTailscaleOnBoot()
+            }
+        }, DaemonBootSchedule.TAILSCALE_LEAD_DELAY_MS)
     }
 
     /**
@@ -340,12 +398,14 @@ class DaemonStartupManager(
         // immediately. See initializeOnAppLaunch for the full rationale.
         clearStaleSentinels()
 
+        scheduleTailscaleLead("Boot")
+
         // Wait 45 seconds for system to fully stabilize before starting any daemons
-        handler.postDelayed({ startCoreDaemonsViaAdb() }, 45000)
-        handler.postDelayed({ startOptionalDaemonsViaAdb() }, 60000)
+        handler.postDelayed({ startCoreDaemonsViaAdb() }, DaemonBootSchedule.CORE_DELAY_MS)
+        handler.postDelayed({ startOptionalDaemonsViaAdb() }, DaemonBootSchedule.OPTIONAL_DELAY_MS)
 
         // Start periodic health check after initial daemons have had time to start
-        handler.postDelayed({ startDaemonHealthCheck() }, 90000)
+        handler.postDelayed({ startDaemonHealthCheck() }, DaemonBootSchedule.HEALTH_CHECK_DELAY_MS)
     }
 
 
@@ -446,61 +506,41 @@ class DaemonStartupManager(
      * Core daemons don't need this gate — clearStaleSentinels intentionally
      * re-arms them — so this is only wired into the optional starts.
      *
-     * Probe runs as the app's shared launcher (UID lets it stat
-     * /data/local/tmp). On probe error we bias toward starting (same
-     * availability bias as relaunchDaemon): a missed start is recoverable by
-     * the user, and the daemon is already pref-enabled here.
+     * The sentinel is stat'd LOCALLY, from the app process. This was an ADB round-trip whose reply
+     * callback carried the actual start, so the decision depended on a reply that is not guaranteed
+     * to arrive (see [DaemonStopGate], including why `false` means "absent OR invisible"). Removing
+     * that dependency is hardening — it was NOT shown to be the cause of any observed failure.
+     *
+     * Delivery of [onAllowed] is unchanged: still posted to the main looper, because four of the
+     * call sites invoke this from an ADB worker thread inside a `*Controller.isRunning { }`
+     * callback and their bodies touch DaemonsViewModel.
      */
     private fun ifNotUserStopped(type: DaemonType, onAllowed: () -> Unit) {
-        // The sentinel is present for MACHINE stops too, not just user stops, and
-        // the machine ones are not cleared post-update for optional daemons. So
-        // existence alone keeps a pref-enabled daemon down after any app update
-        // until something else revives it — for Telegram, the next ACC-off edge,
-        // which reads the same file's TEXT and correctly restarts. Read the text
-        // here too so both gates agree about the same file.
-        //
-        // TELEGRAM ONLY, deliberately. Its sentinel is the one whose text is an
-        // authoritative discriminator: the update sweep writes it write-if-absent
-        // (AppUpdater.stopAllDaemons), so "stopAllDaemons" can only appear when no
-        // user stop was already recorded. zrok's sentinel carries the same text but
-        // is still written with a clobbering `>`, and additionally encodes
-        // mutual-exclusion and killDaemon stops — so trusting its text would read a
-        // clobbered user stop as a machine stop. Those daemons keep the
-        // existence-only gate until their writers are made write-if-absent too.
-        val contentAware = type == DaemonType.TELEGRAM_DAEMON
-        val probe = if (contentAware) {
-            "if [ -f ${type.sentinelPath} ]; then " +
-                "if head -1 ${type.sentinelPath} 2>/dev/null | " +
-                "grep -qE 'ACC-on|stopAllDaemons'; then echo MACHINE; " +
-                "else echo STOPPED; fi; " +
-            "else echo OK; fi"
+        // Decide stop-intent LOCALLY (no ADB round-trip — see [DaemonStopGate]), while preserving
+        // upstream's content-aware discrimination for Telegram: its sentinel's TEXT distinguishes a
+        // MACHINE stop (ACC-off sweep / the update sweep's write-if-absent "stopAllDaemons") from a
+        // real user stop, and only a user stop must suppress a pref-enabled start. Ported from the
+        // former `head -1 | grep -qE 'ACC-on|stopAllDaemons'` ADB probe to a local first-line read.
+        val blocked = if (type == DaemonType.TELEGRAM_DAEMON) {
+            DaemonStopGate.isStartBlockedContentAware(type.sentinelPath, fileExists, firstLineOf)
         } else {
-            "test -f ${type.sentinelPath} && echo STOPPED || echo OK"
+            DaemonStopGate.isStartBlocked(type.sentinelPath, fileExists)
         }
-        adbLauncher.executeShellCommand(
-            probe,
-            object : AdbDaemonLauncher.LaunchCallback {
-                override fun onLog(message: String) {
-                    val out = message.trim()
-                    if (out.contains("STOPPED")) {
-                        log.info(TAG, "Optional startup: ${type.displayName} has a user-stop " +
-                            "sentinel — not auto-starting")
-                    } else {
-                        if (out.contains("MACHINE")) {
-                            log.info(TAG, "Optional startup: ${type.displayName} sentinel is a " +
-                                "machine stop, not a user stop — starting")
-                        }
-                        handler.post { onAllowed() }
-                    }
-                }
-                override fun onLaunched() {}
-                override fun onError(error: String) {
-                    log.warn(TAG, "Optional startup sentinel probe failed for " +
-                        "${type.displayName} ($error) — starting (pref-enabled)")
-                    handler.post { onAllowed() }
-                }
-            }
-        )
+        if (blocked) {
+            log.info(TAG, "Optional startup: ${type.displayName} has a user-stop " +
+                "sentinel — not auto-starting")
+            return
+        }
+        handler.post { onAllowed() }
+    }
+
+    /** Injected so the gate's policy stays unit-testable and the call sites stay honest. */
+    private val fileExists: (String) -> Boolean = { java.io.File(it).exists() }
+
+    /** Reads a sentinel's first line locally for the content-aware Telegram gate; null on any
+     *  read failure (caller treats null as "present but unreadable" — a user stop). */
+    private val firstLineOf: (String) -> String? = { path ->
+        try { java.io.File(path).bufferedReader().use { it.readLine() } } catch (_: Exception) { null }
     }
 
     private fun startOptionalDaemonsFromPreferences() {
@@ -910,12 +950,23 @@ class DaemonStartupManager(
         }
 
         // Optional daemons: only restart if user had them enabled in preferences.
-        // Guard ORDER matters for cost (the conjunction is unchanged):
-        // isDaemonEnabled is an in-memory SharedPreferences set lookup, while
-        // isDaemonStoppedViaTelegram opens + Properties.load()s a file. Checking
-        // the cheap in-memory gate FIRST means a disabled optional daemon no
-        // longer pays a disk read every 30s tick, forever. Same decisions, same
-        // relaunch behaviour — pure short-circuit reordering.
+        // #197: log the supervised optional set on CHANGE — the observability that would have
+        // surfaced the 2026-07-29 dead-tailscaled outage. Grafted onto upstream's batched check.
+        val enabledOptional = try {
+            PreferencesManager.getEnabledDaemons().filter { it in OPTIONAL_DAEMONS }.map { it.name }
+        } catch (e: Exception) {
+            log.warn(TAG, "Health check: cannot read enabled daemons: ${e.message}")
+            emptyList()
+        }
+        if (enabledOptional != lastLoggedOptional) {
+            lastLoggedOptional = enabledOptional
+            log.info(TAG, "Health check: supervising optional daemons $enabledOptional " +
+                "(others are skipped silently by design)")
+        }
+
+        // Guard ORDER matters for cost (upstream v36.6): the cheap in-memory isDaemonEnabled check
+        // runs before the file-reading isDaemonStoppedViaTelegram, so a disabled optional daemon no
+        // longer pays a disk read every tick.
         for (type in OPTIONAL_DAEMONS) {
             if (type in userStoppedDaemons) continue
             if (!PreferencesManager.isDaemonEnabled(type)) continue
@@ -925,10 +976,8 @@ class DaemonStartupManager(
 
         if (candidates.isEmpty()) return
 
-        // ZROK keeps its bespoke two-layer check (process-alive AND edge-stale
-        // HTTP probe) — a `ps` snapshot cannot detect a stale zrok edge, so
-        // routing it through the snapshot would silently lose the 8-9h 502
-        // recovery. Dispatch it on its own path exactly as before.
+        // ZROK keeps its bespoke two-layer check (process-alive AND edge-stale HTTP probe) — a `ps`
+        // snapshot cannot detect a stale zrok edge, so route it on its own path exactly as before.
         val zrokCandidate = candidates.remove(DaemonType.ZROK_TUNNEL)
         if (zrokCandidate) checkAndRelaunchDaemon(DaemonType.ZROK_TUNNEL)
 
@@ -936,12 +985,6 @@ class DaemonStartupManager(
 
         adbLauncher.snapshotProcessTable { snapshot ->
             if (snapshot == null) {
-                // Probe failed (adb transport hiccup). Treat as UNKNOWN, not
-                // dead: the old per-daemon path also reported false-on-error but
-                // then funnelled through relaunchDaemon's sentinel probe, which
-                // biases to relaunch. Skipping this tick entirely is the
-                // conservative choice — the next tick is only 30s away, and the
-                // shell-side watchdogs cover a genuinely dead daemon meanwhile.
                 log.warn(TAG, "Health check: ps snapshot unavailable — skipping this tick")
                 return@snapshotProcessTable
             }
@@ -1066,8 +1109,9 @@ class DaemonStartupManager(
         // the health-check) OR a user-initiated stop from the Daemons UI or
         // Telegram (sentinel present → leave it down). This probe is the only
         // check that works regardless of which UID wrote the stop: the
-        // sentinel is `chmod 666` in /data/local/tmp, readable by both the app
-        // and the UID-2000 daemon family. The in-memory userStoppedDaemons set
+        // stop files live in /data/local/tmp, which the app process can stat directly
+        // (search permission on the directory — the files' 0666 mode is irrelevant to
+        // exists(); see DaemonStopGate). The in-memory userStoppedDaemons set
         // is wiped on app relaunch, and the legacy Telegram .properties file is
         // unreadable across the UID boundary — so without this probe a
         // Telegram or post-restart stop gets resurrected within 30s.
@@ -1075,34 +1119,21 @@ class DaemonStartupManager(
         // Every relaunch path (generic dead-process, zrok PROCESS_DEAD, zrok
         // EDGE_STALE, boot-path ADB fallback) funnels through here, so gating
         // once at this chokepoint covers them all.
-        adbLauncher.executeShellCommand(
-            "test -f ${type.sentinelPath} -o -f ${com.overdrive.app.ui.model.ParkedShutdown.MARKER_PATH} && echo STOPPED || echo OK",
-            object : com.overdrive.app.launcher.AdbDaemonLauncher.LaunchCallback {
-                override fun onLog(message: String) {
-                    if (message.trim().contains("STOPPED")) {
-                        // STOPPED = user disable sentinel present, OR the "Vehicle ON only"
-                        // parked-shutdown marker present. In onOnly the whole stack is
-                        // terminated on park and MUST NOT be revived by the 30s health-check
-                        // until the ACC-on edge clears the marker.
-                        log.info(TAG, "Health check: ${type.displayName} is stopped " +
-                            "(disable sentinel or parked-shutdown marker present) — NOT relaunching")
-                    } else {
-                        doRelaunchDaemon(type)
-                    }
-                }
-                override fun onLaunched() {}
-                override fun onError(error: String) {
-                    // Probe failed (transport hiccup). Bias toward availability:
-                    // relaunch rather than leave a crashed daemon dead on a
-                    // false negative. A user-stopped daemon whose sentinel we
-                    // couldn't read will be re-killed on the user's next stop;
-                    // a crashed safety daemon left dead is the worse outcome.
-                    log.warn(TAG, "Health check: sentinel probe failed for " +
-                        "${type.displayName} ($error) — relaunching defensively")
-                    doRelaunchDaemon(type)
-                }
-            }
-        )
+        // Checked LOCALLY (see DaemonStopGate). Previously an ADB round-trip whose reply callback
+        // carried the relaunch, so a shut-down executor could disarm the health check — the one
+        // thing standing between a crashed daemon and an indefinitely dead stack.
+        // STOPPED = user disable sentinel present, OR the "Vehicle ON only" parked-shutdown marker
+        // present. In onOnly the whole stack is terminated on park and MUST NOT be revived by the
+        // 30s health-check until the ACC-on edge clears the marker.
+        if (DaemonStopGate.isRelaunchBlocked(
+                sentinelPath = type.sentinelPath,
+                markerPath = com.overdrive.app.ui.model.ParkedShutdown.MARKER_PATH,
+                exists = fileExists)) {
+            log.info(TAG, "Health check: ${type.displayName} is stopped " +
+                "(disable sentinel or parked-shutdown marker present) — NOT relaunching")
+            return
+        }
+        doRelaunchDaemon(type)
     }
 
     private fun doRelaunchDaemon(type: DaemonType) {

--- a/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStopGate.kt
+++ b/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStopGate.kt
@@ -1,0 +1,111 @@
+package com.overdrive.app.ui.daemon
+
+/**
+ * Decides whether a daemon is under a *stop intent* and must not be (re)started.
+ *
+ * Two stop signals, both plain files under `/data/local/tmp`:
+ *  - the per-daemon **user-stop sentinel** (`DaemonType.sentinelPath`) — written by the Daemons UI
+ *    or by a Telegram `/daemon <x> stop`, which records the stop ONLY in this cross-UID file and
+ *    never in the app's SharedPreferences;
+ *  - the **parked-shutdown marker** — in "Vehicle ON only" the whole stack is torn down on park and
+ *    must stay down until the ACC-on edge clears the marker.
+ *
+ * The two callers want different policies, so they get named entry points rather than a boolean:
+ * [isStartBlocked] (startup — sentinel only) and [isRelaunchBlocked] (health check — sentinel OR
+ * park marker). Passing the wrong policy is the kind of mistake a boolean invites and a name does
+ * not, and it matters: mixing them up would let the 30s health check revive a parked stack.
+ *
+ * ## Why this exists
+ *
+ * These files used to be probed with `test -f … && echo STOPPED || echo OK` sent over the app's own
+ * ADB connection, with the caller's real work happening inside the reply callback. That makes a
+ * required decision depend on a reply that is not guaranteed to arrive: `AdbShellExecutor.execute()`
+ * swallows `RejectedExecutionException` once its executor is shut down, and `initializeOnAppLaunch()`
+ * shuts down the previous manager's executor during the bootManager→Activity handoff, so work that
+ * manager had already `postDelayed` can no-op with no log line.
+ *
+ * HONESTY NOTE — that failure mode is structural, not observed. It was originally believed to be the
+ * cause of tailscaled failing to auto-start on a BYD Seal head unit, but instrumenting the executor
+ * (correlation-id SUBMIT/RUN/DONE logging, plus lock- and probe-timers) disproved it: every command
+ * in that chain was submitted, ran, and returned exit 0, with no rejections and no lock contention.
+ * The original symptom turned out to be a measurement artifact in the diagnosis harness. This change
+ * therefore removes a genuine fragility and is NOT a fix for that bug — do not cite it as one.
+ *
+ * ## What makes the local check valid — and its one blind spot
+ *
+ * `File.exists()` needs **search (`x`) permission on every parent directory**, not read permission
+ * on the file; the sentinels' `0666` mode is irrelevant to it. What actually makes this work is
+ * `/data/local/tmp` being `0771` plus permissive SELinux for the app domain on this head unit. That
+ * is empirically established: `BootReceiver`, `DaemonKeepaliveService`, `StatusOverlayService` and
+ * `LocationSidecarService` already read the park marker this way from the app process, and park
+ * mode works in the field.
+ *
+ * **Blind spot:** `File.exists()` cannot throw here (no SecurityManager; `stat`/`access` failures
+ * such as EACCES or an unsearchable parent simply return `false`). So `false` means "absent **or
+ * invisible**", and this class cannot tell them apart. If a future OTA tightens `/data/local/tmp`
+ * or SELinux, both signals silently read absent — resurrecting user-stopped daemons and, worse,
+ * letting the health check relaunch the whole stack every 30s while parked. Nothing in-process can
+ * distinguish the two cases, so callers that care should verify visibility out-of-band rather than
+ * trusting a bare `false`.
+ *
+ * Kept as pure functions over an injected `exists` predicate so the policy is unit-testable without
+ * a device, an ADB connection, or a filesystem.
+ */
+object DaemonStopGate {
+
+    /**
+     * Startup policy: block only on the per-daemon user-stop sentinel.
+     *
+     * The park marker is deliberately NOT consulted. This reproduces the previous probe exactly
+     * (`test -f <sentinel>`, no marker term), and the startup paths cannot run under a live marker
+     * anyway — `initializeOnAppLaunch` clears it before scheduling, and on the boot path
+     * `BootReceiver.startDaemons` refuses to reach `startOnBoot` while the marker is present unless
+     * the trigger is a recovery trigger.
+     */
+    fun isStartBlocked(sentinelPath: String?, exists: (String) -> Boolean): Boolean =
+        sentinelPath != null && exists(sentinelPath)
+
+    /** Machine-stop markers in a content-aware sentinel's first line: the ACC-off sweep and the
+     *  update sweep's write-if-absent `stopAllDaemons`. Neither is a user stop. */
+    private val MACHINE_STOP = Regex("ACC-on|stopAllDaemons")
+
+    /**
+     * Startup policy for a **content-aware** sentinel (Telegram): block on the user-stop sentinel
+     * UNLESS its first line marks a MACHINE stop, which is not a user stop and must not suppress a
+     * pref-enabled start. This is the local port of the former over-ADB probe
+     * `head -1 <sentinel> | grep -qE 'ACC-on|stopAllDaemons'`.
+     *
+     * TELEGRAM ONLY, deliberately: its sentinel's text is an authoritative discriminator because the
+     * update sweep writes it write-if-absent (`AppUpdater.stopAllDaemons`), so `stopAllDaemons` can
+     * only appear when no user stop was already recorded. zrok's sentinel carries the same text but
+     * is written with a clobbering `>`, so trusting its text would read a clobbered user stop as a
+     * machine stop — those daemons keep the existence-only [isStartBlocked] gate.
+     *
+     * An existing-but-unreadable sentinel (`firstLine` returns null) is treated as a user stop
+     * (blocked), matching the old probe: with no readable first line its `grep` found no machine
+     * marker and echoed STOPPED. Absent sentinel → not blocked, same as [isStartBlocked].
+     */
+    fun isStartBlockedContentAware(
+        sentinelPath: String?,
+        exists: (String) -> Boolean,
+        firstLine: (String) -> String?
+    ): Boolean {
+        if (sentinelPath == null || !exists(sentinelPath)) return false
+        val head = firstLine(sentinelPath) ?: return true
+        return !MACHINE_STOP.containsMatchIn(head)
+    }
+
+    /**
+     * Health-check policy: block on the user-stop sentinel OR the parked-shutdown marker.
+     *
+     * The health check is the one path that could otherwise revive a stack that "Vehicle ON only"
+     * deliberately tore down on park, so it must see the marker.
+     */
+    fun isRelaunchBlocked(
+        sentinelPath: String?,
+        markerPath: String?,
+        exists: (String) -> Boolean
+    ): Boolean =
+        (sentinelPath != null && exists(sentinelPath)) ||
+            (markerPath != null && exists(markerPath))
+}

--- a/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStopGate.kt
+++ b/app/src/main/java/com/overdrive/app/ui/daemon/DaemonStopGate.kt
@@ -31,6 +31,12 @@ package com.overdrive.app.ui.daemon
  * The original symptom turned out to be a measurement artifact in the diagnosis harness. This change
  * therefore removes a genuine fragility and is NOT a fix for that bug — do not cite it as one.
  *
+ * SCOPE — this gate covers the DECISION only. The ACTION it guards (`startTailscaleOnBoot`, and the
+ * `vm.startDaemon` paths) still runs over the per-manager ADB executor, so a handoff that lands
+ * mid-chain can still lose the start. That half is addressed separately, by
+ * `AdbShellExecutor.submit()` rerouting a rejected command to a process-wide executor rather than
+ * dropping it. Neither change alone closes the window; read them together.
+ *
  * ## What makes the local check valid — and its one blind spot
  *
  * `File.exists()` needs **search (`x`) permission on every parent directory**, not read permission
@@ -62,8 +68,8 @@ object DaemonStopGate {
      * `BootReceiver.startDaemons` refuses to reach `startOnBoot` while the marker is present unless
      * the trigger is a recovery trigger.
      */
-    fun isStartBlocked(sentinelPath: String?, exists: (String) -> Boolean): Boolean =
-        sentinelPath != null && exists(sentinelPath)
+    fun isStartBlocked(sentinelPath: String, exists: (String) -> Boolean): Boolean =
+        exists(sentinelPath)
 
     /** Machine-stop markers in a content-aware sentinel's first line: the ACC-off sweep and the
      *  update sweep's write-if-absent `stopAllDaemons`. Neither is a user stop. */
@@ -102,10 +108,8 @@ object DaemonStopGate {
      * deliberately tore down on park, so it must see the marker.
      */
     fun isRelaunchBlocked(
-        sentinelPath: String?,
-        markerPath: String?,
+        sentinelPath: String,
+        markerPath: String,
         exists: (String) -> Boolean
-    ): Boolean =
-        (sentinelPath != null && exists(sentinelPath)) ||
-            (markerPath != null && exists(markerPath))
+    ): Boolean = exists(sentinelPath) || exists(markerPath)
 }

--- a/app/src/test/java/com/overdrive/app/launcher/ExecutorFallbackTest.kt
+++ b/app/src/test/java/com/overdrive/app/launcher/ExecutorFallbackTest.kt
@@ -1,0 +1,107 @@
+package com.overdrive.app.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
+
+/**
+ * Submit-policy tests.
+ *
+ * The property that matters: a task refused by the owning executor must still RUN, because
+ * "owner shut down" means the bootManager→Activity handoff took its executor away
+ * mid-chain, not that the app is exiting. Before this, such a task was logged once and
+ * dropped — and the dropped step was a daemon that then never started.
+ */
+class ExecutorFallbackTest {
+
+    /** Runs inline and records that it did. */
+    private class Recording : Executor {
+        var ran = 0
+        override fun execute(command: Runnable) {
+            ran++
+            command.run()
+        }
+    }
+
+    /** Always refuses, like a shut-down ThreadPoolExecutor. */
+    private object Refusing : Executor {
+        override fun execute(command: Runnable) = throw RejectedExecutionException("shut down")
+    }
+
+    @Test
+    fun healthyOwnerRunsTheTaskAndNeverTouchesTheShared() {
+        val owner = Recording()
+        val shared = Recording()
+        var ran = false
+
+        val outcome = ExecutorFallback.submit({ ran = true }, owner, shared)
+
+        assertEquals(ExecutorFallback.Outcome.OWNER, outcome)
+        assertTrue(ran)
+        assertEquals(1, owner.ran)
+        assertEquals("shared executor must not be touched on the happy path", 0, shared.ran)
+    }
+
+    @Test
+    fun deadOwnerReroutesAndTheTaskStillRuns() {
+        // The regression this exists for: the work must survive the handoff.
+        val shared = Recording()
+        var ran = false
+
+        val outcome = ExecutorFallback.submit({ ran = true }, Refusing, shared)
+
+        assertEquals(ExecutorFallback.Outcome.REROUTED, outcome)
+        assertTrue("a rerouted task must actually run, not just be reported", ran)
+        assertEquals(1, shared.ran)
+    }
+
+    @Test
+    fun bothDeadIsReportedAndTheTaskDoesNotRun() {
+        var ran = false
+
+        val outcome = ExecutorFallback.submit({ ran = true }, Refusing, Refusing)
+
+        assertEquals(ExecutorFallback.Outcome.REFUSED, outcome)
+        assertTrue("nothing should have run", !ran)
+    }
+
+    @Test
+    fun neverThrowsOnRejection() {
+        // Load-bearing: execute() is called from inside onSuccess/onError on a worker
+        // thread, where an uncaught RejectedExecutionException kills the process.
+        ExecutorFallback.submit({}, Refusing, Refusing)
+        ExecutorFallback.submit({}, Refusing, Recording())
+    }
+
+    @Test
+    fun nonRejectionFailuresPropagate() {
+        // A thread factory that blows up is a real defect, not a handoff. It must NOT be
+        // silently rerouted — that would turn a crash into a mysterious double execution.
+        val exploding = Executor { throw IllegalStateException("thread factory broken") }
+        val shared = Recording()
+
+        val thrown = try {
+            ExecutorFallback.submit({}, exploding, shared)
+            null
+        } catch (e: IllegalStateException) {
+            e
+        }
+
+        assertTrue("IllegalStateException must propagate", thrown != null)
+        assertEquals("must not have fallen through to shared", 0, shared.ran)
+    }
+
+    @Test
+    fun theTaskIsSubmittedOnceNotTwice() {
+        // Guards against a reroute that leaves the task queued on both executors — which on
+        // the daemon paths would mean starting the same daemon twice.
+        val shared = Recording()
+        var runs = 0
+
+        ExecutorFallback.submit({ runs++ }, Refusing, shared)
+
+        assertEquals(1, runs)
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/daemon/DaemonBootScheduleTest.kt
+++ b/app/src/test/java/com/overdrive/app/ui/daemon/DaemonBootScheduleTest.kt
@@ -1,0 +1,39 @@
+package com.overdrive.app.ui.daemon
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Ordering invariants for the boot schedule.
+ *
+ * Deliberately narrow: these pin the *relative order* of the phases, which is the property the
+ * Tailscale lead depends on and the one a careless edit to the constants would invert. They do NOT
+ * assert the absolute values — those are tuning, not contract — and they cannot prove the lead is
+ * long enough in the field (tailscaled's own start latency was measured between 10s and 40s on the
+ * head unit, so the fixed lead narrows the race rather than closing it; see DaemonBootSchedule).
+ */
+class DaemonBootScheduleTest {
+
+    @Test
+    fun tailscaleLeadsTheCoreDaemons() {
+        assertTrue(
+            "tailscaled must be launched before the camera daemon starts MQTT",
+            DaemonBootSchedule.TAILSCALE_LEAD_DELAY_MS < DaemonBootSchedule.CORE_DELAY_MS
+        )
+        assertTrue(DaemonBootSchedule.proxyLeadMs() > 0)
+    }
+
+    @Test
+    fun phasesRunInTheDocumentedOrder() {
+        assertTrue(DaemonBootSchedule.TAILSCALE_LEAD_DELAY_MS < DaemonBootSchedule.CORE_DELAY_MS)
+        assertTrue(DaemonBootSchedule.CORE_DELAY_MS < DaemonBootSchedule.OPTIONAL_DELAY_MS)
+        assertTrue(DaemonBootSchedule.OPTIONAL_DELAY_MS < DaemonBootSchedule.HEALTH_CHECK_DELAY_MS)
+    }
+
+    @Test
+    fun bootStillStabilizesBeforeTheFirstLaunch() {
+        // The lead must not drag the first daemon launch back to the very start of boot, where the
+        // system is still settling — that is what the original 45s stabilisation delay was for.
+        assertTrue(DaemonBootSchedule.TAILSCALE_LEAD_DELAY_MS > 0)
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/daemon/DaemonStopGateTest.kt
+++ b/app/src/test/java/com/overdrive/app/ui/daemon/DaemonStopGateTest.kt
@@ -1,0 +1,145 @@
+package com.overdrive.app.ui.daemon
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Policy tests for the stop gate.
+ *
+ * The distinction that actually matters here is between the two entry points: startup must IGNORE
+ * the parked-shutdown marker, and the health check must HONOUR it. Getting that backwards would let
+ * the 30s health check resurrect a stack that "Vehicle ON only" deliberately tore down on park —
+ * defeating the zero-compute park and draining the 12V battery. That is why the policies are named
+ * functions rather than a boolean parameter: these tests pin each one to its caller's semantics.
+ */
+class DaemonStopGateTest {
+
+    private val SENTINEL = "/data/local/tmp/tailscale.disabled"
+    private val MARKER = "/data/local/tmp/overdrive_parked_shutdown"
+
+    private fun present(vararg paths: String) = { p: String -> p in paths }
+
+    // ---- startup policy: sentinel only ----
+
+    @Test
+    fun startup_allowsWhenNothingPresent() {
+        assertFalse(DaemonStopGate.isStartBlocked(SENTINEL, present()))
+    }
+
+    @Test
+    fun startup_blockedByUserStopSentinel() {
+        assertTrue(DaemonStopGate.isStartBlocked(SENTINEL, present(SENTINEL)))
+    }
+
+    @Test
+    fun startup_IGNORES_parkedMarker() {
+        // The startup paths cannot run under a live marker (BootReceiver gates the boot path;
+        // initializeOnAppLaunch clears it first), so a lingering marker must not block them.
+        // This reproduces the previous ADB probe exactly: `test -f <sentinel>`, no marker term.
+        assertFalse(DaemonStopGate.isStartBlocked(SENTINEL, present(MARKER)))
+    }
+
+    @Test
+    fun startup_nullSentinelNeverBlocks() {
+        assertFalse(DaemonStopGate.isStartBlocked(null, present(SENTINEL, MARKER)))
+    }
+
+    // ---- health-check policy: sentinel OR parked marker ----
+
+    @Test
+    fun relaunch_allowsWhenNothingPresent() {
+        assertFalse(DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, present()))
+    }
+
+    @Test
+    fun relaunch_blockedByUserStopSentinel() {
+        assertTrue(DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, present(SENTINEL)))
+    }
+
+    @Test
+    fun relaunch_HONOURS_parkedMarker() {
+        // The regression that matters: without this the health check revives a parked stack.
+        assertTrue(DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, present(MARKER)))
+    }
+
+    @Test
+    fun relaunch_blockedWhenBothPresent() {
+        assertTrue(DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, present(SENTINEL, MARKER)))
+    }
+
+    @Test
+    fun relaunch_checksSentinelIndependentlyOfMarker() {
+        // Guards against a short-circuit that only ever consults one of the two paths.
+        assertFalse(DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, present("/some/other/file")))
+    }
+
+    // ---- content-aware startup policy (Telegram): sentinel text discriminates user vs machine stop ----
+
+    private val TELEGRAM_SENTINEL = "/data/local/tmp/telegram_bot_daemon.disabled"
+    private fun firstLine(map: Map<String, String?>) = { p: String -> map[p] }
+
+    @Test
+    fun contentAware_allowsWhenSentinelAbsent() {
+        assertFalse(
+            DaemonStopGate.isStartBlockedContentAware(
+                TELEGRAM_SENTINEL, present(), firstLine(emptyMap())
+            )
+        )
+    }
+
+    @Test
+    fun contentAware_blocksOnUserStopText() {
+        // A user stop leaves text that is NOT a machine marker → block.
+        assertTrue(
+            DaemonStopGate.isStartBlockedContentAware(
+                TELEGRAM_SENTINEL, present(TELEGRAM_SENTINEL),
+                firstLine(mapOf(TELEGRAM_SENTINEL to "stopped by user 2026-08-02"))
+            )
+        )
+    }
+
+    @Test
+    fun contentAware_allowsMachineStopText() {
+        // The update sweep's write-if-absent "stopAllDaemons" and the ACC-off sweep are machine
+        // stops, not user stops — a pref-enabled daemon must start.
+        assertFalse(
+            DaemonStopGate.isStartBlockedContentAware(
+                TELEGRAM_SENTINEL, present(TELEGRAM_SENTINEL),
+                firstLine(mapOf(TELEGRAM_SENTINEL to "stopAllDaemons before update"))
+            )
+        )
+        assertFalse(
+            DaemonStopGate.isStartBlockedContentAware(
+                TELEGRAM_SENTINEL, present(TELEGRAM_SENTINEL),
+                firstLine(mapOf(TELEGRAM_SENTINEL to "ACC-on edge"))
+            )
+        )
+    }
+
+    @Test
+    fun contentAware_unreadableSentinelTreatedAsUserStop() {
+        // Present but unreadable (null first line) → block, matching the old `grep` echoing STOPPED.
+        assertTrue(
+            DaemonStopGate.isStartBlockedContentAware(
+                TELEGRAM_SENTINEL, present(TELEGRAM_SENTINEL),
+                firstLine(mapOf(TELEGRAM_SENTINEL to null))
+            )
+        )
+    }
+
+    // ---- the two policies must not be interchangeable ----
+
+    @Test
+    fun theTwoPoliciesDifferOnTheMarker() {
+        val markerOnly = present(MARKER)
+        assertFalse(
+            "startup must ignore the park marker",
+            DaemonStopGate.isStartBlocked(SENTINEL, markerOnly)
+        )
+        assertTrue(
+            "health check must honour the park marker",
+            DaemonStopGate.isRelaunchBlocked(SENTINEL, MARKER, markerOnly)
+        )
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/daemon/DaemonStopGateTest.kt
+++ b/app/src/test/java/com/overdrive/app/ui/daemon/DaemonStopGateTest.kt
@@ -40,11 +40,6 @@ class DaemonStopGateTest {
         assertFalse(DaemonStopGate.isStartBlocked(SENTINEL, present(MARKER)))
     }
 
-    @Test
-    fun startup_nullSentinelNeverBlocks() {
-        assertFalse(DaemonStopGate.isStartBlocked(null, present(SENTINEL, MARKER)))
-    }
-
     // ---- health-check policy: sentinel OR parked marker ----
 
     @Test


### PR DESCRIPTION
Three related changes to the daemon startup/supervision path, plus a boot-ordering tweak that rides along in the same file.

## 1. `feat(adb): make shell command lifecycle observable`

`AdbShellExecutor` logged a single DEBUG line from *inside* the submitted runnable. That makes three different outcomes look identical — never submitted, submitted but never run, and ran fine — because all of them present as "no log line".

Now logs `SUBMIT` (before the submit, on the caller's thread), `RUN` and `DONE` with a correlation id, thread name, connect time, total time and exit code; the id is carried into the failure and rejection paths. Also times `sharedDadbLock` acquisition and the liveness probe taken while holding it — that lock is process-wide and the probe is an un-timed blocking round-trip, and a thread blocked on a monitor reports as `S (sleeping)`, i.e. indistinguishable from idle in `/proc`.

This is the commit that made the rest knowable. It disproved two confidently-held root causes: every command in the suspect chain was submitted, ran, and returned exit 0, with no rejections and no lock contention (25–93 ms round-trips).

## 2. `refactor(daemons): decide stop-intent locally instead of over ADB`

Optional-daemon starts and health-check relaunches gated a required decision behind `test -f <sentinel>` over ADB, with the caller's real work inside the reply callback. That reply isn't guaranteed to arrive — `execute()` swallows `RejectedExecutionException` once the executor is shut down, and `initializeOnAppLaunch()` shuts down the previous manager's executor during the bootManager→Activity handoff.

**Scope: this is hardening, not a bug fix.** The fragility is structural and real, but it was *not* shown to cause any observed failure. I originally believed it explained tailscaled failing to auto-start on my head unit; the instrumentation above disproved that, and the symptom turned out to be an artifact of my own diagnosis harness. The honesty note is on `DaemonStopGate` so nobody cites it as a fix later.

- `DaemonStopGate` with two **named** policies rather than a boolean — `isStartBlocked` (sentinel only, reproducing the old probe exactly) and `isRelaunchBlocked` (sentinel OR parked-shutdown marker). Swapping them would let the 30s health check revive a stack that "Vehicle ON only" tore down on park, so tests pin the distinction.
- `ifNotUserStopped()` rewritten to use it — **signature unchanged, so all 11 call sites are fixed without touching any**. `onAllowed` is still delivered via `handler.post`, because four call sites invoke it from an ADB worker thread and touch `DaemonsViewModel`.
- `relaunchDaemon()`'s gate likewise.
- The supervised optional-daemon set is logged **on change**. A one-shot latches whatever the first tick saw, which on the boot path can be an empty set. An optional daemon that isn't enabled was previously skipped by *both* the startup pass and `runHealthCheck` with zero output.

Reading these files locally is already the established idiom — `BootReceiver`, `DaemonKeepaliveService`, `StatusOverlayService` and `LocationSidecarService` all use `File(MARKER_PATH).exists()` from the app process.

**Documented blind spot:** `File.exists()` cannot throw here, so `false` means "absent **or invisible**". If a future OTA tightens `/data/local/tmp` or SELinux, both signals read absent — resurrecting user-stopped daemons and letting the health check relaunch a parked stack. Recorded on the class.

## 3. `fix(adb): reroute a rejected command instead of dropping it`

Added after review pointed out that commit 2 only closes half the window, which the original description overstated.

The stop gate removed ADB from the **decision**. The **action** it guards still ran over the per-manager executor, so a dead executor still lost the daemon start — visibly, as `adb#N REJECTED`, but lost. The reasoning in the original guard is where the bug lives:

```
// Swallow it — a dead executor means we're shutting down and the
// remaining commands are moot.
```

That holds on process teardown and is wrong on the bootManager→Activity handoff, where a new owner has just taken over and the commands are exactly as live as they were a millisecond earlier. The daemon-start paths are chains — each ADB reply drives the next command — so a chain in flight at that moment loses every remaining step. (`cleanup()` clears the pending Handler queue, so a not-yet-fired task is cancelled cleanly; this is the other case, where the task already fired and is mid-chain.)

- `ExecutorFallback` — try the owner's executor, fall back to a process-wide one, report `OWNER` / `REROUTED` / `REFUSED`. Pure function over two injected `Executor`s, testable without a Context or a real pool. Catches **only** `RejectedExecutionException`; a thread factory that throws is a real defect and must not be silently rerouted.
- The fallback executor runs on a **daemon** thread. It is never shut down, and a non-daemon thread would keep the JVM alive after the last Activity finishes. It shares the process-wide `sharedDadb` that `cleanup()` deliberately leaves open.
- `executeScript` now routes through the same helper. It submitted directly, with **no guard at all**, so it was exposed to the very process-killing crash `execute()`'s comment has warned about since it was written. That's an independent latent crash this fixes.
- On a double rejection we log and stop — we do **not** call `callback.onError`. `ServiceLauncher` chains the next command from inside `onError`, so an error raised on the caller's thread would re-enter `execute()`, be rejected again, and recurse.
- `DaemonStopGate`'s `sentinelPath`/`markerPath` tighten from `String?` to `String` — both call sites pass non-null constants, so the null branches were unreachable and one test asserted on an impossible input.

**⚠️ Behaviour change:** commands that previously died at the handoff now execute. The daemon starts are idempotent (`launchTailscale` probes `isTunnelRunning` and no-ops), but **this has had no hardware cycle yet** — worth one before merge.

## Boot ordering (same file, ships together)

`DaemonBootSchedule` starts tailscaled ahead of the core daemons on **both** `initializeOnBoot` and `initializeOnAppLaunch`. The camera daemon owns the MQTT publisher, and with the tunnel enabled the broker is reachable only via tailscaled's SOCKS listener — so starting it first makes the publisher defer (#182).

**Corrected rationale.** An earlier revision of this PR (and of the commit message and two code comments) justified the lead by claiming the deferral "sits at the 300s backoff cap" and costs "up to five minutes of missing telemetry". **That was wrong.** It describes pre-#182 behaviour, and this branch is cut directly on top of `bc941487`, the merged #182 fix — whose entire point is that it does *not* bump `consecutiveFailures` while waiting on the proxy. `MqttConnectionManager` therefore re-probes at the min-interval floor (`DEFAULT_MIN_INTERVAL` = 5s) and connects the moment the listener binds. A few seconds of ordering slip costs a few seconds of telemetry.

**What the lead actually buys is tail margin, not throughput.** The deferral is bounded by `PROXY_WARMUP_GRACE_MS` (60s); past that the publisher falls through to a direct dial, which off Wi-Fi can never reach a LAN address, and the connection churns until something restarts the daemon. With the core daemons first, tailscaled is only *launched* at 60s and needs a further 10–40s, against a grace window that opens when MQTT first defers (~45–50s) — close to the edge, and past the edge the failure is the bad one. Leading moves the proxy to ~40–70s, comfortably inside.

Observed working: tailscaled up, then `Connecting … (proxy=true)` 2 s later, no deferral lines.

**Caveat, stated in the commit too:** the lead narrows this race, it doesn't close it. The lead is 15s while tailscaled's own start latency measured between 10 s and 40 s on my head unit, and the SOCKS listener is gated on a separate `proxy_enabled` toggle. The tests pin the *relative order* of the phases, not the adequacy of the gap.

**Happy to split this part out** — it is bundled only because it lives in the same file, and its justification is narrower than the stop-gate work's.

## Testing

- 19 unit tests, no device required (`DaemonStopGateTest` 9, `DaemonBootScheduleTest` 3, `ExecutorFallbackTest` 6, plus 1 removed as unreachable). 152 total, 0 failures.
- Hardware: BYD Seal DiLink (DiLink 3.0, Android 10), in-place `pm install -r`. **Note:** the hardware run predates commit 3, which is untested on-device.

## Note on logging volume

The instrumentation in commit 1 fires three lines per ADB command on a path that runs continuously, and `LogManager` has no severity threshold — `.debug()` writes to file exactly like `.info()`. A follow-up PR adds `LogConfig.minLevel` and demotes this trio to DEBUG so it is off by default and switchable from Settings. That PR is stacked on this branch.

Happy to split the boot-ordering part out if you'd rather review it separately — it's in the same file, which is why it's bundled.
