### PR TITLE
fix(storage): bound cleaner waits and deduplicate index deletion

### DIFF
--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -1254,24 +1254,11 @@ public class RecordingsApiHandler {
     }
 
     private static void deleteSidecars(File mp4File, String filename) {
-        // Invalidate the in-memory parse cache so the next /api/recordings
-        // call doesn't return a phantom entry for the just-deleted file.
-        // Tearing down the inverted-index entry happens here too so a
-        // place chip pointing at this file's place key vanishes the
-        // moment the delete completes. Use the helper so the new
-        // (path|type) compound key is matched correctly.
+        // This helper is the single index-removal owner. It delegates to
+        // RecordingsIndex.remove(filename), so a second explicit remove here
+        // would repeat the synchronized DELETE and advance the tombstone
+        // sequence twice for every file deletion.
         invalidateRecordingCache(mp4File.getAbsolutePath());
-
-        // Drop the H2 row eagerly so a /api/recordings call immediately
-        // after delete can't return the just-deleted row. FileObserver
-        // would catch this too, but FUSE-mounted SD cards can drop the
-        // DELETE event.
-        try {
-            com.overdrive.app.server.RecordingsIndex.getInstance().remove(filename);
-        } catch (Throwable ignored) {
-            // RecordingsIndex may not be initialised yet; the
-            // FileObserver / reconcile path will catch up.
-        }
 
         // Sidecar stem: strip a TRAILING ".mp4" only.
         //

--- a/app/src/main/java/com/overdrive/app/storage/ExternalStorageCleaner.java
+++ b/app/src/main/java/com/overdrive/app/storage/ExternalStorageCleaner.java
@@ -78,6 +78,29 @@ public class ExternalStorageCleaner {
         }
     }
 
+    private static final int PROCESS_WAIT_FAILED = -1;
+    private static final long GETPROP_TIMEOUT_MS = 1_000L;
+    private static final long DELETE_TIMEOUT_MS = 4_000L;
+
+    static int waitForBounded(Process process, long timeoutMs) {
+        try {
+            if (process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)) {
+                return process.exitValue();
+            }
+            process.destroyForcibly();
+            try {
+                process.waitFor(500L, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return PROCESS_WAIT_FAILED;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            try { process.destroyForcibly(); } catch (Throwable ignored) {}
+            return PROCESS_WAIT_FAILED;
+        }
+    }
+
     // ==================== Constants ====================
     
     // Known BYD CDR (dashcam) recording directories
@@ -295,11 +318,18 @@ public class ExternalStorageCleaner {
             // Fall back to shell
             try {
                 Process p = Runtime.getRuntime().exec(new String[]{"getprop", key});
-                BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-                String line = reader.readLine();
-                reader.close();
-                p.waitFor();
-                return line != null ? line.trim() : "";
+                int exitCode = waitForBounded(p, GETPROP_TIMEOUT_MS);
+                if (exitCode != 0) {
+                    if (exitCode == PROCESS_WAIT_FAILED) {
+                        logWarn("getprop " + key + " timed out or was interrupted");
+                    }
+                    return "";
+                }
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(p.getInputStream()))) {
+                    String line = reader.readLine();
+                    return line != null ? line.trim() : "";
+                }
             } catch (Exception e2) {
                 return "";
             }
