### PR TITLE
perf(storage): reduce recurring FUSE directory scans

### DIFF
--- a/app/src/main/java/com/overdrive/app/proximity/ProximityRecordingHandler.java
+++ b/app/src/main/java/com/overdrive/app/proximity/ProximityRecordingHandler.java
@@ -191,9 +191,6 @@ public class ProximityRecordingHandler {
 
             logger.info("Proximity recording stopped");
 
-            // Trigger cleanup
-            storageManager.onProximityFileSaved();
-
             // Final-stage push with the now-finalised hero JPEG. The start
             // push deliberately skipped the snapshot URL because the hero
             // JPEG is only written when stopRecording finalises the segment.

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -186,6 +186,10 @@ public class StorageManager {
     
     // Periodic cleanup interval (30 seconds)
     private static final long CLEANUP_INTERVAL_SECONDS = 30;
+    // Out-of-band edits and missed events still need an integrity backstop, but
+    // an idle daemon does not need to walk every recording directory every 30s.
+    private static final long PERIODIC_INTEGRITY_INTERVAL_MS = TimeUnit.HOURS.toMillis(1);
+    private volatile long lastPeriodicIntegrityAtMs = 0L;
 
     // Max anchor files to delete in a single BOUNDED-TRIM pass that runs WHILE the
     // encoder is writing. This caps SD-card I/O contention against the muxer's disk
@@ -6626,7 +6630,8 @@ public class StorageManager {
     
     /**
      * Start periodic cleanup for long recording sessions.
-     * Runs every 30 seconds while recording is active.
+      * Runs every 30 seconds while storage work is active and performs an
+      * hourly full integrity pass while idle.
      */
     public void startPeriodicCleanup() {
         if (cleanupScheduler != null && !cleanupScheduler.isShutdown()) {
@@ -6647,8 +6652,13 @@ public class StorageManager {
             t.setPriority(Thread.MIN_PRIORITY);
             return t;
         });
-        
-        cleanupScheduler.scheduleAtFixedRate(() -> {
+
+        // The constructor already queued a startup reap. Start the idle
+        // integrity clock here so the first 30-second tick does not duplicate
+        // that whole-library work while daemon initialization is still busy.
+        lastPeriodicIntegrityAtMs = statClockMs();
+
+        cleanupScheduler.scheduleWithFixedDelay(() -> {
             try {
                 // Don't run un-gated cleanup before the encoder probe is wired.
                 // Daemon-init ordering: startPeriodicCleanup() fires early
@@ -6659,6 +6669,25 @@ public class StorageManager {
                 if (!probeWired.get()) {
                     logDebug("Periodic cleanup tick skipped — encoder probe not wired yet");
                     return;
+                }
+                final long tickNowMs = statClockMs();
+                final boolean encoderWriting = isEncoderWriting();
+                final boolean activeSession = recordingActive.get()
+                    || surveillanceActive.get()
+                    || activeTripFilePath != null
+                    || encoderWriting;
+                final boolean deferredWork = !deferredCleanupDirs.isEmpty();
+                final boolean fallbackWasActive = recordingsEnospcFallbackActive;
+                final boolean integrityDue = isPeriodicIntegrityDue(
+                    tickNowMs, lastPeriodicIntegrityAtMs);
+                if (!shouldRunPeriodicMaintenance(activeSession, deferredWork,
+                        fallbackWasActive, integrityDue)) {
+                    return;
+                }
+                if (integrityDue) {
+                    // Advance before I/O so a failed or degraded-volume pass
+                    // cannot retry continuously on every 30-second tick.
+                    lastPeriodicIntegrityAtMs = tickNowMs;
                 }
                 // Self-clear a stale ENOSPC fallback. recordingsEnospcFallbackActive
                 // latches true when a mounted-but-full external volume redirects a
@@ -6710,8 +6739,8 @@ public class StorageManager {
                 // to run the whole-tree idle-only work (deferred drain + orphan
                 // tmp sweep) — kept OUT of the steady-state recording path to
                 // hold tick I/O low, but still run during a genuine emergency.
-                boolean encoderWriting = isEncoderWriting();
                 boolean diskCritical = false;
+                boolean emergencyMaintenance = false;
 
                 // Scoped size/limit snapshot for recordings/surveillance/proximity,
                 // measured ONCE per tick in the recording branch and reused by the
@@ -6781,6 +6810,7 @@ public class StorageManager {
                         || (sdFree > 0 && sdFree < 200L * 1024 * 1024);  // <200MB free
 
                     boolean hardOverlimit = recHard || survHard || tripsHard || proxHard || diskCritical;
+                    emergencyMaintenance = hardOverlimit;
                     if (hardOverlimit) {
                         // Emergency: log it AND run the idle-only whole-tree work
                         // (orphan tmp sweep) right now — the disk is about to
@@ -6793,7 +6823,6 @@ public class StorageManager {
                             + " trips=" + formatSize(tripsBytes) + "/" + formatSize(tripsLim) + (tripsHard ? " HARD" : "")
                             + " prox=" + formatSize(proxBytes) + "/" + formatSize(proxLim) + (proxHard ? " HARD" : "")
                             + " sdFree=" + formatSize(sdFree) + (diskCritical ? " CRITICAL" : ""));
-                        sweepOrphanTempFiles();
                     }
                     // Soft state (over cap ≤5%, disk healthy): fall through to the
                     // per-category passes, which run a BOUNDED trim. We intentionally
@@ -6801,10 +6830,22 @@ public class StorageManager {
                     // keep steady-state recording-tick I/O low; both run at idle.
                 } else {
                     // Encoder idle: drain any deferred work first so storage limits
-                    // re-converge after a long recording, then sweep orphan
-                    // .mp4.tmp / .broken / .jpg.tmp partials (whole-tree walk, safe
-                    // when idle; otherwise partials only get reaped at daemon boot).
+                    // re-converge after a long recording. Sweep orphan partials only
+                    // on the hourly integrity pass; startup and hard-emergency paths
+                    // retain their immediate sweeps.
                     drainDeferredCleanupIfDue();
+                    boolean fallbackRecovered = fallbackWasActive
+                        && !recordingsEnospcFallbackActive;
+                    if (!shouldRunFullPeriodicMaintenance(
+                            activeSession, integrityDue, fallbackRecovered)) {
+                        // A deferred-only tick already drained its categories. An
+                        // unresolved fallback-only tick already performed the cheap
+                        // free-space probe. Neither needs the four full scans below.
+                        return;
+                    }
+                }
+
+                if (shouldSweepOrphanTempFiles(integrityDue, emergencyMaintenance)) {
                     sweepOrphanTempFiles();
                 }
 
@@ -6887,6 +6928,28 @@ public class StorageManager {
         }, CLEANUP_INTERVAL_SECONDS, CLEANUP_INTERVAL_SECONDS, TimeUnit.SECONDS);
         
         logInfo("Started periodic storage cleanup (interval=" + CLEANUP_INTERVAL_SECONDS + "s)");
+    }
+
+    static boolean shouldRunPeriodicMaintenance(boolean activeSession,
+                                                boolean deferredWork,
+                                                boolean fallbackActive,
+                                                boolean integrityDue) {
+        return activeSession || deferredWork || fallbackActive || integrityDue;
+    }
+
+    static boolean isPeriodicIntegrityDue(long nowMs, long lastRunMs) {
+        return lastRunMs <= 0L || (nowMs - lastRunMs) >= PERIODIC_INTEGRITY_INTERVAL_MS;
+    }
+
+    static boolean shouldRunFullPeriodicMaintenance(boolean activeSession,
+                                                    boolean integrityDue,
+                                                    boolean fallbackRecovered) {
+        return activeSession || integrityDue || fallbackRecovered;
+    }
+
+    static boolean shouldSweepOrphanTempFiles(boolean integrityDue,
+                                              boolean emergencyMaintenance) {
+        return integrityDue || emergencyMaintenance;
     }
     
     /**

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -6309,9 +6309,6 @@ public class StorageManager {
         asyncCleanupExecutor.execute(() -> {
             synchronized (recordingsCleanupLock) {
                 try {
-                    // Make all files in directory readable
-                    makeFilesReadable(recordingsDir);
-
                     // Scoped to the active volume so a fallback to internal triggers
                     // (and bounds) on internal's pool + effective limit, not the
                     // combined cross-volume pool vs the raw external limit.
@@ -6370,9 +6367,6 @@ public class StorageManager {
         asyncCleanupExecutor.execute(() -> {
             synchronized (surveillanceCleanupLock) {
                 try {
-                    // Make all files in directory readable
-                    makeFilesReadable(surveillanceDir);
-
                     long currentSize = scopedSizeForCategory("surveillance");
                     long limitBytes = scopedLimitBytesForCategory("surveillance");
 
@@ -6415,9 +6409,6 @@ public class StorageManager {
         asyncCleanupExecutor.execute(() -> {
             synchronized (proximityCleanupLock) {
                 try {
-                    // Make all files in directory readable
-                    makeFilesReadable(proximityDir);
-
                     long currentSize = scopedSizeForCategory("proximity");
                     long limitBytes = scopedLimitBytesForCategory("proximity");
 
@@ -6458,9 +6449,6 @@ public class StorageManager {
         asyncCleanupExecutor.execute(() -> {
             synchronized (tripsCleanupLock) {
                 try {
-                    // Make all files in directory readable
-                    makeFilesReadable(tripsDir);
-
                     // Scoped (parity with the other onXxxFileSaved handlers) so a
                     // trips fallback to internal triggers on internal's pool + cap.
                     // scopedSizeForCategory("trips") still uses the DB-cached size in

--- a/app/src/main/java/com/overdrive/app/surveillance/GpuMosaicRecorder.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/GpuMosaicRecorder.java
@@ -559,27 +559,6 @@ public class GpuMosaicRecorder {
                     logger.warn("Segment-rotated listener threw: " + t.getMessage());
                 }
             }
-            
-            // SOTA: Trigger storage cleanup after each file is saved
-            try {
-                com.overdrive.app.storage.StorageManager storageManager =
-                    com.overdrive.app.storage.StorageManager.getInstance();
-                
-                // Determine if this was a surveillance or manual recording based on output path
-                // Surveillance files go to surveillance dir, manual recordings to recordings dir
-                if (encoder != null) {
-                    String lastPath = encoder.getCurrentOutputPath();
-                    if (lastPath != null) {
-                        if (lastPath.contains("/surveillance/") || lastPath.contains("event_")) {
-                            storageManager.onSurveillanceFileSaved();
-                        } else {
-                            storageManager.onRecordingFileSaved();
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                logger.warn("Storage cleanup after file close failed: " + e.getMessage());
-            }
         });
         
         // Get encoder's input surface

--- a/app/src/test/java/com/overdrive/app/storage/StorageManagerPerSavePermissionTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/StorageManagerPerSavePermissionTest.java
@@ -1,0 +1,73 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class StorageManagerPerSavePermissionTest {
+
+    @Test
+    public void fileFinalizationUsesSingleFilePermissionUpdate() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        assertTrue(methodBody(source, "public void onFileSaved")
+                .contains("makeFileReadable(file)"));
+        assertFalse(methodBody(source, "public void onRecordingFileSaved")
+                .contains("makeFilesReadable("));
+        assertFalse(methodBody(source, "public void onSurveillanceFileSaved")
+                .contains("makeFilesReadable("));
+        assertFalse(methodBody(source, "public void onProximityFileSaved")
+                .contains("makeFilesReadable("));
+        assertFalse(methodBody(source, "public void onTripFileSaved")
+                .contains("makeFilesReadable("));
+    }
+
+    @Test
+    public void startupStillRepairsLegacyFilePermissions() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        assertTrue(methodBody(source, "public void fixAllPermissions")
+                .contains("makeFilesReadable(recordingsDir)"));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/StoragePeriodicMaintenancePolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/StoragePeriodicMaintenancePolicyTest.java
@@ -1,0 +1,101 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class StoragePeriodicMaintenancePolicyTest {
+
+    @Test
+    public void idleHealthyStorageSkipsThirtySecondMaintenance() {
+        assertFalse(StorageManager.shouldRunPeriodicMaintenance(
+                false, false, false, false));
+    }
+
+    @Test
+    public void eachActionableReasonArmsMaintenance() {
+        assertTrue(StorageManager.shouldRunPeriodicMaintenance(
+                true, false, false, false));
+        assertTrue(StorageManager.shouldRunPeriodicMaintenance(
+                false, true, false, false));
+        assertTrue(StorageManager.shouldRunPeriodicMaintenance(
+                false, false, true, false));
+        assertTrue(StorageManager.shouldRunPeriodicMaintenance(
+                false, false, false, true));
+    }
+
+    @Test
+    public void integrityPassIsHourlyAndTreatsMissingStampAsDue() {
+        assertTrue(StorageManager.isPeriodicIntegrityDue(1L, 0L));
+        assertFalse(StorageManager.isPeriodicIntegrityDue(3_600_000L, 1L));
+        assertTrue(StorageManager.isPeriodicIntegrityDue(3_600_001L, 1L));
+    }
+
+    @Test
+        public void deferredOrUnresolvedFallbackWorkStopsAfterLightweightPhase() {
+        assertFalse(StorageManager.shouldRunFullPeriodicMaintenance(
+            false, false, false));
+        assertTrue(StorageManager.shouldRunFullPeriodicMaintenance(
+            true, false, false));
+        assertTrue(StorageManager.shouldRunFullPeriodicMaintenance(
+            false, true, false));
+        assertTrue(StorageManager.shouldRunFullPeriodicMaintenance(
+            false, false, true));
+        }
+
+        @Test
+        public void orphanSweepRequiresIntegrityOrEmergency() {
+        assertFalse(StorageManager.shouldSweepOrphanTempFiles(false, false));
+        assertTrue(StorageManager.shouldSweepOrphanTempFiles(true, false));
+        assertTrue(StorageManager.shouldSweepOrphanTempFiles(false, true));
+        }
+
+        @Test
+        public void schedulerUsesCompletionRelativeDelay() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+        String start = methodBody(source, "public void startPeriodicCleanup()");
+
+        assertTrue(start.contains("scheduleWithFixedDelay"));
+        assertFalse(start.contains("scheduleAtFixedRate"));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/StoragePostSaveOwnershipTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/StoragePostSaveOwnershipTest.java
@@ -1,0 +1,82 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class StoragePostSaveOwnershipTest {
+
+    @Test
+    public void mp4FinalizerOwnsPostSaveDispatch() throws IOException {
+        String encoder = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/surveillance/HardwareEventRecorderGpu.java");
+        assertTrue(encoder.contains("onFileSaved(finalFile)"));
+
+        String mosaic = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/surveillance/GpuMosaicRecorder.java");
+        String closeCallback = lambdaBody(mosaic, "encoder.setFileClosedCallback(() ->");
+        assertFalse(closeCallback.contains("onRecordingFileSaved()"));
+        assertFalse(closeCallback.contains("onSurveillanceFileSaved()"));
+
+        String proximity = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/proximity/ProximityRecordingHandler.java");
+        assertFalse(methodBody(proximity, "public void stopRecording()")
+                .contains("onProximityFileSaved()"));
+    }
+
+    @Test
+    public void nonMp4TripFinalizerStillRequestsCleanup() throws IOException {
+        String trips = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/trips/TripTelemetryRecorder.java");
+        assertTrue(methodBody(trips, "public String stopRecording()")
+                .contains("onTripFileSaved()"));
+    }
+
+    private static String lambdaBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        return balancedBlock(source, source.indexOf('{', start), signature);
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        return balancedBlock(source, source.indexOf('{', start), signature);
+    }
+
+    private static String balancedBlock(String source, int openingBrace, String label) {
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced block for " + label);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR removes three recurring sources of whole-library metadata work:

1. Replaces per-save directory-wide permission repair with the existing single-file update.
2. Removes duplicate MP4 post-save cleanup notifications.
3. Skips healthy idle 30-second maintenance ticks and runs idle integrity work hourly.

## Why is this change needed?

Each finalized clip caused the active directory to be listed and every MP4 to receive `setReadable()` again. The MP4 finalizer then dispatched category cleanup, followed by secondary cleanup calls from the mosaic close callback and proximity handler. These paths repeated uncached FUSE size walks for one file.

Separately, the daemon-wide scheduler ran at fixed rate every 30 seconds even while idle. It swept orphan files and performed uncached category-size walks across internal, SD, USB, and legacy roots. On large or degraded FUSE-backed storage, that creates permanent metadata pressure and overdue passes become immediately eligible.

## Commit structure

- `perf(storage): avoid per-save permission directory scans`
- `perf(storage): deduplicate MP4 post-save cleanup`
- `perf(storage): throttle idle integrity scans`

## Preserved safety behavior

- New files still receive the O(1) permission update.
- Startup still repairs legacy file permissions.
- Active recording, surveillance, trip, and encoder maintenance remains on the 30-second cadence.
- Deferred cleanup still drains.
- ENOSPC fallback still receives its recovery probe.
- Hard emergencies and startup still sweep orphan partials immediately.
- Idle full integrity and orphan scans remain as an hourly backstop.
- Scheduling now waits 30 seconds after a pass completes.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.storage.StorageManagerPerSavePermissionTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.storage.StoragePostSaveOwnershipTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.storage.StoragePeriodicMaintenancePolicyTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Moderate. Recurring maintenance cadence changes, but the action policy is isolated and directly tested. Active and emergency enforcement paths remain enabled; only healthy idle repetition is reduced.