### PR TITLE
perf(recordings): bound dashboard and thumbnail I/O

### DIFF
--- a/app/src/main/java/com/overdrive/app/ui/adapter/InFlightLoadCoordinator.kt
+++ b/app/src/main/java/com/overdrive/app/ui/adapter/InFlightLoadCoordinator.kt
@@ -1,0 +1,51 @@
+package com.overdrive.app.ui.adapter
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+internal class InFlightLoadCoordinator<K : Any, V>(
+    private val scope: CoroutineScope,
+    maxConcurrent: Int
+) {
+    private val permits = Semaphore(maxConcurrent)
+    private val inFlight = ConcurrentHashMap<K, Deferred<V>>()
+
+    init {
+        require(maxConcurrent > 0) { "maxConcurrent must be positive" }
+    }
+
+    fun load(key: K, loader: suspend () -> V): Deferred<V> {
+        while (true) {
+            inFlight[key]?.let { existing ->
+                existing.start()
+                return existing
+            }
+
+            val created = scope.async(start = CoroutineStart.LAZY) {
+                permits.withPermit { loader() }
+            }
+            val winner = inFlight.putIfAbsent(key, created)
+            if (winner != null) {
+                created.cancel()
+                winner.start()
+                return winner
+            }
+
+            // Register only after insertion. If the parent scope was already
+            // cancelled, invokeOnCompletion runs immediately and can now remove
+            // the inserted cancelled Deferred instead of leaving a stale entry.
+            created.invokeOnCompletion {
+                inFlight.remove(key, created)
+            }
+            created.start()
+            return created
+        }
+    }
+
+    internal fun inFlightCount(): Int = inFlight.size
+}

--- a/app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt
+++ b/app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt
@@ -17,8 +17,12 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.overdrive.app.ui.model.RecordingFile
 import com.overdrive.app.R
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -42,6 +46,8 @@ class RecordingAdapter(
     private val thumbnailCache = object : LruCache<String, Bitmap>(8 * 1024 * 1024) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
     }
+    private var thumbnailScope = newThumbnailScope()
+    private var thumbnailLoads = newThumbnailCoordinator(thumbnailScope)
     
     // Multi-select state
     var selectMode = false
