### PR TITLE
perf(recordings): coalesce index reconciliation

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -1908,9 +1908,10 @@ public class CameraDaemon {
         // reconcile cadence for the rest of the daemon's life.
         memoryLogScheduler.scheduleAtFixedRate(() -> {
             try {
-                com.overdrive.app.server.RecordingsIndex.getInstance().reconcile();
+                com.overdrive.app.server.RecordingsIndex.getInstance()
+                        .requestReconcile("hourly-integrity");
             } catch (Throwable t) {
-                log("RecordingsIndex reconcile tick failed: "
+                log("RecordingsIndex reconcile request failed: "
                     + t.getClass().getSimpleName() + ": " + t.getMessage());
             }
         }, 60, 60, java.util.concurrent.TimeUnit.MINUTES);

--- a/app/src/main/java/com/overdrive/app/server/CoalescingTaskRunner.java
+++ b/app/src/main/java/com/overdrive/app/server/CoalescingTaskRunner.java
@@ -1,0 +1,45 @@
+package com.overdrive.app.server;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class CoalescingTaskRunner {
+    private final Executor executor;
+    private final Runnable task;
+    private final AtomicBoolean requested = new AtomicBoolean(false);
+    private final AtomicBoolean workerRunning = new AtomicBoolean(false);
+
+    CoalescingTaskRunner(Executor executor, Runnable task) {
+        this.executor = executor;
+        this.task = task;
+    }
+
+    void request() {
+        requested.set(true);
+        scheduleIfNeeded();
+    }
+
+    private void scheduleIfNeeded() {
+        if (!workerRunning.compareAndSet(false, true)) return;
+        try {
+            executor.execute(this::drainRequests);
+        } catch (RuntimeException | Error failure) {
+            workerRunning.set(false);
+            throw failure;
+        }
+    }
+
+    private void drainRequests() {
+        try {
+            while (requested.getAndSet(false)) {
+                task.run();
+            }
+        } finally {
+            workerRunning.set(false);
+            // Covers a request that lands after the loop's final false read but
+            // before workerRunning is cleared. Conditional scheduling keeps the
+            // handoff race from losing that request.
+            if (requested.get()) scheduleIfNeeded();
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/QualitySettingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/QualitySettingsApiHandler.java
@@ -487,28 +487,6 @@ public class QualitySettingsApiHandler {
                 response.put("message", Messages.get("messages.quality_storage_settings_updated"));
             }
 
-            // Re-arm RecordingsIndex FileObservers against the new active dir
-            // set, AND walk the new active dir to populate the index. The
-            // refresh-only call would only catch live writes going forward —
-            // existing files on the new volume would be invisible to the
-            // index until the 1-hour periodic reconcile. Reconcile here fills
-            // them immediately. Run on a background thread so the HTTP
-            // response doesn't block on the FUSE walk.
-            if (storageTypeChanged) {
-                try {
-                    com.overdrive.app.daemon.RecordingsIndexFileWatcher.getInstance().refresh();
-                } catch (Throwable t) {
-                    CameraDaemon.log("RecordingsIndexFileWatcher refresh failed: " + t.getMessage());
-                }
-                new Thread(() -> {
-                    try {
-                        com.overdrive.app.server.RecordingsIndex.getInstance().reconcile();
-                    } catch (Throwable t) {
-                        CameraDaemon.log("Post-storage-switch reconcile failed: " + t.getMessage());
-                    }
-                }, "RecordingsIndexStorageSwitchReconcile").start();
-            }
-            
             HttpResponse.sendJson(out, response.toString());
             
         } catch (Exception e) {

--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -120,9 +120,9 @@ public class RecordingsApiHandler {
      */
     public static void pruneRecordingCache() {
         try {
-            RecordingsIndex.getInstance().reconcile();
+            RecordingsIndex.getInstance().requestReconcile("periodic-prune");
         } catch (Throwable t) {
-            CameraDaemon.log("RecordingsApiHandler reconcile failed: " + t.getMessage());
+            CameraDaemon.log("RecordingsApiHandler reconcile request failed: " + t.getMessage());
         }
     }
     
@@ -835,32 +835,11 @@ public class RecordingsApiHandler {
         return files != null && files.length > 0;
     }
 
-    private static final java.util.concurrent.atomic.AtomicBoolean RECONCILE_IN_FLIGHT =
-            new java.util.concurrent.atomic.AtomicBoolean(false);
-
     /**
-     * @return true when this call started a fresh reconcile thread.
-     *         false when one was already in flight (caller may still
-     *         signal "reconciling" to the client — the existing
-     *         in-flight pass will pick up the missing rows).
+     * @return true only when the coalesced repair request was accepted.
      */
     private static boolean kickBackgroundReconcile(RecordingsIndex idx) {
-        if (!RECONCILE_IN_FLIGHT.compareAndSet(false, true)) {
-            // Already running. Tell caller we're reconciling so the
-            // client retries — but don't spawn a duplicate thread.
-            return true;
-        }
-        Thread t = new Thread(() -> {
-            try { idx.reconcile(); }
-            catch (Throwable thr) {
-                CameraDaemon.log("Reconcile kick failed: " + thr.getMessage());
-            } finally {
-                RECONCILE_IN_FLIGHT.set(false);
-            }
-        }, "RecordingsIndexReconcileKick");
-        t.setDaemon(true);
-        t.start();
-        return true;
+        return idx.requestReconcile("api-repair-on-read");
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -143,9 +143,14 @@ public final class RecordingsIndex {
     // value means something is interrupting the DB write threads.
     private int reconnectCount = 0;
 
-    // Coalesces the post-reconnect heal so repeated reconnects don't stack
-    // reconcile threads.
-    private final AtomicBoolean reconcileAfterReconnectRunning = new AtomicBoolean(false);
+        // All asynchronous repair sources converge here. A burst before execution
+        // becomes one pass; requests arriving during that pass become one follow-up.
+        private final java.util.concurrent.ConcurrentLinkedQueue<String> reconcileReasons =
+            new java.util.concurrent.ConcurrentLinkedQueue<>();
+        private final CoalescingTaskRunner reconcileRequests;
+        // Synchronous warmup reconciliation and asynchronous repair must not walk
+        // the same FUSE roots concurrently.
+        private final Object reconcileExecutionLock = new Object();
 
     // ---------------- queryStats() memo ----------------
     //
@@ -276,7 +281,13 @@ public final class RecordingsIndex {
     private final AtomicInteger warmupTotal = new AtomicInteger(0);
     private final AtomicInteger warmupDone = new AtomicInteger(0);
 
-    private RecordingsIndex() {}
+    private RecordingsIndex() {
+        reconcileRequests = new CoalescingTaskRunner(command -> {
+            Thread thread = new Thread(command, "RecordingsIndexReconcile");
+            thread.setDaemon(true);
+            thread.start();
+        }, this::runRequestedReconcile);
+    }
 
     // =================================================================
     // Lifecycle
@@ -509,7 +520,7 @@ public final class RecordingsIndex {
                     + " re-index anything missed while it was down.");
             // The dead window silently dropped upserts/removes, so the index
             // now drifts from disk. Heal it in the background.
-            kickReconcileAfterReconnect();
+            requestReconcile("store-reconnect");
             return true;
         } catch (Exception e) {
             // CRITICAL: drop the half-open connection. getConnection() may
@@ -600,24 +611,41 @@ public final class RecordingsIndex {
     }
 
     /**
-     * Fire a one-shot background reconcile after a reconnect so rows missed
-     * while the connection was dead get re-indexed without waiting for the
-     * next storage hot-plug. Coalesced — a second reconnect while a heal is
-     * still running does not stack another thread.
+     * Queue a background reconcile without stacking FUSE walks.
+     *
+     * @return true when the request was queued or merged into a running worker;
+     *         false during shutdown or when the worker could not be started.
      */
-    private void kickReconcileAfterReconnect() {
-        if (!reconcileAfterReconnectRunning.compareAndSet(false, true)) return;
-        Thread t = new Thread(() -> {
-            try {
-                reconcile();
-            } catch (Throwable thr) {
-                logger.warn("Post-reconnect reconcile failed: " + thr.getMessage());
-            } finally {
-                reconcileAfterReconnectRunning.set(false);
-            }
-        }, "RecordingsIndexReconnectHeal");
-        t.setDaemon(true);
-        t.start();
+    public boolean requestReconcile(String reason) {
+        if (shuttingDown) return false;
+        if (reason != null && !reason.isEmpty()) reconcileReasons.offer(reason);
+        try {
+            reconcileRequests.request();
+            return true;
+        } catch (Throwable failure) {
+            logger.warn("Could not schedule recordings reconcile (" + reason + "): "
+                    + failure.getMessage());
+            // The runner keeps its pending bit and the reason remains queued.
+            // A later request retries scheduling without losing diagnostics.
+            return false;
+        }
+    }
+
+    private void runRequestedReconcile() {
+        StringBuilder reasons = new StringBuilder();
+        String reason;
+        while ((reason = reconcileReasons.poll()) != null) {
+            if (reasons.length() > 0) reasons.append(',');
+            reasons.append(reason);
+        }
+        if (reasons.length() > 0) {
+            logger.debug("Running requested reconcile: " + reasons);
+        }
+        try {
+            reconcile();
+        } catch (Throwable failure) {
+            logger.warn("Requested reconcile failed: " + failure.getMessage());
+        }
     }
 
     /**
@@ -1406,6 +1434,12 @@ public final class RecordingsIndex {
      * stat() call.
      */
     public void reconcile() {
+        synchronized (reconcileExecutionLock) {
+            reconcileInternal();
+        }
+    }
+
+    private void reconcileInternal() {
         if (!isAvailable()) return;
         long t0 = System.currentTimeMillis();
         StorageManager sm = StorageManager.getInstance();

--- a/app/src/main/java/com/overdrive/app/server/SurveillanceIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/server/SurveillanceIpcServer.java
@@ -765,22 +765,6 @@ public class SurveillanceIpcServer implements Runnable {
                         sentry.setEventOutputDir(storageManager.getSurveillanceDir());
                         logger.info("Updated sentry output dir: " + storageManager.getSurveillanceDir().getAbsolutePath());
                     }
-                    // Re-arm FileObservers + reconcile the index against
-                    // the freshly-targeted volume. Refresh alone catches
-                    // future writes; reconcile pulls in existing files
-                    // that lived on the new volume already.
-                    try {
-                        com.overdrive.app.daemon.RecordingsIndexFileWatcher.getInstance().refresh();
-                    } catch (Throwable t) {
-                        logger.warn("RecordingsIndexFileWatcher refresh failed: " + t.getMessage());
-                    }
-                    new Thread(() -> {
-                        try {
-                            com.overdrive.app.server.RecordingsIndex.getInstance().reconcile();
-                        } catch (Throwable t) {
-                            logger.warn("Post-storage-switch reconcile failed: " + t.getMessage());
-                        }
-                    }, "RecordingsIndexStorageSwitchReconcile").start();
                 } else {
                     logger.warn("Failed to set surveillance storage to " + type + " - not available");
                 }

--- a/app/src/main/java/com/overdrive/app/server/TcpCommandServer.java
+++ b/app/src/main/java/com/overdrive/app/server/TcpCommandServer.java
@@ -364,21 +364,6 @@ public class TcpCommandServer {
                         response.put("path", storageManager.getRecordingsPath());
                         response.put("message", "Recordings storage set to " + recStorageTypeValue);
                         CameraDaemon.log("Recordings storage type set to " + recStorageTypeValue + " via TCP IPC");
-                        // Re-arm FileObservers + reconcile the index against
-                        // the new active dir. Refresh alone wouldn't pull in
-                        // pre-existing files on the new volume.
-                        try {
-                            com.overdrive.app.daemon.RecordingsIndexFileWatcher.getInstance().refresh();
-                        } catch (Throwable t) {
-                            CameraDaemon.log("RecordingsIndexFileWatcher refresh failed: " + t.getMessage());
-                        }
-                        new Thread(() -> {
-                            try {
-                                com.overdrive.app.server.RecordingsIndex.getInstance().reconcile();
-                            } catch (Throwable t) {
-                                CameraDaemon.log("Post-storage-switch reconcile failed: " + t.getMessage());
-                            }
-                        }, "RecordingsIndexStorageSwitchReconcile").start();
                     } else {
                         response.put("status", "error");
                         response.put("message", recType.name() + " not available");

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -5063,13 +5063,12 @@ public class StorageManager {
         } catch (Throwable t) {
             logWarn(reason + ": RecordingsIndexFileWatcher refresh failed: " + t.getMessage());
         }
-        new Thread(() -> {
-            try {
-                com.overdrive.app.server.RecordingsIndex.getInstance().reconcile();
-            } catch (Throwable t) {
-                logWarn(reason + ": RecordingsIndex reconcile failed: " + t.getMessage());
-            }
-        }, "RecordingsIndexHotplugReconcile").start();
+        try {
+            com.overdrive.app.server.RecordingsIndex.getInstance()
+                    .requestReconcile(reason);
+        } catch (Throwable t) {
+            logWarn(reason + ": RecordingsIndex reconcile request failed: " + t.getMessage());
+        }
     }
 
     // ==================== Cleanup Logic ====================

--- a/app/src/test/java/com/overdrive/app/server/CoalescingTaskRunnerTest.java
+++ b/app/src/test/java/com/overdrive/app/server/CoalescingTaskRunnerTest.java
@@ -1,0 +1,93 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CoalescingTaskRunnerTest {
+
+    @Test
+    public void burstBeforeExecutionSchedulesOnePass() {
+        ManualExecutor executor = new ManualExecutor();
+        AtomicInteger runs = new AtomicInteger();
+        CoalescingTaskRunner runner = new CoalescingTaskRunner(executor, runs::incrementAndGet);
+
+        for (int i = 0; i < 100; i++) runner.request();
+
+        assertEquals(1, executor.size());
+        executor.runNext();
+        assertEquals(1, runs.get());
+        assertEquals(0, executor.size());
+    }
+
+    @Test
+    public void requestsDuringPassBecomeOneFollowUpWithoutOverlap() {
+        ManualExecutor executor = new ManualExecutor();
+        AtomicInteger runs = new AtomicInteger();
+        AtomicInteger active = new AtomicInteger();
+        AtomicInteger peak = new AtomicInteger();
+        AtomicReference<CoalescingTaskRunner> runnerRef = new AtomicReference<>();
+        CoalescingTaskRunner runner = new CoalescingTaskRunner(executor, () -> {
+            int nowActive = active.incrementAndGet();
+            peak.accumulateAndGet(nowActive, Math::max);
+            int pass = runs.incrementAndGet();
+            if (pass == 1) {
+                for (int i = 0; i < 100; i++) runnerRef.get().request();
+            }
+            active.decrementAndGet();
+        });
+        runnerRef.set(runner);
+
+        runner.request();
+        executor.runNext();
+
+        assertEquals(2, runs.get());
+        assertEquals(1, peak.get());
+        assertEquals(0, executor.size());
+    }
+
+    @Test
+    public void rejectedScheduleCanBeRetried() {
+        ManualExecutor executor = new ManualExecutor();
+        executor.reject = true;
+        AtomicInteger runs = new AtomicInteger();
+        CoalescingTaskRunner runner = new CoalescingTaskRunner(executor, runs::incrementAndGet);
+
+        try {
+            runner.request();
+        } catch (RejectedExecutionException expected) {
+            // Expected: caller owns logging; the runner must reset its gate.
+        }
+        executor.reject = false;
+        runner.request();
+        executor.runNext();
+
+        assertEquals(1, runs.get());
+    }
+
+    private static final class ManualExecutor implements java.util.concurrent.Executor {
+        final Queue<Runnable> tasks = new ArrayDeque<>();
+        boolean reject;
+
+        @Override
+        public void execute(Runnable command) {
+            if (reject) throw new RejectedExecutionException("test rejection");
+            tasks.add(command);
+        }
+
+        int size() {
+            return tasks.size();
+        }
+
+        void runNext() {
+            Runnable next = tasks.remove();
+            next.run();
+        }
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingsReconcileOwnershipTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsReconcileOwnershipTest.java
@@ -43,6 +43,23 @@ public class RecordingsReconcileOwnershipTest {
         assertTrue(reconcile.contains("reconcileInternal()"));
     }
 
+    @Test
+    public void storageHandlersDelegateIndexMaintenanceToStorageManager() throws IOException {
+        assertNoHandlerOwnedReconcile(
+                "app/src/main/java/com/overdrive/app/server/QualitySettingsApiHandler.java");
+        assertNoHandlerOwnedReconcile(
+                "app/src/main/java/com/overdrive/app/server/SurveillanceIpcServer.java");
+        assertNoHandlerOwnedReconcile(
+                "app/src/main/java/com/overdrive/app/server/TcpCommandServer.java");
+    }
+
+    private static void assertNoHandlerOwnedReconcile(String relativePath) throws IOException {
+        String source = readRepositoryFile(relativePath);
+        assertFalse(source.contains("RecordingsIndexFileWatcher.getInstance().refresh()"));
+        assertFalse(source.contains("RecordingsIndex.getInstance().reconcile()"));
+        assertFalse(source.contains("RecordingsIndexStorageSwitchReconcile"));
+    }
+
     private static String methodBody(String source, String signature) {
         int start = source.indexOf(signature);
         if (start < 0) throw new AssertionError("Could not locate " + signature);

--- a/app/src/test/java/com/overdrive/app/server/RecordingsReconcileOwnershipTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsReconcileOwnershipTest.java
@@ -1,0 +1,77 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingsReconcileOwnershipTest {
+
+    @Test
+    public void asynchronousRepairSourcesUseCentralRequestOwner() throws IOException {
+        String index = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String api = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String storage = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        assertTrue(index.contains("CoalescingTaskRunner reconcileRequests"));
+        assertFalse(index.contains("reconcileAfterReconnectRunning"));
+        assertFalse(api.contains("RECONCILE_IN_FLIGHT"));
+        assertTrue(methodBody(api, "private static boolean kickBackgroundReconcile")
+            .contains("return idx.requestReconcile"));
+        assertFalse(methodBody(storage, "private void notifyRecordingsIndexOfStorageChange")
+                .contains("new Thread"));
+        assertTrue(methodBody(storage, "private void notifyRecordingsIndexOfStorageChange")
+                .contains("requestReconcile"));
+    }
+
+    @Test
+    public void directPassesAreSerializedSeparatelyFromDatabaseMonitor() throws IOException {
+        String index = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String reconcile = methodBody(index, "public void reconcile()");
+
+        assertTrue(reconcile.contains("synchronized (reconcileExecutionLock)"));
+        assertTrue(reconcile.contains("reconcileInternal()"));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR gives recordings-index reconciliation one asynchronous owner and removes duplicate storage-switch repair work.

## Why is this change needed?

Reconnect recovery, API repair-on-read, storage hot-plug, hourly integrity, HTTP settings, surveillance IPC, and TCP commands each owned separate threads or in-flight flags. Bursts could stack full directory scans over the same FUSE roots, while one storage switch could rebuild watchers and reconcile twice.

## Commit structure

- `perf(recordings): centralize reconcile scheduling`
- `perf(recordings): remove duplicate storage-switch repairs`

## Scheduling contract

- Requests before a worker starts collapse into one pass.
- Requests during a pass collapse into one follow-up.
- The worker handoff race cannot lose a request.
- Rejected scheduling resets the gate and remains retryable on the next request.
- Synchronous warmup and asynchronous repair cannot overlap filesystem walks.
- Shutdown rejects new requests.
- API clients receive `reconciling=true` only when work was accepted.
- Reason tags are retained for diagnostics.

## Ownership contract

`StorageManager` is the sole storage-change owner: it refreshes `RecordingsIndexFileWatcher` and submits one coalesced reconcile request. HTTP, IPC, and TCP handlers only call the storage setter.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.CoalescingTaskRunnerTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.RecordingsReconcileOwnershipTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Moderate. Scheduling ownership changes but reconcile content does not. The generic runner has deterministic tests for bursts, follow-ups, non-overlap, rejection recovery, and ownership wiring.