### PR TITLE
docs+build: clean-clone build, third-party notices, libod key-gate note

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -261,6 +261,19 @@ Then build with Gradle:
 ./gradlew assembleRelease
 ```
 
+### Closed component: `libod.so`
+
+The blind-spot lens-projection coefficients ship as a prebuilt, closed-source
+`libod.so` (`app/src/main/jniLibs/arm64-v8a/`); its source (`cpp/od/`) is not
+part of this repository. At runtime the library authorizes against the app's
+signing certificate, so a **release** build signed with a different key will
+render the blind-spot camera card black.
+
+**Debug builds bypass this check** — `./gradlew assembleDebug` works normally
+from a clean clone, including for contributors, and the native build configures
+fine without the `od` source. Only release forks signed with a non-matching key
+are affected.
+
 ## VLESS Proxy Setup (Optional)
 
 The ISP blocklist bypass feature uses a VLESS Reality proxy. The app ships with placeholder credentials — you need to supply your own.
@@ -863,3 +876,7 @@ Android app + web companion rebuilt around how you actually use the car. Materia
 ## License
 
 Open source under MIT License. Your data stays on your device.
+
+OverDrive's own code is MIT-licensed. Bundled third-party components (cloudflared,
+zrok, sing-box, tailscale, YOLO11n, and others) remain under their own licenses —
+see [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,60 @@
+# Third-Party Notices
+
+OverDrive's own source code is licensed under the MIT License (see [LICENSE](LICENSE)).
+The MIT license applies **only** to OverDrive's own code. The application bundles and
+distributes the third-party components listed below, each of which remains under its
+own license — those licenses, not MIT, govern those components.
+
+## Bundled native binaries (`app/src/main/jniLibs/`)
+
+| Component | Upstream | Version | License | Modified? |
+|-----------|----------|---------|---------|-----------|
+| cloudflared | https://github.com/cloudflare/cloudflared | based on 2025.7.0 | Apache-2.0 | **Yes** — see "Modifications" below |
+| zrok | https://github.com/openziti/zrok | based on v1.1.x | Apache-2.0 | **Yes** — see "Modifications" below |
+| sing-box | https://github.com/SagerNet/sing-box | see upstream | **GPL-3.0-or-later** | No |
+| tailscale | https://github.com/tailscale/tailscale | see upstream | BSD-3-Clause | No |
+
+## Machine-learning models (`app/src/main/assets/models/`)
+
+| Component | Upstream | License |
+|-----------|----------|---------|
+| YOLO11n (`yolo11n.tflite`) | https://github.com/ultralytics/ultralytics | **AGPL-3.0** |
+
+## Native libraries linked into the app
+
+| Component | Upstream | License |
+|-----------|----------|---------|
+| OpenCV | https://github.com/opencv/opencv | Apache-2.0 |
+| OpenH264 | https://github.com/cisco/openh264 | BSD-2-Clause |
+| TensorFlow Lite | https://github.com/tensorflow/tensorflow | Apache-2.0 |
+
+## Modifications (Apache-2.0 §4(b) notice of changes)
+
+The following components were modified from their upstream sources:
+
+- **cloudflared** — added a proxy-aware edge dialer that routes the tunnel's edge
+  connection through a SOCKS5/HTTP proxy read from the environment
+  (`edgediscovery/dial.go`). This lets the tunnel operate on restricted networks.
+- **zrok** — added a SOCKS5 proxy and DNS override path for Android / restricted
+  networks, selected via the `ALL_PROXY` / `HTTPS_PROXY` / `HTTP_PROXY` environment
+  variables (`cmd/zrok/main.go`).
+
+## Source-derived work
+
+- **Bangcle / white-box AES port** — derived from reverse-engineering work by
+  [Niek/BYD-re](https://github.com/Niek/BYD-re) and
+  [jkaberg/pyBYD](https://github.com/jkaberg/pyBYD).
+
+## Corresponding source (copyleft components)
+
+**sing-box** is licensed under **GPL-3.0-or-later** and **YOLO11n** under **AGPL-3.0**.
+Their complete corresponding source (including any modifications, if applicable) is
+available from the upstream projects linked above.
+
+**Written offer:** for three years from the date of distribution, the maintainer will,
+on request, provide the complete corresponding source code for the GPL-3.0 and AGPL-3.0
+components as bundled in any given OverDrive release. Contact the maintainer via the
+channels in [SECURITY.md](SECURITY.md) or the [Discord server](https://discord.gg/PZutk9fg4h).
+
+The full text of each license (GPL-3.0, AGPL-3.0, Apache-2.0, BSD-2-Clause,
+BSD-3-Clause) is available from the respective upstream repositories.

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -120,25 +120,33 @@ set_target_properties(surveillance PROPERTIES
 # ==================== od library ====================
 # Standalone utility library with host-authorization gate. Same hardening as surveillance:
 # all symbols hidden, fully stripped, sections GC'd — only the two JNI entry points remain.
-add_library(od SHARED od/od.cpp)
-target_include_directories(od PRIVATE ${CMAKE_SOURCE_DIR}/od)
-target_link_libraries(od android log m)
-target_compile_options(od PRIVATE
-    -fvisibility=hidden
-    -fvisibility-inlines-hidden
-    -ffunction-sections
-    -fdata-sections
-    -O3 -ffast-math
-)
-# Force NDEBUG in release configs so the #ifndef NDEBUG host-auth bypass in
-# od.cpp is preprocessed out (don't rely on the toolchain's implicit default).
-target_compile_definitions(od PRIVATE
-    $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:RelWithDebInfo>:NDEBUG>
-)
-set_target_properties(od PROPERTIES
-    LINK_FLAGS "-Wl,--gc-sections,--strip-all,--exclude-libs,ALL"
-)
+#
+# od/od.cpp is a closed component and is NOT part of this repository. When it is
+# absent (clean public clone), the prebuilt libod.so in jniLibs/ is used at runtime
+# and this target is skipped so the native build still configures and completes.
+if(EXISTS ${CMAKE_SOURCE_DIR}/od/od.cpp)
+    add_library(od SHARED od/od.cpp)
+    target_include_directories(od PRIVATE ${CMAKE_SOURCE_DIR}/od)
+    target_link_libraries(od android log m)
+    target_compile_options(od PRIVATE
+        -fvisibility=hidden
+        -fvisibility-inlines-hidden
+        -ffunction-sections
+        -fdata-sections
+        -O3 -ffast-math
+    )
+    # Force NDEBUG in release configs so the #ifndef NDEBUG host-auth bypass in
+    # od.cpp is preprocessed out (don't rely on the toolchain's implicit default).
+    target_compile_definitions(od PRIVATE
+        $<$<CONFIG:Release>:NDEBUG>
+        $<$<CONFIG:RelWithDebInfo>:NDEBUG>
+    )
+    set_target_properties(od PROPERTIES
+        LINK_FLAGS "-Wl,--gc-sections,--strip-all,--exclude-libs,ALL"
+    )
+else()
+    message(STATUS "od/od.cpp not present — skipping 'od' target; prebuilt libod.so in jniLibs/ is used at runtime.")
+endif()
 
 # ==================== NEON SIMD Optimization ====================
 # Enable NEON for ARM architectures


### PR DESCRIPTION
- CMakeLists: guard the 'od' target on od/od.cpp being present so a clean public clone configures and builds (prebuilt libod.so is used at runtime). (#204)
- THIRD_PARTY_NOTICES.md: attribute bundled/linked third-party components, note cloudflared/zrok as modified forks (Apache-2.0 §4(b)), and add a written offer for GPL-3.0 (sing-box) / AGPL-3.0 (YOLO11n) source. (#203)
- Readme: document that libod.so is a signature-gated closed component (debug builds bypass the check); link THIRD_PARTY_NOTICES from License. (#205)