### PR TITLE
fix(recordings): unify roots and refresh stale index rows

### DIFF
--- a/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
@@ -1,0 +1,55 @@
+package com.overdrive.app.server;
+
+import java.io.File;
+
+final class RecordingFileFingerprint {
+    enum Decision { ADD, REFRESH, UNCHANGED }
+
+    final File file;
+    final String absolutePath;
+    final long sizeBytes;
+    final long mp4Mtime;
+    final long sidecarMtime;
+
+    private RecordingFileFingerprint(File file, String absolutePath, long sizeBytes,
+                                     long mp4Mtime, long sidecarMtime) {
+        this.file = file;
+        this.absolutePath = absolutePath;
+        this.sizeBytes = sizeBytes;
+        this.mp4Mtime = mp4Mtime;
+        this.sidecarMtime = sidecarMtime;
+    }
+
+    static RecordingFileFingerprint from(File mp4) {
+        File sidecar = sidecarFor(mp4);
+        return new RecordingFileFingerprint(
+                mp4,
+                mp4.getAbsolutePath(),
+                mp4.length(),
+                mp4.lastModified(),
+            sidecar.canRead() ? sidecar.lastModified() : 0L);
+    }
+
+    static File sidecarFor(File mp4) {
+        String name = mp4.getName();
+        String stem = name.endsWith(".mp4")
+                ? name.substring(0, name.length() - ".mp4".length())
+                : name;
+        return new File(mp4.getParentFile(), stem + ".json");
+    }
+
+    boolean matches(String indexedPath, long indexedSizeBytes,
+                    long indexedMp4Mtime, long indexedSidecarMtime) {
+        return absolutePath.equals(indexedPath)
+                && sizeBytes == indexedSizeBytes
+                && mp4Mtime == indexedMp4Mtime
+                && sidecarMtime == indexedSidecarMtime;
+    }
+
+    Decision decisionAgainst(String indexedPath, long indexedSizeBytes,
+                             long indexedMp4Mtime, long indexedSidecarMtime) {
+        if (indexedPath == null) return Decision.ADD;
+        return matches(indexedPath, indexedSizeBytes, indexedMp4Mtime, indexedSidecarMtime)
+                ? Decision.UNCHANGED : Decision.REFRESH;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -52,15 +52,6 @@ public class RecordingsApiHandler {
         return StorageManager.getInstance().getSurveillancePath();
     }
     
-    // Legacy paths for backward compatibility (migration). Used by the
-    // findVideoFile / findSiblingJpeg / findJsonSidecar fallback paths
-    // when the active StorageManager dirs don't contain the requested
-    // file — covers very old installs that wrote into <base>/recordings
-    // or directly into <base>.
-    private static final String LEGACY_RECORDINGS_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files";
-    private static final String LEGACY_SENTRY_DIR = LEGACY_RECORDINGS_DIR + "/sentry_events";
-
-
     // -----------------------------------------------------------------
     // Index integration
     // -----------------------------------------------------------------
@@ -527,14 +518,6 @@ public class RecordingsApiHandler {
             if (f.exists() && f.canRead() && f.length() > 0) return f;
         }
 
-        // Check legacy recordings location
-        File legacyFile = new File(LEGACY_RECORDINGS_DIR, filename);
-        if (legacyFile.exists() && legacyFile.canRead() && legacyFile.length() > 0) return legacyFile;
-
-        // Check legacy sentry location
-        File legacySentryFile = new File(LEGACY_SENTRY_DIR, filename);
-        if (legacySentryFile.exists() && legacySentryFile.canRead() && legacySentryFile.length() > 0) return legacySentryFile;
-
         // In-flight fallback (thumbnails only): a notification fires the moment
         // startRecording() returns, but the file on disk is still
         // <name>.mp4.tmp until closeEventRecording() finishes (10-15s
@@ -582,10 +565,6 @@ public class RecordingsApiHandler {
             File f = new File(dir, jpegName);
             if (f.exists() && f.canRead() && f.length() > 0) return f;
         }
-        File legacy = new File(LEGACY_RECORDINGS_DIR, jpegName);
-        if (legacy.exists() && legacy.canRead() && legacy.length() > 0) return legacy;
-        File legacySentry = new File(LEGACY_SENTRY_DIR, jpegName);
-        if (legacySentry.exists() && legacySentry.canRead() && legacySentry.length() > 0) return legacySentry;
         return null;
     }
 

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -16,9 +16,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -841,10 +844,8 @@ public final class RecordingsIndex {
      * per unindexed file, so a K-file drift chopped the monitor into K windows
      * of ~30ms and every concurrent queryStats/queryRecordings/queryDates
      * request queued behind them. That defeated the explicit intent documented
-     * in reconcile() ("we deliberately do NOT hold the lock across the
-     * locateFile() stat() calls ... they can each block 100-500ms, serializing
-     * every concurrent queryRecordings/queryCount/queryStats request"), which
-     * kept locateFile() out of the lock but then re-entered it here.
+    * in reconcile(): filesystem fingerprinting stays outside the monitor so
+    * FUSE metadata stalls cannot serialize every query behind a parse.
      *
      * <p>Only the short MERGE ({@link #upsertRow}) is synchronized — the same
      * split the warmup pipeline already uses (4 unsynchronized parser threads
@@ -1386,60 +1387,58 @@ public final class RecordingsIndex {
     }
 
     /**
-     * Reconcile the index against the filesystem. Walks every dir,
-     * upserts unknown files, removes index rows whose mp4 is gone.
+      * Reconcile the index against the filesystem. Walks every dir,
+      * upserts new or changed files, removes index rows whose mp4 is gone.
      * Backstop for FileObserver event drops on FUSE-mounted SD cards.
-     * Cheap when the index is in sync — every existing row is one
-     * stat() call.
+      * Cheap when the index is in sync — existing rows compare filesystem
+      * fingerprints without parsing sidecar JSON.
      */
     public void reconcile() {
         if (!isAvailable()) return;
         long t0 = System.currentTimeMillis();
         StorageManager sm = StorageManager.getInstance();
 
-        Set<String> diskNames = new HashSet<>();
-        scanDirNames(diskNames, sm.getAllRecordingsDirs());
-        scanDirNames(diskNames, sm.getAllSurveillanceDirs());
-        scanDirNames(diskNames, sm.getAllProximityDirs());
+          Map<String, RecordingFileFingerprint> diskFiles = new LinkedHashMap<>();
+          scanDirFiles(diskFiles, sm.getAllRecordingsDirs());
+          scanDirFiles(diskFiles, sm.getAllSurveillanceDirs());
+          scanDirFiles(diskFiles, sm.getAllProximityDirs());
 
-        // Three-phase walk: index enumerate → drop missing → upsert new.
+          // Three-phase walk: index snapshot → drop missing → upsert new/changed.
         // The SELECT enumerate is synchronized so the snapshot is
         // consistent. The per-row remove()/upsert() calls re-acquire the
-        // monitor themselves; we deliberately do NOT hold the lock across
-        // the locateFile() stat() calls because on FUSE-mounted SD cards
-        // they can each block 100-500ms, serializing every concurrent
+          // monitor themselves; filesystem fingerprinting stays outside that
+          // monitor because FUSE metadata calls can block, serializing every concurrent
         // queryRecordings/queryCount/queryStats request behind reconcile.
         // Accept temporary inconsistency — a file deleted between the
         // collect and verify phases will be cleaned up on the next
         // periodic reconcile (the operation is idempotent).
         int removed = 0;
         int added = 0;
-        // Files seen by scanDirNames() (exists, readable, size>0) but not
-        // findable by locateFile() — usually means a mount path drift or a
-        // symlinked dir that scanDirNames() followed but locateFile()'s
-        // canonical dir list does not. Surfaced in the summary so operators
-        // can spot data-loss-shaped gaps instead of silent skips.
-        int unlocatable = 0;
+        int refreshed = 0;
 
         // Phase 1: snapshot the index under the monitor.
-        Set<String> indexNames;
+        Map<String, IndexedFileState> indexFiles;
         synchronized (this) {
             // Built inside the body so a reconnect-retry re-enumerates into a
-            // fresh set rather than merging two partial snapshots.
-            indexNames = withRetry("reconcile: index enumerate", null, () -> {
-                Set<String> names = new HashSet<>();
+            // fresh map rather than merging two partial snapshots.
+            indexFiles = withRetry("reconcile: index enumerate", null, () -> {
+                Map<String, IndexedFileState> rows = new HashMap<>();
                 try (PreparedStatement ps = connection.prepareStatement(
-                        "SELECT filename FROM recordings");
+                        "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"
+                                + " FROM recordings");
                      ResultSet rs = ps.executeQuery()) {
-                    while (rs.next()) names.add(rs.getString(1));
+                    while (rs.next()) {
+                        rows.put(rs.getString(1), new IndexedFileState(
+                                rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getLong(5)));
+                    }
                 }
-                return names;
+                return rows;
             });
         }
         // null (not empty) distinguishes "enumerate failed" from "index is
         // legitimately empty". Bailing on failure is important: an empty
         // snapshot would make Phase 2 believe every indexed row is missing.
-        if (indexNames == null) {
+        if (indexFiles == null) {
             logger.warn("reconcile: index enumerate unavailable — skipping this pass");
             return;
         }
@@ -1447,31 +1446,66 @@ public final class RecordingsIndex {
         // Phase 2: drop rows whose file is gone. remove() takes the
         // monitor per call; that's fine — we want short critical sections
         // here so query threads can interleave.
-        for (String name : indexNames) {
-            if (!diskNames.contains(name)) {
+        for (String name : indexFiles.keySet()) {
+            if (!diskFiles.containsKey(name)) {
                 if (remove(name)) removed++;
             }
         }
 
-        // Phase 3: upsert anything not already known. locateFile() is
-        // intentionally OUTSIDE any synchronized block — its stat() calls
-        // can stall on FUSE mounts and would otherwise serialize queries.
-        for (String name : diskNames) {
-            if (!indexNames.contains(name)) {
-                File f = locateFile(name, sm);
-                if (f != null) {
-                    if (upsert(f)) added++;
-                } else {
-                    unlocatable++;
-                    logger.warn("reconcile: file seen on disk but not locatable: " + name);
-                }
+        // Phase 3: parse only new or fingerprint-changed files. Active-first
+        // map insertion also repairs abs_path when the same filename moved
+        // between roots or volumes.
+        for (Map.Entry<String, RecordingFileFingerprint> entry : diskFiles.entrySet()) {
+            RecordingFileFingerprint fingerprint = entry.getValue();
+            IndexedFileState indexed = indexFiles.get(entry.getKey());
+            RecordingFileFingerprint.Decision decision = fingerprint.decisionAgainst(
+                    indexed != null ? indexed.absolutePath : null,
+                    indexed != null ? indexed.sizeBytes : 0L,
+                    indexed != null ? indexed.mp4Mtime : 0L,
+                    indexed != null ? indexed.sidecarMtime : 0L);
+            switch (decision) {
+                case ADD:
+                    if (upsert(fingerprint.file)) added++;
+                    break;
+                case REFRESH:
+                    if (upsert(fingerprint.file)) refreshed++;
+                    break;
+                case UNCHANGED:
+                    break;
             }
         }
         long ms = System.currentTimeMillis() - t0;
-        if (added > 0 || removed > 0 || unlocatable > 0) {
-            logger.info("Reconcile: +" + added + " / -" + removed
-                    + (unlocatable > 0 ? " / unlocatable=" + unlocatable : "")
+        if (added > 0 || refreshed > 0 || removed > 0) {
+            logger.info("Reconcile: +" + added + " / ~" + refreshed + " / -" + removed
                     + " in " + ms + "ms");
+        }
+    }
+
+    private static final class IndexedFileState {
+        final String absolutePath;
+        final long sizeBytes;
+        final long mp4Mtime;
+        final long sidecarMtime;
+
+        IndexedFileState(String absolutePath, long sizeBytes,
+                         long mp4Mtime, long sidecarMtime) {
+            this.absolutePath = absolutePath;
+            this.sizeBytes = sizeBytes;
+            this.mp4Mtime = mp4Mtime;
+            this.sidecarMtime = sidecarMtime;
+        }
+    }
+
+    private void scanDirFiles(Map<String, RecordingFileFingerprint> out, List<File> dirs) {
+        StorageManager sm = StorageManager.getInstance();
+        for (File dir : dirs) {
+            if (dir == null) continue;
+            File[] files = sm.listMp4Files(dir);
+            for (File file : files) {
+                if (!file.isFile() || out.containsKey(file.getName())) continue;
+                RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(file);
+                if (fingerprint.sizeBytes > 0) out.put(file.getName(), fingerprint);
+            }
         }
     }
 
@@ -1486,22 +1520,6 @@ public final class RecordingsIndex {
                 if (f.isFile() && f.length() > 0) out.add(f.getName());
             }
         }
-    }
-
-    private File locateFile(String name, StorageManager sm) {
-        for (File dir : sm.getAllRecordingsDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        for (File dir : sm.getAllSurveillanceDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        for (File dir : sm.getAllProximityDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        return null;
     }
 
     // =================================================================
@@ -1986,7 +2004,7 @@ public final class RecordingsIndex {
         // Sidecar enrichment — same logic as
         // RecordingsApiHandler.parseRecordingUncached, kept close to
         // identical so existing callers don't notice the swap.
-        File sidecar = new File(mp4.getParentFile(), name.replace(".mp4", ".json"));
+        File sidecar = RecordingFileFingerprint.sidecarFor(mp4);
         if (sidecar.exists() && sidecar.canRead()) {
             r.sidecarMtime = sidecar.lastModified();
             try {

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -1218,19 +1218,6 @@ public final class RecordingsIndex {
         addDirFiles(entries, sm.getAllRecordingsDirs(), null);
         addDirFiles(entries, sm.getAllSurveillanceDirs(), null);
         addDirFiles(entries, sm.getAllProximityDirs(), null);
-        // Legacy paths — keep mirrored with RecordingsApiHandler.
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/recordings")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/sentry_events")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/proximity_events")),
-                null);
 
         // Dedup by filename (mirror dirs hold the same .mp4).
         Set<String> seen = new HashSet<>(entries.size() * 2);

--- a/app/src/main/java/com/overdrive/app/storage/RecordingDirectoryRegistry.java
+++ b/app/src/main/java/com/overdrive/app/storage/RecordingDirectoryRegistry.java
@@ -1,0 +1,40 @@
+package com.overdrive.app.storage;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class RecordingDirectoryRegistry {
+    static final String LEGACY_BASE =
+            "/storage/emulated/0/Android/data/com.overdrive.app/files";
+    static final String LEGACY_RECORDINGS = LEGACY_BASE + "/recordings";
+    static final String LEGACY_SENTRY = LEGACY_BASE + "/sentry_events";
+    static final String LEGACY_PROXIMITY = LEGACY_BASE + "/proximity_events";
+
+    private RecordingDirectoryRegistry() {}
+
+    static List<File> recordings(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb,
+                new File(LEGACY_RECORDINGS), new File(LEGACY_BASE));
+    }
+
+    static List<File> surveillance(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb, new File(LEGACY_SENTRY));
+    }
+
+    static List<File> proximity(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb, new File(LEGACY_PROXIMITY));
+    }
+
+    private static List<File> unique(File... candidates) {
+        List<File> directories = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (File candidate : candidates) {
+            if (candidate == null) continue;
+            if (seen.add(candidate.getAbsolutePath())) directories.add(candidate);
+        }
+        return directories;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -130,8 +130,8 @@ public class StorageManager {
     // Legacy paths from older app versions. Files here aren't written anymore
     // but they still count toward the user's configured limit and must be
     // reaped — otherwise a 500 MB limit can show 800 MB used in the UI.
-    private static final String LEGACY_APP_FILES_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files";
-    private static final String LEGACY_SURVEILLANCE_DIR = LEGACY_APP_FILES_DIR + "/sentry_events";
+    private static final String LEGACY_APP_FILES_DIR = RecordingDirectoryRegistry.LEGACY_BASE;
+    private static final String LEGACY_SURVEILLANCE_DIR = RecordingDirectoryRegistry.LEGACY_SENTRY;
 
     // Subdirectories
     public static final String RECORDINGS_SUBDIR = "recordings";
@@ -3530,15 +3530,18 @@ public class StorageManager {
      * Callers should iterate all returned directories to find all files.
      */
     public List<File> getAllRecordingsDirs() {
-        return getAllDirsForType(recordingsDir, internalRecordingsDir, sdCardRecordingsDir, usbRecordingsDir);
+        return RecordingDirectoryRegistry.recordings(
+            recordingsDir, internalRecordingsDir, sdCardRecordingsDir, usbRecordingsDir);
     }
 
     public List<File> getAllSurveillanceDirs() {
-        return getAllDirsForType(surveillanceDir, internalSurveillanceDir, sdCardSurveillanceDir, usbSurveillanceDir);
+        return RecordingDirectoryRegistry.surveillance(
+            surveillanceDir, internalSurveillanceDir, sdCardSurveillanceDir, usbSurveillanceDir);
     }
 
     public List<File> getAllProximityDirs() {
-        return getAllDirsForType(proximityDir, internalProximityDir, sdCardProximityDir, usbProximityDir);
+        return RecordingDirectoryRegistry.proximity(
+            proximityDir, internalProximityDir, sdCardProximityDir, usbProximityDir);
     }
 
     public List<File> getAllTripsDirs() {
@@ -3580,60 +3583,29 @@ public class StorageManager {
     }
 
     /**
-     * Same as {@link #getAllSurveillanceDirs()} et al, but additionally
-     * includes legacy app-files locations from older app versions where
-     * stale media may still be living and counting toward the limit.
+    * Same canonical roots as {@link #getAllSurveillanceDirs()} et al.
      *
      * Used by both the size accounting and the cleanup reaper so the two
      * agree about what "the surveillance pool" actually is — otherwise
      * the UI can show 800 MB used against a 500 MB limit while cleanup
      * (which only saw the active dir) thinks everything is fine.
      *
-     * Includes the flat legacy base ({@link #LEGACY_APP_FILES_DIR}) when a
-     * non-null filename prefix is supplied via {@link #namePrefixForCategory},
-     * because the flat base is shared across categories and only files
-     * matching the category's prefix should be touched.
+     * The flat legacy base is shared across categories, so callers use
+     * {@link #namePrefixForCategory} to touch only matching files.
      */
     private List<File> getReapableDirs(String category) {
-        List<File> dirs;
-        String legacyPath = null;
-        boolean includeFlatBase = false;
         switch (category) {
             case "recordings":
-                dirs = new ArrayList<>(getAllRecordingsDirs());
-                legacyPath = LEGACY_APP_FILES_DIR + "/recordings";
-                includeFlatBase = true;  // some old installs wrote cam_* into <base>
-                break;
+                return new ArrayList<>(getAllRecordingsDirs());
             case "surveillance":
-                dirs = new ArrayList<>(getAllSurveillanceDirs());
-                legacyPath = LEGACY_SURVEILLANCE_DIR;
-                break;
+                return new ArrayList<>(getAllSurveillanceDirs());
             case "proximity":
-                dirs = new ArrayList<>(getAllProximityDirs());
-                legacyPath = LEGACY_APP_FILES_DIR + "/proximity_events";
-                break;
+                return new ArrayList<>(getAllProximityDirs());
             case "trips":
-                dirs = new ArrayList<>(getAllTripsDirs());
-                break;
+                return new ArrayList<>(getAllTripsDirs());
             default:
                 return new ArrayList<>();
         }
-        if (legacyPath != null) {
-            addDirIfMissing(dirs, new File(legacyPath));
-        }
-        if (includeFlatBase) {
-            addDirIfMissing(dirs, new File(LEGACY_APP_FILES_DIR));
-        }
-        return dirs;
-    }
-
-    private static void addDirIfMissing(List<File> dirs, File candidate) {
-        if (candidate == null || !candidate.exists() || !candidate.isDirectory()) return;
-        String path = candidate.getAbsolutePath();
-        for (File d : dirs) {
-            if (d != null && d.getAbsolutePath().equals(path)) return;
-        }
-        dirs.add(candidate);
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
+++ b/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
@@ -23,16 +23,6 @@ import java.util.Calendar
 object RecordingScanner {
     private const val TAG = "RecordingScanner"
 
-    // Legacy paths for backward compatibility (migration). The base dir
-    // historically held a `recordings/` subdir for dashcam clips and a
-    // `sentry_events/` subdir for surveillance clips; some very old builds
-    // wrote dashcam clips directly into the base dir, so we scan both.
-    private const val LEGACY_BASE_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files"
-    private const val LEGACY_RECORDINGS_DIR = "$LEGACY_BASE_DIR/recordings"
-    private const val LEGACY_RECORDINGS_DIR_FLAT = LEGACY_BASE_DIR
-    private const val LEGACY_SENTRY_DIR = "$LEGACY_BASE_DIR/sentry_events"
-    private const val LEGACY_PROXIMITY_DIR = "$LEGACY_BASE_DIR/proximity_events"
-
     // ==================== Public API ====================
 
     /**
@@ -246,35 +236,16 @@ object RecordingScanner {
         for (dir in sm.allRecordingsDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.NORMAL, normal, seenNormal)
         }
-        // Legacy locations (some installs wrote into <base>/recordings,
-        // others directly into the base dir). Both checked, deduped on name.
-        for (path in listOf(LEGACY_RECORDINGS_DIR, LEGACY_RECORDINGS_DIR_FLAT)) {
-            val dir = File(path)
-            if (dir.exists()) {
-                scanDirectoryDedup(dir, RecordingFile.RecordingType.NORMAL, normal, seenNormal)
-            }
-        }
-
         val sentry = mutableListOf<RecordingFile>()
         val seenSentry = mutableSetOf<String>()
         for (dir in sm.allSurveillanceDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.SENTRY, sentry, seenSentry)
         }
-        val legacySentryDir = File(LEGACY_SENTRY_DIR)
-        if (legacySentryDir.exists()) {
-            scanDirectoryDedup(legacySentryDir, RecordingFile.RecordingType.SENTRY, sentry, seenSentry)
-        }
-
         val proximity = mutableListOf<RecordingFile>()
         val seenProximity = mutableSetOf<String>()
         for (dir in sm.allProximityDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.PROXIMITY, proximity, seenProximity)
         }
-        val legacyProximityDir = File(LEGACY_PROXIMITY_DIR)
-        if (legacyProximityDir.exists()) {
-            scanDirectoryDedup(legacyProximityDir, RecordingFile.RecordingType.PROXIMITY, proximity, seenProximity)
-        }
-
         // OEM Dashcam clips (dvr_*.mp4) live in the same physical directory
         // as cam_*.mp4 (StorageManager.allRecordingsDirs), but parse as a
         // distinct type so the segmented control / library can show them

--- a/app/src/test/java/com/overdrive/app/server/RecordingFileFingerprintTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingFileFingerprintTest.java
@@ -1,0 +1,120 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+public class RecordingFileFingerprintTest {
+
+    @Test
+    public void exactStoredStateMatches() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_120000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_120000.json"), "{}");
+        Files.setLastModifiedTime(mp4.toPath(), FileTime.fromMillis(10_000L));
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(20_000L));
+
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertTrue(fingerprint.matches(mp4.getAbsolutePath(), mp4.length(),
+                mp4.lastModified(), sidecar.lastModified()));
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                fingerprint.decisionAgainst(mp4.getAbsolutePath(), mp4.length(),
+                        mp4.lastModified(), sidecar.lastModified()));
+    }
+
+    @Test
+    public void pathSizeAndMtimeChangesRequireRefresh() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("cam_20260810_120000.mp4"), "video");
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(RecordingFileFingerprint.Decision.ADD,
+                fingerprint.decisionAgainst(null, 0L, 0L, 0L));
+        assertFalse(fingerprint.matches("/old/volume/" + mp4.getName(),
+                fingerprint.sizeBytes, fingerprint.mp4Mtime, fingerprint.sidecarMtime));
+        assertFalse(fingerprint.matches(fingerprint.absolutePath,
+                fingerprint.sizeBytes + 1L, fingerprint.mp4Mtime, fingerprint.sidecarMtime));
+        assertFalse(fingerprint.matches(fingerprint.absolutePath,
+                fingerprint.sizeBytes, fingerprint.mp4Mtime + 1L, fingerprint.sidecarMtime));
+        assertEquals(RecordingFileFingerprint.Decision.REFRESH,
+                fingerprint.decisionAgainst("/old/volume/" + mp4.getName(),
+                        fingerprint.sizeBytes, fingerprint.mp4Mtime,
+                        fingerprint.sidecarMtime));
+    }
+
+    @Test
+    public void sidecarCreationChangeAndDeletionRequireRefresh() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("proximity_20260810_120000.mp4"), "video");
+        RecordingFileFingerprint withoutSidecar = RecordingFileFingerprint.from(mp4);
+
+        File sidecar = write(dir.resolve("proximity_20260810_120000.json"), "{}");
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(30_000L));
+        RecordingFileFingerprint withSidecar = RecordingFileFingerprint.from(mp4);
+
+        assertFalse(withSidecar.matches(withoutSidecar.absolutePath,
+                withoutSidecar.sizeBytes, withoutSidecar.mp4Mtime,
+                withoutSidecar.sidecarMtime));
+        assertTrue(sidecar.delete());
+        RecordingFileFingerprint afterDelete = RecordingFileFingerprint.from(mp4);
+        assertFalse(afterDelete.matches(withSidecar.absolutePath,
+                withSidecar.sizeBytes, withSidecar.mp4Mtime, withSidecar.sidecarMtime));
+    }
+
+    @Test
+    public void sidecarMtimeUpdateRefreshesOnceThenConverges() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_130000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_130000.json"), "{}");
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(30_000L));
+        RecordingFileFingerprint before = RecordingFileFingerprint.from(mp4);
+
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(40_000L));
+        RecordingFileFingerprint after = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(RecordingFileFingerprint.Decision.REFRESH,
+                after.decisionAgainst(before.absolutePath, before.sizeBytes,
+                        before.mp4Mtime, before.sidecarMtime));
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                after.decisionAgainst(after.absolutePath, after.sizeBytes,
+                        after.mp4Mtime, after.sidecarMtime));
+    }
+
+    @Test
+    public void unreadableSidecarUsesSameZeroMtimeAsParser() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_140000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_140000.json"), "{}");
+        sidecar.setReadable(false, false);
+        Assume.assumeFalse("filesystem did not make sidecar unreadable", sidecar.canRead());
+
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(0L, fingerprint.sidecarMtime);
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                fingerprint.decisionAgainst(fingerprint.absolutePath,
+                        fingerprint.sizeBytes, fingerprint.mp4Mtime, 0L));
+    }
+
+    @Test
+    public void sidecarNameOnlyReplacesTrailingMp4Suffix() {
+        File mp4 = new File("/recordings/event_a.mp4_2.mp4");
+
+        assertTrue(RecordingFileFingerprint.sidecarFor(mp4).getPath()
+                .endsWith("/recordings/event_a.mp4_2.json"));
+    }
+
+    private static File write(Path path, String content) throws Exception {
+        Files.write(path, content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return path.toFile();
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingRootParityTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingRootParityTest.java
@@ -1,0 +1,52 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingRootParityTest {
+
+    @Test
+    public void consumersUseStorageManagerInsteadOfDuplicatingLegacyPaths() throws IOException {
+        String index = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String api = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String scanner = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt");
+        String storage = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        String legacyPrefix = "/storage/emulated/0/Android/data/com.overdrive.app/files";
+        assertFalse(index.contains(legacyPrefix));
+        assertFalse(api.contains(legacyPrefix));
+        assertFalse(scanner.contains(legacyPrefix));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.recordings"));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.surveillance"));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.proximity"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
@@ -1,0 +1,61 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingsReconcileFreshnessTest {
+
+    @Test
+    public void reconcileSnapshotsAndComparesStoredFingerprints() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String reconcile = methodBody(source, "public void reconcile()");
+
+        assertTrue(reconcile.contains("Map<String, RecordingFileFingerprint> diskFiles"));
+        assertTrue(source.contains(
+                "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"));
+        assertTrue(source.contains("fingerprint.decisionAgainst("));
+        assertTrue(source.contains("if (upsert(fingerprint.file)) refreshed++"));
+        assertFalse(source.contains("private File locateFile("));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/RecordingDirectoryRegistryTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/RecordingDirectoryRegistryTest.java
@@ -1,0 +1,48 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RecordingDirectoryRegistryTest {
+
+    @Test
+    public void recordingsAreActiveFirstAndIncludeBothLegacyLayouts() {
+        File active = new File("/active/recordings");
+        File internal = new File("/internal/recordings");
+
+        assertEquals(List.of(
+                active.getAbsolutePath(),
+                internal.getAbsolutePath(),
+                RecordingDirectoryRegistry.LEGACY_RECORDINGS,
+                RecordingDirectoryRegistry.LEGACY_BASE
+        ), paths(RecordingDirectoryRegistry.recordings(active, internal, null, null)));
+    }
+
+    @Test
+    public void categoryRegistriesIncludeTheirLegacyRoots() {
+        assertEquals(List.of(RecordingDirectoryRegistry.LEGACY_SENTRY),
+                paths(RecordingDirectoryRegistry.surveillance(null, null, null, null)));
+        assertEquals(List.of(RecordingDirectoryRegistry.LEGACY_PROXIMITY),
+                paths(RecordingDirectoryRegistry.proximity(null, null, null, null)));
+    }
+
+    @Test
+    public void duplicatePathsAreReturnedOnce() {
+        File same = new File("/same/recordings");
+
+        List<File> directories = RecordingDirectoryRegistry.recordings(
+                same, same, same, same);
+
+        assertEquals(3, directories.size());
+        assertEquals(same.getAbsolutePath(), directories.get(0).getAbsolutePath());
+    }
+
+    private static List<String> paths(List<File> directories) {
+        return directories.stream().map(File::getAbsolutePath).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes two correctness gaps in the persistent recording index:

1. Makes current and legacy recording roots come from one canonical registry.
2. Refreshes existing rows when their path, size, MP4 mtime, or sidecar mtime changes.

## Why is this change needed?

Warmup indexed four legacy locations, but reconcile scanned only current roots and deleted those legacy rows as missing. Playback and thumbnail lookup covered only part of the warmup set, while the UI fallback maintained another independent list.

Reconcile also snapshotted only filenames. Existing rows were never reparsed after a file moved between roots or a JSON sidecar was created, changed, or deleted, so stale paths, place data, actor metadata, and storage tags could persist indefinitely.

## Commit structure

- `fix(recordings): unify current and legacy storage roots`
- `fix(recordings): refresh changed index rows`

## Root contract

- Active root remains first, followed by internal, SD, USB, then legacy roots.
- Flat legacy recordings, legacy `recordings`, `sentry_events`, and `proximity_events` are included.
- Roots are deduplicated by absolute path.
- Warmup, reconcile, watcher, retention, playback, delete, thumbnail, and direct fallback inherit the same lists.

## Freshness contract

- Unchanged rows perform fingerprint checks but skip JSON parsing.
- New and changed rows use the existing upsert path.
- Path moves, size/mtime changes, and sidecar create/update/delete are healed.
- Unreadable sidecars converge at the same zero-mtime state used by the parser.
- Duplicate mirrored names preserve active-first priority.

## How to test

```bash
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.storage.RecordingDirectoryRegistryTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.RecordingRootParityTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.RecordingFileFingerprintTest
./gradlew :app:testDebugUnitTest --tests com.overdrive.app.server.RecordingsReconcileFreshnessTest
./gradlew :app:testDebugUnitTest
```

All commands pass locally with the API 36 Android SDK.

## Risk

Moderate. Root ownership and reconcile behavior change, but both are isolated and covered by focused tests. Filesystem authority remains unchanged.

## Merge note

PR #216 also modifies `RecordingsIndex` scheduling. The changes are semantically compatible; whichever PR merges second should be rebased to resolve the localized method conflict.