@@ -89,6 +95,30 @@ class RecordingAdapter(
     override fun onBindViewHolder(holder: RecordingViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
+
+    override fun onViewRecycled(holder: RecordingViewHolder) {
+        holder.cancelThumbnailWait()
+        super.onViewRecycled(holder)
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        if (!thumbnailScope.isActive) {
+            thumbnailScope = newThumbnailScope()
+            thumbnailLoads = newThumbnailCoordinator(thumbnailScope)
+        }
+        super.onAttachedToRecyclerView(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailScope.cancel()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
+    private fun newThumbnailScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private fun newThumbnailCoordinator(scope: CoroutineScope) =
+        InFlightLoadCoordinator<String, Bitmap?>(scope, maxConcurrent = 2)
     
     inner class RecordingViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val ivThumbnail: ImageView = itemView.findViewById(R.id.ivThumbnail)
@@ -106,8 +136,10 @@ class RecordingAdapter(
         private val tvActorSummary: TextView? = itemView.findViewById(R.id.tvActorSummary)
         private val severityStripe: View? = itemView.findViewById(R.id.severityStripe)
         private val tvLocation: TextView? = itemView.findViewById(R.id.tvLocation)
+        private var thumbnailWaitJob: Job? = null
 
         fun bind(recording: RecordingFile) {
+            cancelThumbnailWait()
             tvCameraId.text = "C${recording.cameraId}"
             tvRecordingTime.text = recording.formattedTime
             tvDuration.text = if (recording.durationMs > 0) recording.formattedDuration else "--:--"
@@ -284,16 +316,23 @@ class RecordingAdapter(
 
             ivThumbnail.setImageResource(R.color.surface_variant)
 
-            CoroutineScope(Dispatchers.IO).launch {
-                // Prefer the hero JPEG written by ThumbnailBuffer next to the MP4.
-                // Falls back to MediaMetadataRetriever for legacy clips with no
-                // sidecar.
-                val thumbnail = recording.heroThumbnailFile?.let { decodeJpeg(it) }
-                    ?: extractThumbnail(recording.path)
-                if (thumbnail != null) {
-                    thumbnailCache.put(cacheKey, thumbnail)
+            val load = thumbnailLoads.load(cacheKey) {
+                thumbnailCache.get(cacheKey) ?: run {
+                    // Prefer the hero JPEG written by ThumbnailBuffer next to the MP4.
+                    // Falls back to MediaMetadataRetriever for legacy clips with no
+                    // sidecar. InFlightLoadCoordinator deduplicates identical keys and
+                    // caps distinct storage reads across the adapter.
+                    val thumbnail = recording.heroThumbnailFile?.let { decodeJpeg(it) }
+                        ?: extractThumbnail(recording.path)
+                    if (thumbnail != null) {
+                        thumbnailCache.put(cacheKey, thumbnail)
+                    }
+                    thumbnail
                 }
+            }
 
+            thumbnailWaitJob = thumbnailScope.launch {
+                val thumbnail = load.await()
                 withContext(Dispatchers.Main) {
                     if (bindingAdapterPosition != RecyclerView.NO_POSITION &&
                         getItem(bindingAdapterPosition).path == recording.path &&
@@ -302,6 +341,11 @@ class RecordingAdapter(
                     }
                 }
             }
+        }
+
+        fun cancelThumbnailWait() {
+            thumbnailWaitJob?.cancel()
+            thumbnailWaitJob = null
         }
 
         private fun decodeJpeg(file: java.io.File): Bitmap? {

--- a/app/src/main/java/com/overdrive/app/ui/dashboard/DashboardInsight.kt
+++ b/app/src/main/java/com/overdrive/app/ui/dashboard/DashboardInsight.kt
@@ -15,12 +15,10 @@ import android.util.TypedValue
 import androidx.annotation.AttrRes
 import androidx.annotation.WorkerThread
 import com.overdrive.app.R
-import com.overdrive.app.ui.model.RecordingFile
-import com.overdrive.app.ui.util.RecordingScanner
+import com.overdrive.app.ui.util.RecordingsApiClient
 import com.overdrive.app.util.DaemonHttpClient
 import org.json.JSONObject
 import java.net.HttpURLConnection
-import java.util.Calendar
 
 /**
  * One row in the rotating dashboard hero subtitle.
@@ -73,15 +71,21 @@ class DashboardInsightProvider(appContext: Context) {
             androidx.appcompat.R.attr.colorPrimary,
             fallback = 0
         )
+        val recordingStats = fetchRecordingStats()
+        val newestSentryTimestamp = fetchNewestSentryTimestamp()
 
         val insights = mutableListOf<DashboardInsight>()
 
         welcomeInsight(visitCountBefore)?.let { insights += it }
         parkingDeltaInsight(emphasisColor)?.let { insights += it }
-        lastSurveillanceInsight(emphasisColor)?.let { insights += it }
+        lastSurveillanceInsight(emphasisColor, newestSentryTimestamp)?.let { insights += it }
         chargingRecapInsight(emphasisColor)?.let { insights += it }
-        todaysClipsInsight(emphasisColor)?.let { insights += it }
-        storageMilestoneInsight(emphasisColor)?.let { insights += it }
+        todaysClipsInsight(emphasisColor, recordingStats?.totalToday)?.let { insights += it }
+        storageMilestoneInsight(
+            emphasisColor,
+            recordingStats?.totalCount,
+            recordingStats?.totalSize
+        )?.let { insights += it }
         uptimeInsight(emphasisColor)?.let { insights += it }
 
         // Deterministic order by priority, but tie-break randomly so back-to-back
@@ -154,18 +158,11 @@ class DashboardInsightProvider(appContext: Context) {
     }
 
     /** "Last surveillance alert: 2 hours ago" — only when an event ≤ 7 days old exists. */
-    private fun lastSurveillanceInsight(emphasisColor: Int): DashboardInsight? {
-        // Use the shared scanner so the dashboard agrees with the recordings
-        // page on what "surveillance" means (covers active + alternate +
-        // legacy paths, picks the parsed-from-filename timestamp not mtime).
-        val newest = try {
-            RecordingScanner.scanRecordings(ctx)
-                .asSequence()
-                .filter { it.type == RecordingFile.RecordingType.SENTRY }
-                .maxOfOrNull { it.timestamp } ?: 0L
-        } catch (_: Throwable) {
-            return null
-        }
+    private fun lastSurveillanceInsight(
+        emphasisColor: Int,
+        newest: Long?
+    ): DashboardInsight? {
+        if (newest == null) return null
         if (newest <= 0L) return null
         val ageMs = System.currentTimeMillis() - newest
         if (ageMs <= 0L || ageMs > 7L * 24 * 60 * 60 * 1000L) return null
@@ -203,18 +200,12 @@ class DashboardInsightProvider(appContext: Context) {
     }
 
     /** "12 clips recorded today" — only when count > 0. */
-    private fun todaysClipsInsight(emphasisColor: Int): DashboardInsight? {
-        val startOfDay = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 0)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }.timeInMillis
-        val n = try {
-            RecordingScanner.scanRecordings(ctx).count { it.timestamp >= startOfDay }
-        } catch (_: Throwable) {
-            return null
-        }
+    private fun todaysClipsInsight(
+        emphasisColor: Int,
+        todayCount: Long?
+    ): DashboardInsight? {
+        if (todayCount == null || todayCount > Int.MAX_VALUE) return null
+        val n = todayCount.toInt()
         if (n <= 0) return null
         val template = ctx.resources.getQuantityString(
             R.plurals.dashboard_insight_today_clips, n, n
@@ -226,14 +217,12 @@ class DashboardInsightProvider(appContext: Context) {
     }
 
     /** "320 clips · 42 GB recorded" — only when total clips > 50. */
-    private fun storageMilestoneInsight(emphasisColor: Int): DashboardInsight? {
-        val all = try {
-            RecordingScanner.scanRecordings(ctx)
-        } catch (_: Throwable) {
-            return null
-        }
-        val totalClips = all.size
-        val totalBytes = all.sumOf { it.sizeBytes }
+    private fun storageMilestoneInsight(
+        emphasisColor: Int,
+        totalClips: Long?,
+        totalBytes: Long?
+    ): DashboardInsight? {
+        if (totalClips == null || totalBytes == null) return null
         if (totalClips <= 50) return null
         if (totalBytes <= 0L) return null
         val sizeStr = Formatter.formatShortFileSize(ctx, totalBytes)
@@ -274,6 +263,30 @@ class DashboardInsightProvider(appContext: Context) {
     }
 
     // ============== Helpers ==============
+
+    private fun fetchRecordingStats(): RecordingsApiClient.StatsPayload? {
+        return try {
+            RecordingsApiClient.fetchStats()?.takeUnless {
+                it.indexUnavailable || it.warming
+            }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun fetchNewestSentryTimestamp(): Long? {
+        return try {
+            val page = RecordingsApiClient.fetchRecordings(
+                RecordingsApiClient.Filter(type = "sentry"),
+                page = 1,
+                pageSize = 1
+            ) ?: return null
+            if (page.indexUnavailable || page.warming) return null
+            page.recordings.firstOrNull()?.timestamp
+        } catch (_: Throwable) {
+            null
+        }
+    }
 
     /**
      * GET against the in-process daemon. Returns null on any error (timeout,

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
@@ -31,12 +30,11 @@ import com.overdrive.app.ui.model.DaemonStatus
 import com.overdrive.app.ui.model.DaemonType
 import com.overdrive.app.ui.model.localizedName
 import com.overdrive.app.ui.util.QrCodeGenerator
-import com.overdrive.app.ui.util.RecordingScanner
+import com.overdrive.app.ui.util.RecordingsApiClient
 import com.overdrive.app.ui.viewmodel.DaemonsViewModel
 import com.overdrive.app.ui.viewmodel.MainViewModel
 import com.overdrive.app.ui.viewmodel.RecordingViewModel
 import com.overdrive.app.util.DeviceIdGenerator
-import java.util.Calendar
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -111,7 +109,7 @@ class DashboardFragment : Fragment() {
 
     // Latest values cached so the recording-state observer (which fires on its
     // own cadence) can re-render without re-walking the disk.
-    @Volatile private var todayClipCount: Int = 0
+    @Volatile private var todayClipCount: Int = -1
 
     // ============== Hero subtitle insights carousel ==============
     //
@@ -173,15 +171,8 @@ class DashboardFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        // Cheap-but-not-free disk walk: refresh on every resume so the storage
-        // and today's-clip-count numbers update after the user records, deletes,
-        // or sentry events fire while the dashboard wasn't on screen.
-        //
-        // Drop the scanner cache first — deletions in other fragments don't
-        // notify the dashboard, so without this the tile and the carousel
-        // could read up to 5s of stale data after the user navigates back
-        // from the recordings page.
-        RecordingScanner.invalidateCache()
+        // Refresh indexed recording statistics on every return so new and
+        // deleted clips are reflected without materializing the full library.
         refreshMetricsTiles()
         refreshVehicleTile()
         // Always rebuild the insight list on resume — data may have changed
@@ -327,34 +318,25 @@ class DashboardFragment : Fragment() {
     // ============== Metric tiles (storage + today's recordings) ==============
 
     /**
-     * Walks the recordings directories on a background thread via the
-     * shared [RecordingScanner], then posts today's clip count back.
-     *
-     * Uses the same source-of-truth as [RecordingsFragment] so the dashboard
-     * tile and the recordings page can never disagree. The scanner already
-     * walks active + alternate + legacy paths for cam_* / surveillance /
-     * proximity, dedupes by filename, and exposes parsed-from-filename
-     * timestamps — counting via mtime here would have missed every clip
-     * whose file was copied after capture (different mtime than filename).
+     * Reads today's clip count from the daemon's indexed stats endpoint on a
+     * background thread, then posts it to the tile. An unavailable or warming
+     * index leaves the last known value intact instead of rendering a false zero.
      */
     private fun refreshMetricsTiles() {
-        val ctx = context?.applicationContext ?: return
+        if (context == null) return
         val executor = metricsExecutor ?: Executors.newSingleThreadExecutor()
             .also { metricsExecutor = it }
 
         executor.execute {
-            var clipCountToday = 0
-            try {
-                val startOfDayMs = Calendar.getInstance().apply {
-                    set(Calendar.HOUR_OF_DAY, 0)
-                    set(Calendar.MINUTE, 0)
-                    set(Calendar.SECOND, 0)
-                    set(Calendar.MILLISECOND, 0)
-                }.timeInMillis
-                clipCountToday = RecordingScanner.scanRecordings(ctx)
-                    .count { it.timestamp >= startOfDayMs }
+            val clipCountToday = try {
+                val stats = RecordingsApiClient.fetchStats()
+                DashboardRecordingMetricPolicy.authoritativeTodayCount(
+                    indexUnavailable = stats?.indexUnavailable ?: true,
+                    warming = stats?.warming ?: false,
+                    totalToday = stats?.totalToday ?: 0L
+                )
             } catch (_: Throwable) {
-                // Leave defaults — still post so the tile updates off "—".
+                null
             }
 
             mainHandler.post {
@@ -366,7 +348,9 @@ class DashboardFragment : Fragment() {
                 // width. Storage lives in its own surfaces.
                 metricStorageValue.text = getString(R.string.dashboard_metric_recordings)
 
-                todayClipCount = clipCountToday
+                if (clipCountToday != null) {
+                    todayClipCount = clipCountToday
+                }
                 renderRecordingsValue()
             }
         }
@@ -380,11 +364,28 @@ class DashboardFragment : Fragment() {
      */
     private fun renderRecordingsValue() {
         if (!::metricRecordingsValue.isInitialized) return
+        if (todayClipCount < 0) {
+            metricRecordingsValue.setText(R.string.battery_health_dashes)
+            return
+        }
         val isRec = recordingViewModel.isRecording.value == true
         metricRecordingsValue.text = if (isRec) {
             getString(R.string.dashboard_recordings_value_live, todayClipCount)
         } else {
             todayClipCount.toString()
+        }
+    }
+
+    internal object DashboardRecordingMetricPolicy {
+        fun authoritativeTodayCount(
+            indexUnavailable: Boolean,
+            warming: Boolean,
+            totalToday: Long
+        ): Int? {
+            if (indexUnavailable || warming || totalToday < 0L || totalToday > Int.MAX_VALUE) {
+                return null
+            }
+            return totalToday.toInt()
         }
     }
 

--- a/app/src/test/java/com/overdrive/app/ui/adapter/InFlightLoadCoordinatorTest.kt
+++ b/app/src/test/java/com/overdrive/app/ui/adapter/InFlightLoadCoordinatorTest.kt
@@ -1,0 +1,179 @@
+package com.overdrive.app.ui.adapter
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InFlightLoadCoordinatorTest {
+
+    @Test
+    fun sameKeySharesOneInFlightLoad() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val coordinator = InFlightLoadCoordinator<String, Int>(scope, maxConcurrent = 2)
+            val release = CompletableDeferred<Unit>()
+            val calls = AtomicInteger()
+
+            val first = coordinator.load("recording") {
+                calls.incrementAndGet()
+                release.await()
+                42
+            }
+            val second = coordinator.load("recording") {
+                calls.incrementAndGet()
+                99
+            }
+
+            assertSame(first, second)
+            release.complete(Unit)
+            assertEquals(listOf(42, 42), awaitAll(first, second))
+            assertEquals(1, calls.get())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun distinctLoadsRespectConcurrencyLimit() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val coordinator = InFlightLoadCoordinator<Int, Int>(scope, maxConcurrent = 2)
+            val entered = Channel<Unit>(Channel.UNLIMITED)
+            val release = Channel<Unit>(Channel.UNLIMITED)
+            val active = AtomicInteger()
+            val peak = AtomicInteger()
+
+            val loads = (0 until 4).map { key ->
+                coordinator.load(key) {
+                    val nowActive = active.incrementAndGet()
+                    peak.accumulateAndGet(nowActive, ::maxOf)
+                    entered.send(Unit)
+                    try {
+                        release.receive()
+                        key
+                    } finally {
+                        active.decrementAndGet()
+                    }
+                }
+            }
+
+            repeat(2) { entered.receive() }
+            assertEquals(2, active.get())
+            assertEquals(4, coordinator.inFlightCount())
+
+            repeat(2) { release.send(Unit) }
+            repeat(2) { entered.receive() }
+            repeat(2) { release.send(Unit) }
+
+            assertEquals(listOf(0, 1, 2, 3), loads.awaitAll().sorted())
+            assertEquals(2, peak.get())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun cancellingOneWaiterDoesNotCancelSharedLoad() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val coordinator = InFlightLoadCoordinator<String, Int>(scope, maxConcurrent = 1)
+            val entered = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            val shared = coordinator.load("recording") {
+                entered.complete(Unit)
+                release.await()
+                42
+            }
+            val waiter = launch { shared.await() }
+
+            entered.await()
+            waiter.cancelAndJoin()
+            assertFalse(shared.isCancelled)
+
+            release.complete(Unit)
+            assertEquals(42, shared.await())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun cancelledScopeCannotLeaveStaleInFlightEntry() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = InFlightLoadCoordinator<String, Int>(scope, maxConcurrent = 1)
+        scope.cancel()
+
+        val first = coordinator.load("recording") { 1 }
+        first.join()
+        assertEquals(0, coordinator.inFlightCount())
+
+        val second = coordinator.load("recording") { 2 }
+        second.join()
+        assertNotSame(first, second)
+        assertEquals(0, coordinator.inFlightCount())
+    }
+
+    @Test
+    fun completedLoadIsRemovedSoARefreshCanRun() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val coordinator = InFlightLoadCoordinator<String, Int>(scope, maxConcurrent = 1)
+            val first = coordinator.load("recording") { 1 }
+            assertEquals(1, first.await())
+
+            val second = coordinator.load("recording") { 2 }
+            assertNotSame(first, second)
+            assertEquals(2, second.await())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun recordingAdapterUsesSharedBoundedCoordinator() {
+        val source = readRepositoryFile(
+            "app/src/main/java/com/overdrive/app/ui/adapter/RecordingAdapter.kt"
+        )
+
+        assertTrue(source.contains("InFlightLoadCoordinator<String, Bitmap?>"))
+        assertTrue(source.contains("maxConcurrent = 2"))
+        assertTrue(source.contains("holder.cancelThumbnailWait()"))
+        assertTrue(source.contains("thumbnailScope.cancel()"))
+        assertTrue(source.contains("if (!thumbnailScope.isActive)"))
+        assertFalse(source.contains("CoroutineScope(Dispatchers.IO).launch"))
+    }
+
+    private fun readRepositoryFile(relativePath: String): String {
+        var current = Paths.get(System.getProperty("user.dir"))
+            .toAbsolutePath().normalize()
+        while (true) {
+            val candidate = current.resolve(relativePath)
+            if (Files.isRegularFile(candidate)) {
+                return String(Files.readAllBytes(candidate), StandardCharsets.UTF_8)
+            }
+            val fromModule = current.resolve(relativePath.removePrefix("app/"))
+            if (Files.isRegularFile(fromModule)) {
+                return String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8)
+            }
+            current = current.parent ?: break
+        }
+        throw AssertionError("Could not locate repository file: $relativePath")
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/dashboard/DashboardRecordingQueryBudgetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/dashboard/DashboardRecordingQueryBudgetTest.java
@@ -1,0 +1,103 @@
+package com.overdrive.app.ui.dashboard;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.overdrive.app.ui.fragment.DashboardFragment;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DashboardRecordingQueryBudgetTest {
+
+    @Test
+    public void dashboardDoesNotMaterializeTheRecordingLibrary() throws IOException {
+        String insights = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/dashboard/DashboardInsight.kt");
+        String fragment = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/fragment/DashboardFragment.kt");
+
+        assertFalse(insights.contains("RecordingScanner.scanRecordings"));
+        assertFalse(fragment.contains("RecordingScanner.scanRecordings"));
+        assertTrue(insights.contains("RecordingsApiClient.fetchStats()"));
+        assertTrue(insights.contains("pageSize = 1"));
+        assertTrue(fragment.contains("RecordingsApiClient.fetchStats()"));
+    }
+
+    @Test
+    public void recordingInsightsRejectUnavailableOrWarmingStats() throws IOException {
+        String insights = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/dashboard/DashboardInsight.kt");
+        String fetchStats = methodBody(insights, "private fun fetchRecordingStats");
+
+        assertTrue(fetchStats.contains("it.indexUnavailable || it.warming"));
+    }
+
+        @Test
+        public void tileAcceptsOnlyAuthoritativeTodayCounts() {
+        DashboardFragment.DashboardRecordingMetricPolicy policy =
+            DashboardFragment.DashboardRecordingMetricPolicy.INSTANCE;
+
+        assertNull(policy.authoritativeTodayCount(true, false, 12L));
+        assertNull(policy.authoritativeTodayCount(false, true, 12L));
+        assertNull(policy.authoritativeTodayCount(false, false, -1L));
+        assertNull(policy.authoritativeTodayCount(
+            false, false, ((long) Integer.MAX_VALUE) + 1L));
+        assertEquals(Integer.valueOf(0),
+            policy.authoritativeTodayCount(false, false, 0L));
+        assertEquals(Integer.valueOf(12),
+            policy.authoritativeTodayCount(false, false, 12L));
+        }
+
+        @Test
+        public void newestSentryQueryReliesOnNewestFirstIndexOrdering() throws IOException {
+        String insights = readRepositoryFile(
+            "app/src/main/java/com/overdrive/app/ui/dashboard/DashboardInsight.kt");
+        String index = readRepositoryFile(
+            "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+
+        String newest = methodBody(insights, "private fun fetchNewestSentryTimestamp");
+        assertTrue(newest.contains("page = 1"));
+        assertTrue(newest.contains("pageSize = 1"));
+        assertTrue(index.contains("ORDER BY ts_ms DESC"));
+        }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR bounds recording-related I/O in two common UI workflows:

1. Replaces dashboard full-library scans with indexed stats and a one-row newest-sentry query.
2. Deduplicates thumbnail cache misses and caps distinct storage-backed decodes at two.

## Why is this change needed?

A dashboard resume materialized the entire recording library once for the metric tile and three more times while building insights. A 5,000-row library could therefore issue roughly 100 paginated requests and repeatedly allocate the same recording objects for aggregate values already available from the index.

Each thumbnail cache miss also launched an independent unscoped IO coroutine. Fast RecyclerView binding could decode the same key more than once and start many concurrent random MP4 reads against FUSE-backed storage.

## Commit structure

- `perf(dashboard): use bounded recording queries`
- `perf(recordings): bound and deduplicate thumbnail loads`

## New budgets and behavior

- Each insight build uses one stats payload and one `pageSize=1` sentry query.
- The metric tile uses stats only and never materializes recording rows.
- Warming/unavailable stats remain unknown, not authoritative zero.
- Same-key thumbnail requests share one Deferred.
- At most two distinct thumbnail decodes access storage concurrently.
- Recycled holders cancel their waiters without cancelling shared work.
- Adapter detach cancels work; reattach creates a fresh loader.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.ui.dashboard.DashboardRecordingQueryBudgetTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.ui.adapter.InFlightLoadCoordinatorTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Moderate-low. Dashboard data comes from the existing indexed API contracts. Thumbnail concurrency and lifecycle behavior are isolated in a generic coordinator with deterministic JVM tests. Frame extraction itself is unchanged.