### PR TITLE
fix(recordings): remove duplicate load and release thumbnail resources

### DIFF
--- a/app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt
+++ b/app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt
@@ -313,14 +313,19 @@ class RecordingAdapter(
         }
 
         private fun extractThumbnail(path: String): Bitmap? {
+            var retriever: MediaMetadataRetriever? = null
             return try {
-                val retriever = MediaMetadataRetriever()
+                retriever = MediaMetadataRetriever()
                 retriever.setDataSource(path)
-                val frame = retriever.getFrameAtTime(1_000_000) // 1 second in
-                retriever.release()
-                frame
+                retriever.getFrameAtTime(1_000_000) // 1 second in
             } catch (e: Exception) {
                 null
+            } finally {
+                try {
+                    retriever?.release()
+                } catch (_: Throwable) {
+                    // Best-effort cleanup; thumbnail extraction has already completed.
+                }
             }
         }
     }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/RecordingLibraryFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/RecordingLibraryFragment.kt
@@ -328,7 +328,6 @@ class RecordingLibraryFragment : Fragment() {
         checkPermissionsAndScan()
 
         updateDateHeader()
-        loadRecordingsForSelectedDate()
         renderActiveFilters()
     }
 

--- a/app/src/test/java/com/overdrive/app/ui/adapter/RecordingAdapterRetrieverReleaseTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/adapter/RecordingAdapterRetrieverReleaseTest.java
@@ -1,0 +1,59 @@
+package com.overdrive.app.ui.adapter;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingAdapterRetrieverReleaseTest {
+
+    @Test
+    public void thumbnailRetrieverIsReleasedFromFinally() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt");
+        String method = methodBody(source, "private fun extractThumbnail");
+
+        int extraction = method.indexOf("retriever.getFrameAtTime");
+        int cleanup = method.indexOf("finally");
+        int release = method.indexOf("retriever?.release()", cleanup);
+        assertTrue("frame extraction must occur before cleanup", extraction >= 0 && extraction < cleanup);
+        assertTrue("retriever release must be in the finally block", cleanup >= 0 && release > cleanup);
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/fragment/RecordingLibraryInitialLoadTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/fragment/RecordingLibraryInitialLoadTest.java
@@ -1,0 +1,68 @@
+package com.overdrive.app.ui.fragment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingLibraryInitialLoadTest {
+
+    @Test
+    public void viewCreationHasOneInitialLoadOwner() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/fragment/RecordingLibraryFragment.kt");
+        String onViewCreated = methodBody(source, "override fun onViewCreated");
+        String setupAndLoad = methodBody(source, "private fun checkPermissionsAndScan");
+
+        assertFalse(onViewCreated.contains("loadRecordingsForSelectedDate()"));
+        assertEquals(1, occurrences(setupAndLoad, "loadRecordingsForSelectedDate()"));
+    }
+
+    private static int occurrences(String text, String needle) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = text.indexOf(needle, offset)) >= 0) {
+            count++;
+            offset += needle.length();
+        }
+        return count;
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR applies two low-risk recording-library fixes in separate, revertible commits:

1. Removes the duplicate page-one request during `RecordingLibraryFragment` creation.
2. Guarantees `MediaMetadataRetriever.release()` on both successful and failed legacy thumbnail extraction.

## Why is this change needed?

`onViewCreated()` called `checkPermissionsAndScan()`, which already reset paging and started page one, and then immediately reset paging and submitted page one again. The second request invalidated the first response through the paging-generation guard and doubled initial API work.

The thumbnail fallback released `MediaMetadataRetriever` only after successful extraction. Corrupt, incomplete, or temporarily unavailable MP4 files could throw before release and retain native resources while the user scrolled.

## Commit structure

- `fix(recordings): avoid duplicate initial library load`
- `fix(recordings): always release thumbnail retriever`

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.ui.fragment.RecordingLibraryInitialLoadTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.ui.adapter.RecordingAdapterRetrieverReleaseTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Low. The library still loads from the same initial owner, and thumbnail output is unchanged. The PR removes redundant work and closes a resource leak on exceptional paths.