@@ -892,7 +922,10 @@ public class ExternalStorageCleaner {
         // Try shell rm
         try {
             Process p = Runtime.getRuntime().exec(new String[]{"rm", "-f", file.getAbsolutePath()});
-            int exitCode = p.waitFor();
+            int exitCode = waitForBounded(p, DELETE_TIMEOUT_MS);
+            if (exitCode == PROCESS_WAIT_FAILED) {
+                logWarn("Shell delete timed out or was interrupted: " + file.getAbsolutePath());
+            }
             return exitCode == 0 && !file.exists();
         } catch (Exception e) {
             logWarn("Shell delete failed: " + e.getMessage());

--- a/app/src/test/java/com/overdrive/app/server/RecordingsApiHandlerIndexRemovalTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsApiHandlerIndexRemovalTest.java
@@ -1,0 +1,57 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingsApiHandlerIndexRemovalTest {
+
+    @Test
+    public void deleteSidecarsHasOneIndexRemovalOwner() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String method = methodBody(source, "private static void deleteSidecars");
+
+        assertTrue(method.contains("invalidateRecordingCache(mp4File.getAbsolutePath())"));
+        assertFalse(method.contains("RecordingsIndex.getInstance().remove"));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/ExternalStorageCleanerProcessTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/ExternalStorageCleanerProcessTest.java
@@ -1,0 +1,121 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+
+public class ExternalStorageCleanerProcessTest {
+
+    @After
+    public void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    @Test
+    public void completedProcessReturnsExitCodeWithoutDestroying() {
+        FakeProcess process = FakeProcess.completed(7);
+
+        int result = ExternalStorageCleaner.waitForBounded(process, 100L);
+
+        assertEquals(7, result);
+        assertFalse(process.destroyed);
+    }
+
+    @Test
+    public void timedOutProcessIsDestroyed() {
+        FakeProcess process = FakeProcess.running();
+
+        int result = ExternalStorageCleaner.waitForBounded(process, 100L);
+
+        assertEquals(-1, result);
+        assertTrue(process.destroyed);
+    }
+
+    @Test
+    public void interruptedWaitDestroysProcessAndPreservesInterrupt() {
+        FakeProcess process = FakeProcess.interrupted();
+
+        int result = ExternalStorageCleaner.waitForBounded(process, 100L);
+
+        assertEquals(-1, result);
+        assertTrue(process.destroyed);
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    private static final class FakeProcess extends Process {
+        private final int exitCode;
+        private final boolean complete;
+        private final boolean interruptOnWait;
+        private boolean destroyed;
+
+        private FakeProcess(int exitCode, boolean complete, boolean interruptOnWait) {
+            this.exitCode = exitCode;
+            this.complete = complete;
+            this.interruptOnWait = interruptOnWait;
+        }
+
+        static FakeProcess completed(int exitCode) {
+            return new FakeProcess(exitCode, true, false);
+        }
+
+        static FakeProcess running() {
+            return new FakeProcess(0, false, false);
+        }
+
+        static FakeProcess interrupted() {
+            return new FakeProcess(0, false, true);
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            if (interruptOnWait) throw new InterruptedException("test interrupt");
+            return complete || destroyed;
+        }
+
+        @Override
+        public int waitFor() throws InterruptedException {
+            if (interruptOnWait) throw new InterruptedException("test interrupt");
+            return exitCode;
+        }
+
+        @Override
+        public int exitValue() {
+            if (!complete && !destroyed) throw new IllegalThreadStateException("still running");
+            return exitCode;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroyed = true;
+            return this;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR applies two low-risk storage reliability fixes in separate, revertible commits:

1. Bounds `ExternalStorageCleaner` subprocess waits for `getprop` and shell deletion.
2. Removes a duplicate H2 recordings-index deletion from `deleteSidecars()`.

## Why is this change needed?

`ExternalStorageCleaner` held its cleanup lock while waiting indefinitely for child processes. A stalled process on a degraded FUSE-backed SD card could block all later reserve-space and manual-cleanup requests. The new helper caps `getprop` at 1 second and shell deletion at 4 seconds, forcibly terminates timed-out children, and preserves interrupt status.

`deleteSidecars()` called `invalidateRecordingCache()`, which already delegates to `RecordingsIndex.remove(filename)`, and then issued the same synchronized H2 deletion again. This repeated database work and advanced removal tombstones twice per recording deletion.

## Commit structure

- `fix(storage): bound external cleaner subprocess waits`
- `fix(recordings): remove duplicate index deletion`

Each recommendation is isolated in its own commit with focused regression coverage.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.storage.ExternalStorageCleanerProcessTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.RecordingsApiHandlerIndexRemovalTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Low. Successful subprocess and deletion behavior is unchanged. The only new behavior is bounded failure for stalled children and removal of a redundant database call.