### PR TITLE
feat(recordings): make index identity volume-aware

### DIFF
--- a/app/src/main/assets/web/shared/events.js
+++ b/app/src/main/assets/web/shared/events.js
@@ -87,6 +87,15 @@ BYD.events = {
     _QUADRANT_HIDE_MS: 3000,
     _quadrantHideTimer: null,
 
+    recordingKey(rec) {
+        return rec && rec.id ? rec.id : (rec ? rec.filename : '');
+    },
+
+    findRecording(key) {
+        return this.recordings.find(rec => this.recordingKey(rec) === key)
+            || this.recordings.find(rec => rec.filename === key);
+    },
+
     /**
      * Read the recording.audioEnabled setting from the backend on every
      * call. Used by playVideo() to decide whether to default the mute
@@ -516,6 +525,7 @@ BYD.events = {
         // exploit it.
         const qParam = (urlParams.get('q') || '').slice(0, 64).trim();
         if (qParam) this.placeContainsQuery = qParam;
+        const idParam = urlParams.get('id');
         const fileParam = urlParams.get('file');
 
         // iOS Web Push can't render options.image, so the SW forwards the
@@ -539,7 +549,10 @@ BYD.events = {
         //   - If it's neither finalized nor in flight (older notification, file
         //     was deleted, etc.): silently no-op so we don't yank the user
         //     around.
-        if (fileParam) {
+        if (idParam) {
+            const found = this.findRecording(idParam);
+            if (found) this.playVideo(idParam);
+        } else if (fileParam) {
             const found = this.recordings.find(r => r.filename === fileParam);
             if (found) {
                 this.playVideo(fileParam);
@@ -1570,20 +1583,21 @@ BYD.events = {
         }
 
         list.innerHTML = inflightHtml + visible.map(rec => {
-            const thumbId = this._thumbDomId(rec.filename);
+            const recordingKey = this.recordingKey(rec);
+            const thumbId = this._thumbDomId(recordingKey);
             const badge = rec.type === 'sentry' ? BYD.i18n.t('events.badge_sentry') : rec.type === 'proximity' ? BYD.i18n.t('events.badge_proximity') : rec.type === 'replay' ? BYD.i18n.t('events.badge_replay') : BYD.i18n.t('events.badge_normal');
             const fname = rec.filename.length > 28 ? rec.filename.substring(0, 25) + '...' : rec.filename;
-            const isSelected = this.selectedFiles.has(rec.filename);
+            const isSelected = this.selectedFiles.has(recordingKey);
             
             // Checkbox for select mode
             const checkbox = this.selectMode 
-                ? '<label class="select-checkbox-wrap" onclick="event.stopPropagation()"><input type="checkbox" class="select-checkbox" ' + (isSelected ? 'checked' : '') + ' onchange="BYD.events.toggleFileSelection(\'' + rec.filename + '\', event)"></label>'
+                ? '<label class="select-checkbox-wrap" onclick="event.stopPropagation()"><input type="checkbox" class="select-checkbox" ' + (isSelected ? 'checked' : '') + ' onchange="BYD.events.toggleFileSelection(\'' + recordingKey + '\', event)"></label>'
                 : '';
             
             // Card click handler depends on mode
             const cardClick = this.selectMode 
-                ? 'BYD.events.toggleFileSelection(\'' + rec.filename + '\')'
-                : 'BYD.events.playVideo(\'' + rec.filename + '\')';
+                ? 'BYD.events.toggleFileSelection(\'' + recordingKey + '\')'
+                : 'BYD.events.playVideo(\'' + recordingKey + '\')';
             
             // v3 enrichment (item 6): use hero JPEG when present, sev badge, actor summary
             const sev = (rec.peakSeverity || '').toUpperCase();
@@ -1640,7 +1654,7 @@ BYD.events = {
                 placeRow = '<div class="recording-place">📍 ' + escaped + '</div>';
             }
 
-            return '<div class="recording-card' + (isSelected ? ' selected' : '') + (sevClass ? ' ' + sevClass : '') + '" data-filename="' + rec.filename + '" onclick="' + cardClick + '">' +
+            return '<div class="recording-card' + (isSelected ? ' selected' : '') + (sevClass ? ' ' + sevClass : '') + '" data-recording-key="' + recordingKey + '" data-filename="' + rec.filename + '" onclick="' + cardClick + '">' +
                 checkbox +
                 '<div class="recording-thumbnail" id="' + thumbId + '" data-thumb="' + thumbUrl + '">' +
                 '<div class="thumb-placeholder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m22 8-6 4 6 4V8Z"/><rect width="14" height="12" x="2" y="6" rx="2"/></svg></div>' +
@@ -1655,8 +1669,8 @@ BYD.events = {
                 '</div>' +
                 (this.selectMode ? '' : 
                 '<div class="recording-actions">' +
-                '<button class="action-btn" onclick="event.stopPropagation(); BYD.events.downloadVideo(\'' + rec.filename + '\')" title="' + BYD.i18n.t('common.download') + '"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>' +
-                '<button class="action-btn delete" onclick="event.stopPropagation(); BYD.events.deleteRecording(\'' + rec.filename + '\')" title="' + BYD.i18n.t('common.delete') + '"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>' +
+                '<button class="action-btn" onclick="event.stopPropagation(); BYD.events.downloadVideo(\'' + recordingKey + '\')" title="' + BYD.i18n.t('common.download') + '"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>' +
+                '<button class="action-btn delete" onclick="event.stopPropagation(); BYD.events.deleteRecording(\'' + recordingKey + '\')" title="' + BYD.i18n.t('common.delete') + '"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg></button>' +
                 '</div>') +
                 '</div>';
         }).join('');
@@ -1726,8 +1740,8 @@ BYD.events = {
         container.innerHTML = '<div class="thumb-placeholder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m22 8-6 4 6 4V8Z"/><rect width="14" height="12" x="2" y="6" rx="2"/></svg><span>' + BYD.i18n.t('events.no_preview') + '</span></div><div class="play-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="white"><polygon points="5 3 19 12 5 21 5 3"/></svg></div>';
     },
     
-    playVideo(filename) {
-        const rec = this.recordings.find(r => r.filename === filename);
+    playVideo(recordingKey) {
+        const rec = this.findRecording(recordingKey);
         if (!rec) return;
         
         document.getElementById('videoTitle').textContent = rec.filename;
@@ -1794,7 +1808,7 @@ BYD.events = {
 
         // Load event-timeline marker overlay for this recording (the
         // scrubber itself stays visible even with no markers).
-        this.loadTimeline(rec.filename, player);
+        this.loadTimeline(rec, player);
     },
     
     closeVideo() {
@@ -1819,8 +1833,8 @@ BYD.events = {
         this.destroyTimeline();
     },
     
-    downloadVideo(filename) {
-        const rec = this.recordings.find(r => r.filename === filename);
+    downloadVideo(recordingKey) {
+        const rec = this.findRecording(recordingKey);
         if (!rec) return;
         const a = document.createElement('a');
         a.href = rec.videoUrl;
@@ -1830,8 +1844,10 @@ BYD.events = {
         document.body.removeChild(a);
     },
     
-    async deleteRecording(filename) {
-        if (!confirm(BYD.i18n.t('events.confirm_delete_one', {filename: filename}))) return;
+    async deleteRecording(recordingKey) {
+        const rec = this.findRecording(recordingKey);
+        if (!rec) return;
+        if (!confirm(BYD.i18n.t('events.confirm_delete_one', {filename: rec.filename}))) return;
 
         // If the modal player is currently showing this recording, pause it
         // and detach the source BEFORE the DELETE goes through. Otherwise
@@ -1839,13 +1855,14 @@ BYD.events = {
         // the user sees an "error: source not supported" toast.
         try {
             const player = document.getElementById('videoPlayer');
-            if (player && player.src && player.src.endsWith('/video/' + filename)) {
+            if (player && player.getAttribute('src') === rec.videoUrl) {
                 this.closeVideo();
             }
         } catch (_) {}
 
         try {
-            const res = await fetch('/api/recordings/' + filename, { method: 'DELETE' });
+            const deleteUrl = rec.deleteUrl || ('/api/recordings/' + encodeURIComponent(rec.filename));
+            const res = await fetch(deleteUrl, { method: 'DELETE' });
             const data = await res.json();
 
             if (data.success) {
@@ -1886,20 +1903,20 @@ BYD.events = {
         this.renderRecordings();
     },
     
-    toggleFileSelection(filename, event) {
+    toggleFileSelection(recordingKey, event) {
         if (event) event.stopPropagation();
         
-        if (this.selectedFiles.has(filename)) {
-            this.selectedFiles.delete(filename);
+        if (this.selectedFiles.has(recordingKey)) {
+            this.selectedFiles.delete(recordingKey);
         } else {
-            this.selectedFiles.add(filename);
+            this.selectedFiles.add(recordingKey);
         }
         this.updateSelectUI();
-        this.updateCardSelection(filename);
+        this.updateCardSelection(recordingKey);
     },
     
     selectAll() {
-        this.recordings.forEach(rec => this.selectedFiles.add(rec.filename));
+        this.recordings.forEach(rec => this.selectedFiles.add(this.recordingKey(rec)));
         this.updateSelectUI();
         this.renderRecordings();
     },
@@ -1910,12 +1927,12 @@ BYD.events = {
         this.renderRecordings();
     },
     
-    updateCardSelection(filename) {
-        const card = document.querySelector('[data-filename="' + filename + '"]');
+    updateCardSelection(recordingKey) {
+        const card = document.querySelector('[data-recording-key="' + recordingKey + '"]');
         if (card) {
-            card.classList.toggle('selected', this.selectedFiles.has(filename));
+            card.classList.toggle('selected', this.selectedFiles.has(recordingKey));
             const checkbox = card.querySelector('.select-checkbox');
-            if (checkbox) checkbox.checked = this.selectedFiles.has(filename);
+            if (checkbox) checkbox.checked = this.selectedFiles.has(recordingKey);
         }
     },
     
@@ -1940,13 +1957,17 @@ BYD.events = {
         
         if (!confirm(BYD.i18n.plural('events.confirm_delete_n', count))) return;
         
-        const filenames = Array.from(this.selectedFiles);
+        const selected = Array.from(this.selectedFiles)
+            .map(key => this.findRecording(key)).filter(Boolean);
+        const ids = selected.map(rec => rec.id).filter(Boolean);
+        const filenames = selected.filter(rec => !rec.id).map(rec => rec.filename);
+        const payload = { ids: ids, filenames: filenames };
         
         try {
             const res = await fetch('/api/recordings/batch-delete', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ filenames: filenames })
+                body: JSON.stringify(payload)
             });
             const data = await res.json();
             
@@ -2003,7 +2024,7 @@ BYD.events = {
      * from the JSON sidecar — when none exists, the scrubber still shows
      * (so the user can still seek), just without colored event ranges.
      */
-    async loadTimeline(filename, videoEl) {
+    async loadTimeline(recording, videoEl) {
         const scrubber = document.getElementById('timelineScrubber');
         const legend = document.getElementById('timelineLegend');
         const track = document.getElementById('timelineTrack');
@@ -2029,7 +2050,9 @@ BYD.events = {
         if (_wrapReset) _wrapReset.classList.remove('dashcam');
 
         try {
-            const res = await fetch('/api/events/' + filename);
+            const eventUrl = recording.eventUrl
+                || ('/api/events/' + encodeURIComponent(recording.filename));
+            const res = await fetch(eventUrl);
             const data = await res.json();
             // Composition layout drives the per-camera zoom regions: toggle the
             // `dashcam` class so the dashcam CSS zoom rects apply, and store it

--- a/app/src/main/java/com/overdrive/app/daemon/RecordingsIndexFileWatcher.java
+++ b/app/src/main/java/com/overdrive/app/daemon/RecordingsIndexFileWatcher.java
@@ -218,7 +218,7 @@ public final class RecordingsIndexFileWatcher {
                         RecordingsIndex.getInstance().upsert(f);
                     }
                 } else if ((action & (FileObserver.DELETE | FileObserver.MOVED_FROM)) != 0) {
-                    RecordingsIndex.getInstance().remove(path);
+                    RecordingsIndex.getInstance().removeByPath(new File(dir, path).getAbsolutePath());
                 }
             } else if (path.endsWith(".json")
                     && (action & FileObserver.MODIFY) != 0) {

--- a/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
@@ -6,14 +6,19 @@ final class RecordingFileFingerprint {
     enum Decision { ADD, REFRESH, UNCHANGED }
 
     final File file;
+    final String recordingId;
+    final String rootId;
     final String absolutePath;
     final long sizeBytes;
     final long mp4Mtime;
     final long sidecarMtime;
 
-    private RecordingFileFingerprint(File file, String absolutePath, long sizeBytes,
+    private RecordingFileFingerprint(File file, String recordingId, String rootId,
+                                     String absolutePath, long sizeBytes,
                                      long mp4Mtime, long sidecarMtime) {
         this.file = file;
+        this.recordingId = recordingId;
+        this.rootId = rootId;
         this.absolutePath = absolutePath;
         this.sizeBytes = sizeBytes;
         this.mp4Mtime = mp4Mtime;
@@ -22,8 +27,11 @@ final class RecordingFileFingerprint {
 
     static RecordingFileFingerprint from(File mp4) {
         File sidecar = sidecarFor(mp4);
+        RecordingIdentity identity = RecordingIdentity.fromFile(mp4);
         return new RecordingFileFingerprint(
                 mp4,
+            identity.recordingId,
+            identity.rootId,
                 mp4.getAbsolutePath(),
                 mp4.length(),
                 mp4.lastModified(),

--- a/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingFileFingerprint.java
@@ -1,0 +1,55 @@
+package com.overdrive.app.server;
+
+import java.io.File;
+
+final class RecordingFileFingerprint {
+    enum Decision { ADD, REFRESH, UNCHANGED }
+
+    final File file;
+    final String absolutePath;
+    final long sizeBytes;
+    final long mp4Mtime;
+    final long sidecarMtime;
+
+    private RecordingFileFingerprint(File file, String absolutePath, long sizeBytes,
+                                     long mp4Mtime, long sidecarMtime) {
+        this.file = file;
+        this.absolutePath = absolutePath;
+        this.sizeBytes = sizeBytes;
+        this.mp4Mtime = mp4Mtime;
+        this.sidecarMtime = sidecarMtime;
+    }
+
+    static RecordingFileFingerprint from(File mp4) {
+        File sidecar = sidecarFor(mp4);
+        return new RecordingFileFingerprint(
+                mp4,
+                mp4.getAbsolutePath(),
+                mp4.length(),
+                mp4.lastModified(),
+            sidecar.canRead() ? sidecar.lastModified() : 0L);
+    }
+
+    static File sidecarFor(File mp4) {
+        String name = mp4.getName();
+        String stem = name.endsWith(".mp4")
+                ? name.substring(0, name.length() - ".mp4".length())
+                : name;
+        return new File(mp4.getParentFile(), stem + ".json");
+    }
+
+    boolean matches(String indexedPath, long indexedSizeBytes,
+                    long indexedMp4Mtime, long indexedSidecarMtime) {
+        return absolutePath.equals(indexedPath)
+                && sizeBytes == indexedSizeBytes
+                && mp4Mtime == indexedMp4Mtime
+                && sidecarMtime == indexedSidecarMtime;
+    }
+
+    Decision decisionAgainst(String indexedPath, long indexedSizeBytes,
+                             long indexedMp4Mtime, long indexedSidecarMtime) {
+        if (indexedPath == null) return Decision.ADD;
+        return matches(indexedPath, indexedSizeBytes, indexedMp4Mtime, indexedSidecarMtime)
+                ? Decision.UNCHANGED : Decision.REFRESH;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RecordingIdentity.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingIdentity.java
@@ -1,0 +1,97 @@
+package com.overdrive.app.server;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+final class RecordingIdentity {
+    final String recordingId;
+    final String rootId;
+    final String volumeId;
+    final String relativePath;
+
+    private RecordingIdentity(String recordingId, String rootId,
+                              String volumeId, String relativePath) {
+        this.recordingId = recordingId;
+        this.rootId = rootId;
+        this.volumeId = volumeId;
+        this.relativePath = relativePath;
+    }
+
+    static RecordingIdentity fromFile(File file) {
+        return fromPath(file.getAbsolutePath());
+    }
+
+    static RecordingIdentity fromPath(String absolutePath) {
+        String path = normalize(absolutePath);
+        String volumeId;
+        String relativePath;
+
+        final String emulated = "/storage/emulated/0/";
+        final String storage = "/storage/";
+        final String mediaRw = "/mnt/media_rw/";
+        final String mnt = "/mnt/";
+
+        if (path.startsWith(emulated)) {
+            volumeId = "internal";
+            relativePath = path.substring(emulated.length());
+        } else if (path.startsWith(storage)) {
+            int slash = path.indexOf('/', storage.length());
+            String volume = slash > 0 ? path.substring(storage.length(), slash)
+                    : path.substring(storage.length());
+            volumeId = "portable:" + volume.toLowerCase(Locale.US);
+            relativePath = slash > 0 ? path.substring(slash + 1) : new File(path).getName();
+        } else if (path.startsWith(mediaRw)) {
+            int slash = path.indexOf('/', mediaRw.length());
+            String volume = slash > 0 ? path.substring(mediaRw.length(), slash)
+                    : path.substring(mediaRw.length());
+            volumeId = "portable:" + volume.toLowerCase(Locale.US);
+            relativePath = slash > 0 ? path.substring(slash + 1) : new File(path).getName();
+        } else if (path.startsWith(mnt)) {
+            int slash = path.indexOf('/', mnt.length());
+            String volume = slash > 0 ? path.substring(mnt.length(), slash)
+                    : path.substring(mnt.length());
+            volumeId = "mount:" + volume.toLowerCase(Locale.US);
+            relativePath = slash > 0 ? path.substring(slash + 1) : new File(path).getName();
+        } else if (path.startsWith("/data/")) {
+            volumeId = "data";
+            relativePath = path.substring(1);
+        } else {
+            File file = new File(path);
+            String parent = file.getParent() != null ? file.getParent() : "/";
+            volumeId = "path:" + digest(parent, 16);
+            relativePath = file.getName();
+        }
+
+        int lastSlash = relativePath.lastIndexOf('/');
+        String relativeRoot = lastSlash >= 0 ? relativePath.substring(0, lastSlash) : "";
+        String rootId = digest(volumeId + "|" + relativeRoot, 24);
+        String recordingId = digest(volumeId + "|" + relativePath, 32);
+        return new RecordingIdentity(recordingId, rootId, volumeId, relativePath);
+    }
+
+    static String rootIdFor(File directory) {
+        RecordingIdentity marker = fromPath(new File(directory, ".root").getAbsolutePath());
+        return marker.rootId;
+    }
+
+    private static String normalize(String path) {
+        if (path == null || path.isEmpty()) return "/unknown";
+        String normalized = path.replace('\\', '/');
+        while (normalized.contains("//")) normalized = normalized.replace("//", "/");
+        return normalized;
+    }
+
+    private static String digest(String value, int chars) {
+        try {
+            byte[] bytes = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(bytes.length * 2);
+            for (byte b : bytes) hex.append(String.format(Locale.US, "%02x", b & 0xff));
+            return hex.substring(0, chars);
+        } catch (Exception impossible) {
+            throw new IllegalStateException("SHA-256 unavailable", impossible);
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RecordingReconcilePolicy.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingReconcilePolicy.java
@@ -1,0 +1,11 @@
+package com.overdrive.app.server;
+
+final class RecordingReconcilePolicy {
+    private RecordingReconcilePolicy() {}
+
+    static boolean shouldDeleteMissingRow(boolean rootAvailable,
+                                          boolean scanComplete,
+                                          boolean rowDiscovered) {
+        return rootAvailable && scanComplete && !rowDiscovered;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -52,15 +52,6 @@ public class RecordingsApiHandler {
         return StorageManager.getInstance().getSurveillancePath();
     }
     
-    // Legacy paths for backward compatibility (migration). Used by the
-    // findVideoFile / findSiblingJpeg / findJsonSidecar fallback paths
-    // when the active StorageManager dirs don't contain the requested
-    // file — covers very old installs that wrote into <base>/recordings
-    // or directly into <base>.
-    private static final String LEGACY_RECORDINGS_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files";
-    private static final String LEGACY_SENTRY_DIR = LEGACY_RECORDINGS_DIR + "/sentry_events";
-
-
     // -----------------------------------------------------------------
     // Index integration
     // -----------------------------------------------------------------
@@ -527,14 +518,6 @@ public class RecordingsApiHandler {
             if (f.exists() && f.canRead() && f.length() > 0) return f;
         }
 
-        // Check legacy recordings location
-        File legacyFile = new File(LEGACY_RECORDINGS_DIR, filename);
-        if (legacyFile.exists() && legacyFile.canRead() && legacyFile.length() > 0) return legacyFile;
-
-        // Check legacy sentry location
-        File legacySentryFile = new File(LEGACY_SENTRY_DIR, filename);
-        if (legacySentryFile.exists() && legacySentryFile.canRead() && legacySentryFile.length() > 0) return legacySentryFile;
-
         // In-flight fallback (thumbnails only): a notification fires the moment
         // startRecording() returns, but the file on disk is still
         // <name>.mp4.tmp until closeEventRecording() finishes (10-15s
@@ -582,10 +565,6 @@ public class RecordingsApiHandler {
             File f = new File(dir, jpegName);
             if (f.exists() && f.canRead() && f.length() > 0) return f;
         }
-        File legacy = new File(LEGACY_RECORDINGS_DIR, jpegName);
-        if (legacy.exists() && legacy.canRead() && legacy.length() > 0) return legacy;
-        File legacySentry = new File(LEGACY_SENTRY_DIR, jpegName);
-        if (legacySentry.exists() && legacySentry.canRead() && legacySentry.length() > 0) return legacySentry;
         return null;
     }
 

--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -1496,7 +1496,9 @@ public class RecordingsApiHandler {
             
             // Limit batch size to prevent abuse
             int maxBatch = 100;
-            int batchSize = ids != null && ids.length() > 0 ? ids.length() : filenames.length();
+            int idCount = ids != null ? ids.length() : 0;
+            int filenameCount = filenames != null ? filenames.length() : 0;
+            int batchSize = idCount + filenameCount;
             if (batchSize > maxBatch) {
                 response.put("success", false);
                 response.put("error", Messages.get("errors.recordings_max_batch_with_count", maxBatch));
@@ -1509,8 +1511,8 @@ public class RecordingsApiHandler {
             JSONArray errors = new JSONArray();
             
             for (int i = 0; i < batchSize; i++) {
-                String recordingId = ids != null && ids.length() > 0 ? ids.getString(i) : null;
-                String filename = recordingId == null ? filenames.getString(i) : null;
+                String recordingId = i < idCount ? ids.getString(i) : null;
+                String filename = recordingId == null ? filenames.getString(i - idCount) : null;
                 
                 // Security: prevent path traversal
                 if ((recordingId != null && !validRecordingId(recordingId))

--- a/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java
@@ -79,12 +79,8 @@ public class RecordingsApiHandler {
      */
     public static void invalidateRecordingCache(String absMp4Path) {
         if (absMp4Path == null) return;
-        int slash = absMp4Path.lastIndexOf('/');
-        String filename = (slash >= 0 && slash + 1 < absMp4Path.length())
-                ? absMp4Path.substring(slash + 1)
-                : absMp4Path;
         try {
-            RecordingsIndex.getInstance().remove(filename);
+            RecordingsIndex.getInstance().removeByPath(absMp4Path);
         } catch (Throwable ignored) {}
     }
 
@@ -200,7 +196,32 @@ public class RecordingsApiHandler {
             return true;
         }
         
-        // Serve thumbnail
+        // Exact identity routes must be checked before legacy filename prefixes.
+        if (path.startsWith("/thumb/id/")) {
+            String recordingId = stripQuery(path.substring("/thumb/id/".length()));
+            serveThumbnailById(out, recordingId);
+            return true;
+        }
+
+        if (path.startsWith("/video/id/")) {
+            String recordingId = stripQuery(path.substring("/video/id/".length()));
+            streamVideoById(out, recordingId, null, null);
+            return true;
+        }
+
+        if (path.startsWith("/api/recordings/id/") && method.equals("DELETE")) {
+            String recordingId = stripQuery(path.substring("/api/recordings/id/".length()));
+            deleteRecordingById(out, recordingId);
+            return true;
+        }
+
+        if (path.startsWith("/api/events/id/") && method.equals("GET")) {
+            String recordingId = stripQuery(path.substring("/api/events/id/".length()));
+            serveEventTimelineById(out, recordingId);
+            return true;
+        }
+
+        // Serve legacy filename thumbnail
         if (path.startsWith("/thumb/")) {
             String filename = path.substring(7);
             // Strip any cache-busting/auth query (e.g. /thumb/foo.jpg?t=<token>);
@@ -267,12 +288,26 @@ public class RecordingsApiHandler {
     public static boolean handleWithRange(String method, String path, String body,
                                           String rangeHeader, String ifNoneMatchHeader,
                                           OutputStream out) throws Exception {
+        if (path.startsWith("/video/id/")) {
+            String recordingId = stripQuery(path.substring("/video/id/".length()));
+            streamVideoById(out, recordingId, rangeHeader, ifNoneMatchHeader);
+            return true;
+        }
         if (path.startsWith("/video/")) {
             String filename = path.substring(7);
             streamVideo(out, filename, rangeHeader, ifNoneMatchHeader);
             return true;
         }
         return handle(method, path, body, out);
+    }
+
+    private static String stripQuery(String value) {
+        int query = value.indexOf('?');
+        return query >= 0 ? value.substring(0, query) : value;
+    }
+
+    private static boolean validRecordingId(String recordingId) {
+        return recordingId != null && recordingId.matches("[0-9a-f]{32}");
     }
     
     // Background thumbnail generator
@@ -366,10 +401,64 @@ public class RecordingsApiHandler {
         }
         
         // Return 202 Accepted with retry hint - client should retry
-        String headers = "HTTP/1.1 202 Accepted\r\n" +
-                        "Content-Type: application/json\r\n" +
-                        "Retry-After: 1\r\n" +
-                        "Connection: close\r\n\r\n";
+        sendThumbnailGenerating(out);
+    }
+
+    private static void serveThumbnailById(OutputStream out, String recordingId) throws Exception {
+        if (!validRecordingId(recordingId)) {
+            HttpResponse.sendError(out, 400, Messages.get("errors.recordings_invalid_filename"));
+            return;
+        }
+        RecordingsIndex.RecordingRef ref =
+                RecordingsIndex.getInstance().resolveById(recordingId);
+        if (ref == null) {
+            HttpResponse.sendError(out, 404,
+                Messages.get("errors.recordings_thumbnail_not_found_with_filename", recordingId));
+            return;
+        }
+        File videoFile = ref.file();
+        if (!videoFile.isFile() || !videoFile.canRead()) {
+            HttpResponse.sendError(out, 410, Messages.get("errors.recordings_file_no_longer_accessible"));
+            return;
+        }
+        if (ref.heroThumbnail != null && !ref.heroThumbnail.isEmpty()) {
+            File hero = new File(videoFile.getParentFile(), ref.heroThumbnail);
+            if (hero.isFile() && hero.canRead() && hero.length() > 0) {
+                HttpResponse.sendImage(out, hero, "image/jpeg");
+                return;
+            }
+        }
+        File cacheDir = new File(getThumbnailCacheDir());
+        if (!cacheDir.exists()) cacheDir.mkdirs();
+        File thumbFile = new File(cacheDir, recordingId + ".jpg");
+        if (thumbFile.isFile() && thumbFile.length() > 0) {
+            HttpResponse.sendImage(out, thumbFile, "image/jpeg");
+            return;
+        }
+        if (pendingThumbs.add(recordingId)) {
+            thumbExecutor.submit(() -> {
+                try {
+                    byte[] data = generateThumbnail(videoFile);
+                    if (data != null) {
+                        try (FileOutputStream output = new FileOutputStream(thumbFile)) {
+                            output.write(data);
+                        }
+                    }
+                } catch (Exception failure) {
+                    CameraDaemon.log("ID thumbnail generation failed: " + failure.getMessage());
+                } finally {
+                    pendingThumbs.remove(recordingId);
+                }
+            });
+        }
+        sendThumbnailGenerating(out);
+    }
+
+    private static void sendThumbnailGenerating(OutputStream out) throws Exception {
+        String headers = "HTTP/1.1 202 Accepted\r\n"
+                + "Content-Type: application/json\r\n"
+                + "Retry-After: 1\r\n"
+                + "Connection: close\r\n\r\n";
         out.write(headers.getBytes());
         out.write("{\"status\":\"generating\"}".getBytes());
         out.flush();
@@ -1114,6 +1203,31 @@ public class RecordingsApiHandler {
             return;
         }
 
+        streamVideoFile(out, file, rangeHeader, ifNoneMatchHeader);
+    }
+
+    private static void streamVideoById(OutputStream out, String recordingId,
+                                        String rangeHeader, String ifNoneMatchHeader) throws Exception {
+        if (!validRecordingId(recordingId)) {
+            HttpResponse.sendError(out, 400, Messages.get("errors.recordings_invalid_filename"));
+            return;
+        }
+        RecordingsIndex.RecordingRef ref =
+                RecordingsIndex.getInstance().resolveById(recordingId);
+        if (ref == null) {
+            HttpResponse.sendError(out, 404, Messages.get("errors.recordings_not_found"));
+            return;
+        }
+        File file = ref.file();
+        if (!file.isFile() || !file.canRead()) {
+            HttpResponse.sendError(out, 410, Messages.get("errors.recordings_file_no_longer_accessible"));
+            return;
+        }
+        streamVideoFile(out, file, rangeHeader, ifNoneMatchHeader);
+    }
+
+    private static void streamVideoFile(OutputStream out, File file, String rangeHeader,
+                                        String ifNoneMatchHeader) throws Exception {
         // Conditional GET: if the client's cached copy matches our ETag,
         // skip re-streaming. Tag is "<length>-<mtime>" so any append/replace
         // invalidates without us needing a content hash.
@@ -1207,6 +1321,28 @@ public class RecordingsApiHandler {
         HttpResponse.sendJson(out, response.toString());
     }
 
+    private static void deleteRecordingById(OutputStream out, String recordingId) throws Exception {
+        if (!validRecordingId(recordingId)) {
+            HttpResponse.sendJsonError(out, Messages.get("errors.recordings_invalid_filename"));
+            return;
+        }
+        RecordingsIndex.RecordingRef ref =
+            RecordingsIndex.getInstance().resolveById(recordingId);
+        if (ref == null) {
+            HttpResponse.sendJsonError(out, Messages.get("errors.recordings_not_found"));
+            return;
+        }
+        File file = ref.file();
+        boolean deleted = file.delete();
+        if (deleted) {
+            deleteSidecars(file, ref.filename);
+        }
+        JSONObject response = new JSONObject();
+        response.put("success", deleted);
+        if (!deleted) response.put("error", Messages.get("errors.recordings_delete_failed"));
+        HttpResponse.sendJson(out, response.toString());
+    }
+
     /**
      * Sweep the .mp4's sidecar files: JSON event timeline, cached thumb,
      * v3 hero JPEG, per-actor thumbs ({@code thumb_<base>_a*.jpg}).
@@ -1241,17 +1377,6 @@ public class RecordingsApiHandler {
         // (path|type) compound key is matched correctly.
         invalidateRecordingCache(mp4File.getAbsolutePath());
 
-        // Drop the H2 row eagerly so a /api/recordings call immediately
-        // after delete can't return the just-deleted row. FileObserver
-        // would catch this too, but FUSE-mounted SD cards can drop the
-        // DELETE event.
-        try {
-            com.overdrive.app.server.RecordingsIndex.getInstance().remove(filename);
-        } catch (Throwable ignored) {
-            // RecordingsIndex may not be initialised yet; the
-            // FileObserver / reconcile path will catch up.
-        }
-
         // Sidecar stem: strip a TRAILING ".mp4" only.
         //
         // These three used filename.replace(".mp4", "<ext>"), which is wrong in two
@@ -1277,6 +1402,9 @@ public class RecordingsApiHandler {
         // Cached thumbnail
         File thumbFile = new File(getThumbnailCacheDir(), stem + ".jpg");
         if (thumbFile.exists()) thumbFile.delete();
+        File idThumbFile = new File(getThumbnailCacheDir(),
+            RecordingIdentity.fromPath(mp4File.getAbsolutePath()).recordingId + ".jpg");
+        if (idThumbFile.exists()) idThumbFile.delete();
 
         // v3 hero JPEG sibling: <base>.jpg next to the mp4.
         //
@@ -1355,9 +1483,11 @@ public class RecordingsApiHandler {
         
         try {
             JSONObject request = new JSONObject(body);
-            JSONArray filenames = request.optJSONArray("filenames");
+                JSONArray ids = request.optJSONArray("ids");
+                JSONArray filenames = request.optJSONArray("filenames");
             
-            if (filenames == null || filenames.length() == 0) {
+                if ((ids == null || ids.length() == 0)
+                    && (filenames == null || filenames.length() == 0)) {
                 response.put("success", false);
                 response.put("error", Messages.get("errors.recordings_no_filenames"));
                 HttpResponse.sendJson(out, response.toString());
@@ -1366,7 +1496,8 @@ public class RecordingsApiHandler {
             
             // Limit batch size to prevent abuse
             int maxBatch = 100;
-            if (filenames.length() > maxBatch) {
+            int batchSize = ids != null && ids.length() > 0 ? ids.length() : filenames.length();
+            if (batchSize > maxBatch) {
                 response.put("success", false);
                 response.put("error", Messages.get("errors.recordings_max_batch_with_count", maxBatch));
                 HttpResponse.sendJson(out, response.toString());
@@ -1377,30 +1508,37 @@ public class RecordingsApiHandler {
             int failed = 0;
             JSONArray errors = new JSONArray();
             
-            for (int i = 0; i < filenames.length(); i++) {
-                String filename = filenames.getString(i);
+            for (int i = 0; i < batchSize; i++) {
+                String recordingId = ids != null && ids.length() > 0 ? ids.getString(i) : null;
+                String filename = recordingId == null ? filenames.getString(i) : null;
                 
                 // Security: prevent path traversal
-                if (filename.contains("..") || filename.contains("/")) {
+                if ((recordingId != null && !validRecordingId(recordingId))
+                        || (filename != null && (filename.contains("..") || filename.contains("/")))) {
                     failed++;
-                    errors.put(filename + ": invalid filename");
+                    errors.put((recordingId != null ? recordingId : filename) + ": invalid identity");
                     continue;
                 }
                 
-                File file = findVideoFile(filename);
+                RecordingsIndex.RecordingRef ref = recordingId != null
+                        ? RecordingsIndex.getInstance().resolveById(recordingId) : null;
+                File file = recordingId != null
+                    ? (ref != null ? ref.file() : null)
+                    : findVideoFile(filename);
+                String resolvedFilename = ref != null ? ref.filename : filename;
                 if (file == null) {
                     failed++;
-                    errors.put(filename + ": not found");
+                    errors.put((recordingId != null ? recordingId : filename) + ": not found");
                     continue;
                 }
                 
                 boolean success = file.delete();
                 if (success) {
                     deleted++;
-                    deleteSidecars(file, filename);
+                    deleteSidecars(file, resolvedFilename);
                 } else {
                     failed++;
-                    errors.put(filename + ": delete failed");
+                    errors.put((recordingId != null ? recordingId : filename) + ": delete failed");
                 }
             }
             
@@ -1430,8 +1568,11 @@ public class RecordingsApiHandler {
             return;
         }
         
-        // Convert .mp4 filename to .json
-        String jsonFilename = filename.replace(".mp4", ".json");
+        // Replace only the trailing extension. Segmented/custom names may
+        // legitimately contain ".mp4" earlier in the stem.
+        String jsonFilename = filename.endsWith(".mp4")
+            ? filename.substring(0, filename.length() - ".mp4".length()) + ".json"
+            : filename + ".json";
         
         // Search for the JSON sidecar in all storage locations
         File jsonFile = findJsonSidecar(jsonFilename);
@@ -1455,6 +1596,40 @@ public class RecordingsApiHandler {
             // Backward compatible: no sidecar = empty events array
             sendEmptyTimeline(out);
         }
+    }
+
+    private static void serveEventTimelineById(OutputStream out, String recordingId) throws Exception {
+        if (!validRecordingId(recordingId)) {
+            HttpResponse.sendError(out, 400, Messages.get("errors.recordings_invalid_filename"));
+            return;
+        }
+        RecordingsIndex.RecordingRef ref =
+                RecordingsIndex.getInstance().resolveById(recordingId);
+        if (ref == null) {
+            HttpResponse.sendError(out, 404, Messages.get("errors.recordings_not_found"));
+            return;
+        }
+        String name = ref.filename;
+        String stem = name.endsWith(".mp4")
+                ? name.substring(0, name.length() - ".mp4".length()) : name;
+        File jsonFile = new File(ref.file().getParentFile(), stem + ".json");
+        serveTimelineFile(out, jsonFile);
+    }
+
+    private static void serveTimelineFile(OutputStream out, File jsonFile) throws Exception {
+        if (jsonFile != null && jsonFile.exists()) {
+            try (java.io.BufferedReader reader =
+                         new java.io.BufferedReader(new java.io.FileReader(jsonFile))) {
+                StringBuilder json = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) json.append(line);
+                HttpResponse.sendJson(out, json.toString());
+                return;
+            } catch (Exception ignored) {
+                // Fall through to the backward-compatible empty timeline.
+            }
+        }
+        sendEmptyTimeline(out);
     }
     
     /**

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -124,7 +124,7 @@ public final class RecordingsIndex {
     //            dedicated Replays tab instead of mixed with dashcam loops.
     //            Migration is a data UPDATE, not a column change — see
     //            createSchema().
-    private static final int SCHEMA_VERSION = 3;
+    private static final int SCHEMA_VERSION = RecordingsIndexSchema.VERSION;
 
     // Singleton — one index per daemon process.
     private static volatile RecordingsIndex INSTANCE;
@@ -225,9 +225,9 @@ public final class RecordingsIndex {
         return removalSeq;
     }
 
-    /** Record that {@code filename} was removed, and prune old entries. */
-    private void noteRemoval(String filename) {
-        removalTombstones.put(filename, ++removalSeq);
+    /** Record that {@code recordingId} was removed, and prune old entries. */
+    private void noteRemoval(String recordingId) {
+        removalTombstones.put(recordingId, ++removalSeq);
         if (removalTombstones.size() > TOMBSTONE_SOFT_CAP) {
             long cutoff = removalSeq - TOMBSTONE_KEEP;
             removalTombstones.entrySet().removeIf(e -> e.getValue() <= cutoff);
@@ -236,9 +236,9 @@ public final class RecordingsIndex {
 
     /** True when {@code filename} was removed after {@code seqSampled}, i.e. a
      *  delete landed while the caller was parsing and its Row is now stale. */
-    private boolean removedSince(String filename, long seqSampled) {
+    private boolean removedSince(String recordingId, long seqSampled) {
         if (seqSampled == NO_REMOVAL_GATE) return false;
-        Long removedAt = removalTombstones.get(filename);
+        Long removedAt = removalTombstones.get(recordingId);
         return removedAt != null && removedAt > seqSampled;
     }
 
@@ -727,101 +727,8 @@ public final class RecordingsIndex {
     }
 
     private void createSchema() throws Exception {
-        try (Statement stmt = connection.createStatement()) {
-            stmt.execute(
-                "CREATE TABLE IF NOT EXISTS recordings (" +
-                "  filename        VARCHAR(256) PRIMARY KEY," +
-                "  abs_path        VARCHAR(512) NOT NULL," +
-                "  type            VARCHAR(16) NOT NULL," +
-                "  camera_id       INT DEFAULT 0," +
-                "  ts_ms           BIGINT NOT NULL," +
-                "  size_bytes      BIGINT NOT NULL DEFAULT 0," +
-                "  mp4_mtime       BIGINT NOT NULL DEFAULT 0," +
-                "  sidecar_mtime   BIGINT NOT NULL DEFAULT 0," +
-                "  schema_version  INT DEFAULT 0," +
-                // Sidecar denorm — filterable columns
-                "  peak_severity   VARCHAR(16)," +
-                "  peak_proximity  VARCHAR(16)," +
-                "  person_count    INT DEFAULT 0," +
-                "  vehicle_count   INT DEFAULT 0," +
-                "  bike_count      INT DEFAULT 0," +
-                "  animal_count    INT DEFAULT 0," +
-                "  hero_thumb      VARCHAR(256)," +
-                "  actor_classes   VARCHAR(256)," +   // CSV lowercase
-                "  place_short     VARCHAR(128)," +
-                "  place_medium    VARCHAR(192)," +
-                "  place_display   VARCHAR(256)," +
-                "  place_country   VARCHAR(8)," +
-                "  place_source    VARCHAR(32)," +
-                "  start_lat       DOUBLE," +
-                "  start_lng       DOUBLE," +
-                // Date-bucket helpers, populated at insert time so the
-                // /api/recordings/dates and /api/recordings GROUP-BY
-                // queries can hit a covering index instead of recomputing
-                // the date string per row.
-                "  ymd             VARCHAR(10)," +    // "yyyy-MM-dd" local
-                // Physical volume the clip lives on: "INTERNAL" / "SD_CARD" /
-                // "USB", classified from abs_path at index time. NULL on rows
-                // written before v2 (the storage filter treats NULL via the
-                // path-derivation fallback in rowToJson). Appended LAST so the
-                // upsert MERGE's positional VALUES list stays append-only.
-                "  storage         VARCHAR(16)" +
-                ")"
-            );
-
-            // v1 → v2 migration for DBs created before the `storage` column
-            // existed. ADD COLUMN IF NOT EXISTS is a no-op on a fresh v2 table
-            // (the CREATE above already has it) and additive on an old v1 file,
-            // so this is safe to run unconditionally on every open. Existing
-            // rows get storage=NULL and are backfilled lazily by reconcile()/
-            // upsert as files are re-touched; rowToJson also derives the tag
-            // from the path when the column is NULL, so the UI never shows a
-            // blank badge for a legacy row.
-            stmt.execute("ALTER TABLE recordings ADD COLUMN IF NOT EXISTS storage VARCHAR(16)");
-
-            // v2 → v3 migration: retype existing replay_* rows from 'normal'
-            // to 'replay'. Idempotent (the predicate excludes already-migrated
-            // rows) and cheap at the ~1000-row scale, so it runs on every
-            // open like the ADD COLUMN above. ESCAPE pins the underscore as a
-            // literal — without it '_' is the single-char wildcard and a
-            // hypothetical 'replayX...' name would be swept in too.
-            stmt.execute("UPDATE recordings SET type = 'replay'"
-                    + " WHERE type <> 'replay'"
-                    + " AND filename LIKE 'replay\\_%' ESCAPE '\\'");
-            // Rows moved between type buckets — drop any queryStats() memo
-            // carried across a reopen (this runs on every open, including the
-            // mid-session reconnect path).
-            invalidateStatsCache();
-
-            // Indexes — covering most common access patterns.
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_ts ON recordings(ts_ms DESC)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_type_ts ON recordings(type, ts_ms DESC)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_ymd ON recordings(ymd)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_place ON recordings(place_short)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_country ON recordings(place_country)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_severity ON recordings(peak_severity)");
-            stmt.execute("CREATE INDEX IF NOT EXISTS idx_rec_storage ON recordings(storage)");
-
-            // Schema version table — for future migrations.
-            //
-            // Column is `meta_key`, not `key`. H2 2.2.x (build 224) promoted
-            // KEY to a reserved word — it's now part of MERGE's `KEY(...)`
-            // grammar — and rejects bare `key` as a column identifier with
-            // "expected identifier" at parse time. The whole index init
-            // bails on this CREATE, the ctor returns false, and the
-            // recordings API silently falls back to direct-FS scanning
-            // (no thumbnails, no place chips, no warming counters). Use a
-            // non-reserved name and a quoted constraint identifier to
-            // avoid the same trap with KEY in MERGE.
-            stmt.execute(
-                "CREATE TABLE IF NOT EXISTS recordings_meta (" +
-                "  meta_key VARCHAR(64) PRIMARY KEY," +
-                "  meta_value VARCHAR(256)" +
-                ")"
-            );
-            stmt.execute("MERGE INTO recordings_meta KEY(meta_key) VALUES('schema_version', '"
-                    + SCHEMA_VERSION + "')");
-        }
+        RecordingsIndexSchema.ensure(connection);
+        invalidateStatsCache();
     }
 
     // =================================================================
@@ -897,7 +804,7 @@ public final class RecordingsIndex {
         // A delete landed while the caller was parsing: the file is already gone
         // from disk, so MERGEing this Row would create a ghost row that 404s on
         // playback and inflates the storage card until the next reconcile.
-        if (removedSince(row.filename, seqSampled)) {
+        if (removedSince(row.recordingId, seqSampled)) {
             logger.debug("upsertRow: dropping stale row for removed " + row.filename);
             return false;
         }
@@ -908,35 +815,47 @@ public final class RecordingsIndex {
         final Row r = row;
         return withRetry("upsertRow(" + row.filename + ")", Boolean.FALSE, () -> {
             String sql =
-                "MERGE INTO recordings KEY(filename) VALUES (" +
-                "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                "MERGE INTO recordings (recording_id, filename, abs_path, root_id, volume_id,"
+                + " relative_path, root_rank, is_available, type, camera_id, ts_ms, size_bytes,"
+                + " mp4_mtime, sidecar_mtime, schema_version, peak_severity, peak_proximity,"
+                + " person_count, vehicle_count, bike_count, animal_count, hero_thumb,"
+                + " actor_classes, place_short, place_medium, place_display, place_country,"
+                + " place_source, start_lat, start_lng, ymd, storage) KEY(recording_id) VALUES ("
+                + "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,"
+                + " ?, ?, ?, ?, ?, ?, ?, ?)";
             try (PreparedStatement ps = connection.prepareStatement(sql)) {
-                ps.setString(1, r.filename);
-                ps.setString(2, r.absPath);
-                ps.setString(3, r.type);
-                ps.setInt(4, r.cameraId);
-                ps.setLong(5, r.tsMs);
-                ps.setLong(6, r.sizeBytes);
-                ps.setLong(7, r.mp4Mtime);
-                ps.setLong(8, r.sidecarMtime);
-                ps.setInt(9, r.schemaVersion);
-                setNullableString(ps, 10, r.peakSeverity);
-                setNullableString(ps, 11, r.peakProximity);
-                ps.setInt(12, r.personCount);
-                ps.setInt(13, r.vehicleCount);
-                ps.setInt(14, r.bikeCount);
-                ps.setInt(15, r.animalCount);
-                setNullableString(ps, 16, r.heroThumb);
-                setNullableString(ps, 17, r.actorClasses);
-                setNullableString(ps, 18, r.placeShort);
-                setNullableString(ps, 19, r.placeMedium);
-                setNullableString(ps, 20, r.placeDisplay);
-                setNullableString(ps, 21, r.placeCountry);
-                setNullableString(ps, 22, r.placeSource);
-                setNullableDouble(ps, 23, r.startLat);
-                setNullableDouble(ps, 24, r.startLng);
-                ps.setString(25, r.ymd);
-                setNullableString(ps, 26, r.storage);
+                ps.setString(1, r.recordingId);
+                ps.setString(2, r.filename);
+                ps.setString(3, r.absPath);
+                ps.setString(4, r.rootId);
+                ps.setString(5, r.volumeId);
+                ps.setString(6, r.relativePath);
+                ps.setInt(7, r.rootRank);
+                ps.setBoolean(8, true);
+                ps.setString(9, r.type);
+                ps.setInt(10, r.cameraId);
+                ps.setLong(11, r.tsMs);
+                ps.setLong(12, r.sizeBytes);
+                ps.setLong(13, r.mp4Mtime);
+                ps.setLong(14, r.sidecarMtime);
+                ps.setInt(15, r.schemaVersion);
+                setNullableString(ps, 16, r.peakSeverity);
+                setNullableString(ps, 17, r.peakProximity);
+                ps.setInt(18, r.personCount);
+                ps.setInt(19, r.vehicleCount);
+                ps.setInt(20, r.bikeCount);
+                ps.setInt(21, r.animalCount);
+                setNullableString(ps, 22, r.heroThumb);
+                setNullableString(ps, 23, r.actorClasses);
+                setNullableString(ps, 24, r.placeShort);
+                setNullableString(ps, 25, r.placeMedium);
+                setNullableString(ps, 26, r.placeDisplay);
+                setNullableString(ps, 27, r.placeCountry);
+                setNullableString(ps, 28, r.placeSource);
+                setNullableDouble(ps, 29, r.startLat);
+                setNullableDouble(ps, 30, r.startLng);
+                ps.setString(31, r.ymd);
+                setNullableString(ps, 32, r.storage);
                 ps.executeUpdate();
                 invalidateStatsCache();   // row counts/bytes changed
                 return Boolean.TRUE;
@@ -1020,20 +939,33 @@ public final class RecordingsIndex {
      */
     public synchronized boolean remove(String filename) {
         if (filename == null || filename.isEmpty()) return false;
-        // Tombstone FIRST, and unconditionally — before the DELETE and
-        // regardless of how many rows it affects. An upsert() that is mid-parse
-        // for this file hasn't MERGEd yet, so the DELETE below will report 0
-        // rows; recording the removal is what stops that in-flight upsert from
-        // resurrecting the row once it wakes. See the tombstone block above.
-        noteRemoval(filename);
-        // Same reconnect+retry rationale as upsertRow: a dropped DELETE
-        // leaves a ghost row pointing at a file the cleaner already removed,
-        // and playback then 404s.
         final String name = filename;
-        return withRetry("remove(" + filename + ")", Boolean.FALSE, () -> {
+        String recordingId = withRetry("resolve legacy remove(" + filename + ")", null, () -> {
             try (PreparedStatement ps = connection.prepareStatement(
-                    "DELETE FROM recordings WHERE filename = ?")) {
+                    "SELECT recording_id FROM recordings WHERE filename = ?"
+                            + " ORDER BY is_available DESC, root_rank ASC, ts_ms DESC LIMIT 1")) {
                 ps.setString(1, name);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? rs.getString(1) : null;
+                }
+            }
+        });
+        return recordingId != null && removeById(recordingId);
+    }
+
+    public boolean removeByPath(String absolutePath) {
+        if (absolutePath == null || absolutePath.isEmpty()) return false;
+        return removeById(RecordingIdentity.fromPath(absolutePath).recordingId);
+    }
+
+    public synchronized boolean removeById(String recordingId) {
+        if (recordingId == null || recordingId.isEmpty()) return false;
+        noteRemoval(recordingId);
+        final String id = recordingId;
+        return withRetry("removeById(" + recordingId + ")", Boolean.FALSE, () -> {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "DELETE FROM recordings WHERE recording_id = ?")) {
+                ps.setString(1, id);
                 boolean deleted = ps.executeUpdate() > 0;
                 if (deleted) invalidateStatsCache();
                 return deleted;
@@ -1053,6 +985,20 @@ public final class RecordingsIndex {
             try (PreparedStatement ps = connection.prepareStatement(
                     "SELECT 1 FROM recordings WHERE filename = ? LIMIT 1")) {
                 ps.setString(1, name);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next();
+                }
+            }
+        });
+    }
+
+    public synchronized boolean containsPath(String absolutePath) {
+        if (absolutePath == null) return false;
+        final String id = RecordingIdentity.fromPath(absolutePath).recordingId;
+        return withRetry("containsPath", Boolean.FALSE, () -> {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT 1 FROM recordings WHERE recording_id = ? LIMIT 1")) {
+                ps.setString(1, id);
                 try (ResultSet rs = ps.executeQuery()) {
                     return rs.next();
                 }
@@ -1149,7 +1095,7 @@ public final class RecordingsIndex {
     private synchronized int countIndexedRows() {
         return withRetry("countIndexedRows", -1, () -> {
             try (PreparedStatement ps = connection.prepareStatement(
-                    "SELECT COUNT(*) FROM recordings");
+                    "SELECT COUNT(*) FROM recordings WHERE is_available = TRUE");
                  ResultSet rs = ps.executeQuery()) {
                 return rs.next() ? rs.getInt(1) : 0;
             }
@@ -1220,11 +1166,12 @@ public final class RecordingsIndex {
         addDirFiles(entries, sm.getAllSurveillanceDirs(), null);
         addDirFiles(entries, sm.getAllProximityDirs(), null);
 
-        // Dedup by filename (mirror dirs hold the same .mp4).
+        // Dedup by row identity. Equal filenames on different volumes remain
+        // distinct; repeated references to the same root/path collapse.
         Set<String> seen = new HashSet<>(entries.size() * 2);
         List<File> unique = new ArrayList<>(entries.size());
         for (DirEntry e : entries) {
-            if (seen.add(e.file.getName())) unique.add(e.file);
+            if (seen.add(RecordingIdentity.fromFile(e.file).recordingId)) unique.add(e.file);
         }
 
         warmupTotal.set(unique.size());
@@ -1398,10 +1345,13 @@ public final class RecordingsIndex {
         long t0 = System.currentTimeMillis();
         StorageManager sm = StorageManager.getInstance();
 
-          Map<String, RecordingFileFingerprint> diskFiles = new LinkedHashMap<>();
-          scanDirFiles(diskFiles, sm.getAllRecordingsDirs());
-          scanDirFiles(diskFiles, sm.getAllSurveillanceDirs());
-          scanDirFiles(diskFiles, sm.getAllProximityDirs());
+        List<RootScan> rootScans = scanRoots(sm);
+        Map<String, RecordingFileFingerprint> diskFiles = new LinkedHashMap<>();
+        for (RootScan root : rootScans) {
+            for (RecordingFileFingerprint fingerprint : root.files.values()) {
+                diskFiles.putIfAbsent(fingerprint.recordingId, fingerprint);
+            }
+        }
 
           // Three-phase walk: index snapshot → drop missing → upsert new/changed.
         // The SELECT enumerate is synchronized so the snapshot is
@@ -1424,12 +1374,15 @@ public final class RecordingsIndex {
             indexFiles = withRetry("reconcile: index enumerate", null, () -> {
                 Map<String, IndexedFileState> rows = new HashMap<>();
                 try (PreparedStatement ps = connection.prepareStatement(
-                        "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"
+                        "SELECT recording_id, filename, root_id, abs_path, size_bytes,"
+                            + " mp4_mtime, sidecar_mtime, is_available"
                                 + " FROM recordings");
                      ResultSet rs = ps.executeQuery()) {
                     while (rs.next()) {
                         rows.put(rs.getString(1), new IndexedFileState(
-                                rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getLong(5)));
+                            rs.getString(2), rs.getString(3), rs.getString(4),
+                            rs.getLong(5), rs.getLong(6), rs.getLong(7),
+                            rs.getBoolean(8)));
                     }
                 }
                 return rows;
@@ -1443,12 +1396,19 @@ public final class RecordingsIndex {
             return;
         }
 
-        // Phase 2: drop rows whose file is gone. remove() takes the
-        // monitor per call; that's fine — we want short critical sections
-        // here so query threads can interleave.
-        for (String name : indexFiles.keySet()) {
-            if (!diskFiles.containsKey(name)) {
-                if (remove(name)) removed++;
+        applyRootAvailability(rootScans);
+
+        Map<String, RootScan> scansByRoot = new HashMap<>();
+        for (RootScan scan : rootScans) scansByRoot.put(scan.rootId, scan);
+
+        // Phase 2: delete only after a complete scan of an available root.
+        // Missing/offline and partial roots preserve their rows.
+        for (Map.Entry<String, IndexedFileState> indexedEntry : indexFiles.entrySet()) {
+            RootScan root = scansByRoot.get(indexedEntry.getValue().rootId);
+                if (root != null && RecordingReconcilePolicy.shouldDeleteMissingRow(
+                    root.available, root.complete,
+                    root.files.containsKey(indexedEntry.getKey()))) {
+                if (removeById(indexedEntry.getKey())) removed++;
             }
         }
 
@@ -1482,31 +1442,90 @@ public final class RecordingsIndex {
     }
 
     private static final class IndexedFileState {
+        final String filename;
+        final String rootId;
         final String absolutePath;
         final long sizeBytes;
         final long mp4Mtime;
         final long sidecarMtime;
 
-        IndexedFileState(String absolutePath, long sizeBytes,
-                         long mp4Mtime, long sidecarMtime) {
+        final boolean available;
+
+        IndexedFileState(String filename, String rootId, String absolutePath,
+                         long sizeBytes, long mp4Mtime, long sidecarMtime,
+                         boolean available) {
+            this.filename = filename;
+            this.rootId = rootId;
             this.absolutePath = absolutePath;
             this.sizeBytes = sizeBytes;
             this.mp4Mtime = mp4Mtime;
             this.sidecarMtime = sidecarMtime;
+            this.available = available;
         }
     }
 
-    private void scanDirFiles(Map<String, RecordingFileFingerprint> out, List<File> dirs) {
-        StorageManager sm = StorageManager.getInstance();
-        for (File dir : dirs) {
-            if (dir == null) continue;
-            File[] files = sm.listMp4Files(dir);
-            for (File file : files) {
-                if (!file.isFile() || out.containsKey(file.getName())) continue;
-                RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(file);
-                if (fingerprint.sizeBytes > 0) out.put(file.getName(), fingerprint);
+    private static final class RootScan {
+        final String rootId;
+        final int rank;
+        final boolean available;
+        final boolean complete;
+        final Map<String, RecordingFileFingerprint> files = new LinkedHashMap<>();
+
+        RootScan(String rootId, int rank, boolean available, boolean complete) {
+            this.rootId = rootId;
+            this.rank = rank;
+            this.available = available;
+            this.complete = complete;
+        }
+    }
+
+    private List<RootScan> scanRoots(StorageManager sm) {
+        List<File> roots = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (List<File> category : java.util.Arrays.asList(
+                sm.getAllRecordingsDirs(), sm.getAllSurveillanceDirs(), sm.getAllProximityDirs())) {
+            for (File root : category) {
+                if (root != null && seen.add(root.getAbsolutePath())) roots.add(root);
             }
         }
+
+        List<RootScan> scans = new ArrayList<>(roots.size());
+        for (int rank = 0; rank < roots.size(); rank++) {
+            File root = roots.get(rank);
+            StorageManager.Mp4Listing listing = sm.listMp4FilesWithStatus(root);
+            RootScan scan = new RootScan(
+                    RecordingIdentity.rootIdFor(root), rank, listing.available, listing.complete);
+            for (File file : listing.files) {
+                if (!file.isFile()) continue;
+                RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(file);
+                if (fingerprint.sizeBytes > 0) {
+                    scan.files.put(fingerprint.recordingId, fingerprint);
+                }
+            }
+            scans.add(scan);
+        }
+        return scans;
+    }
+
+    private synchronized void applyRootAvailability(List<RootScan> scans) {
+        withRetry("reconcile: root availability", Boolean.FALSE, () -> {
+            try (PreparedStatement offline = connection.prepareStatement(
+                    "UPDATE recordings SET is_available = FALSE")) {
+                offline.executeUpdate();
+            }
+            try (PreparedStatement online = connection.prepareStatement(
+                    "UPDATE recordings SET is_available = TRUE, root_rank = ? WHERE root_id = ?")) {
+                for (RootScan scan : scans) {
+                    if (!scan.available) continue;
+                    online.setInt(1, scan.rank);
+                    online.setString(2, scan.rootId);
+                    online.addBatch();
+                }
+                online.executeBatch();
+            }
+            invalidateStatsCache();
+            return Boolean.TRUE;
+        });
     }
 
     private void scanDirNames(Set<String> out, List<File> dirs) {
@@ -1517,7 +1536,9 @@ public final class RecordingsIndex {
             // shell ls when listFiles() returns null on SD-card mounts.
             File[] files = sm.listMp4Files(dir);
             for (File f : files) {
-                if (f.isFile() && f.length() > 0) out.add(f.getName());
+                if (f.isFile() && f.length() > 0) {
+                    out.add(RecordingIdentity.fromFile(f).recordingId);
+                }
             }
         }
     }
@@ -1600,7 +1621,7 @@ public final class RecordingsIndex {
 
         String sql = "SELECT * FROM recordings"
                 + (where.length() > 0 ? " WHERE " + where : "")
-                + " ORDER BY ts_ms DESC"
+            + " ORDER BY ts_ms DESC, root_rank ASC"
                 + " LIMIT ? OFFSET ?";
 
         // The result list is built INSIDE the body so a reconnect-retry
@@ -1689,7 +1710,7 @@ public final class RecordingsIndex {
         String sql =
             "SELECT ymd, COUNT(*) AS c, "
             + " MAX(CASE WHEN type = 'sentry' THEN 1 ELSE 0 END) AS hasSentry"
-            + " FROM recordings WHERE ymd IS NOT NULL GROUP BY ymd";
+            + " FROM recordings WHERE is_available = TRUE AND ymd IS NOT NULL GROUP BY ymd";
         return withRetry("queryDates", new ArrayList<DateBucket>(), () -> {
             List<DateBucket> out = new ArrayList<>();
             try (PreparedStatement ps = connection.prepareStatement(sql);
@@ -1723,7 +1744,7 @@ public final class RecordingsIndex {
             + "  COUNT(*) AS c,"
             + "  COALESCE(SUM(size_bytes), 0) AS bytes,"
             + "  SUM(CASE WHEN ts_ms >= ? THEN 1 ELSE 0 END) AS todayC"
-            + " FROM recordings GROUP BY type";
+            + " FROM recordings WHERE is_available = TRUE GROUP BY type";
         // Stats is accumulated with += for the normal/oemDashcam fold, so a
         // fresh instance MUST be allocated inside the body — reusing one
         // across a reconnect-retry would double-count the dashcam bucket.
@@ -1772,6 +1793,7 @@ public final class RecordingsIndex {
     // =================================================================
 
     private static void buildWhere(Filter f, StringBuilder where, List<Object> args) {
+        appendAnd(where, "is_available = TRUE");
         if (f == null) return;
         if (f.types != null && !f.types.isEmpty()) {
             // Multi-type path: literal IN(...) — caller is explicit about
@@ -1940,6 +1962,12 @@ public final class RecordingsIndex {
     private static Row parse(File mp4) {
         String name = mp4.getName();
         Row r = new Row();
+        RecordingIdentity identity = RecordingIdentity.fromFile(mp4);
+        r.recordingId = identity.recordingId;
+        r.rootId = identity.rootId;
+        r.volumeId = identity.volumeId;
+        r.relativePath = identity.relativePath;
+        r.rootRank = 100;
         r.filename = name;
         r.absPath = mp4.getAbsolutePath();
         r.sizeBytes = mp4.length();
@@ -1950,8 +1978,10 @@ public final class RecordingsIndex {
         // failure leaves storage NULL and rowToJson falls back to deriving the
         // tag from the path at read time, so the row is never dropped.
         try {
-            r.storage = com.overdrive.app.storage.StorageManager
-                    .getInstance().classifyStorageForPath(r.absPath);
+            com.overdrive.app.storage.StorageManager storageManager =
+                    com.overdrive.app.storage.StorageManager.getInstance();
+            r.storage = storageManager.classifyStorageForPath(r.absPath);
+            r.rootRank = storageManager.getRecordingRootRank(mp4);
         } catch (Throwable ignored) {
             r.storage = null;
         }
@@ -2134,11 +2164,15 @@ public final class RecordingsIndex {
      */
     private static JSONObject rowToJson(ResultSet rs) throws Exception {
         JSONObject rec = new JSONObject();
+        rec.put("id", rs.getString("recording_id"));
         String name = rs.getString("filename");
         long ts = rs.getLong("ts_ms");
         rec.put("filename", name);
         String absPath = rs.getString("abs_path");
         rec.put("path", absPath);
+        rec.put("available", rs.getBoolean("is_available"));
+        rec.put("volumeId", rs.getString("volume_id"));
+        rec.put("rootId", rs.getString("root_id"));
         // Per-clip storage tag (INTERNAL / SD_CARD / USB). Makes the silent
         // SD→internal fallback (SD bridged behind USB power) visible at the
         // file level, and backs the storage filter. Prefer the indexed column
@@ -2288,6 +2322,11 @@ public final class RecordingsIndex {
 
     /** Internal row representation — pre-DB and post-DB share the shape. */
     private static final class Row {
+        String recordingId;
+        String rootId;
+        String volumeId;
+        String relativePath;
+        int rootRank;
         String filename;
         String absPath;
         String type;

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -16,9 +16,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -841,10 +844,8 @@ public final class RecordingsIndex {
      * per unindexed file, so a K-file drift chopped the monitor into K windows
      * of ~30ms and every concurrent queryStats/queryRecordings/queryDates
      * request queued behind them. That defeated the explicit intent documented
-     * in reconcile() ("we deliberately do NOT hold the lock across the
-     * locateFile() stat() calls ... they can each block 100-500ms, serializing
-     * every concurrent queryRecordings/queryCount/queryStats request"), which
-     * kept locateFile() out of the lock but then re-entered it here.
+    * in reconcile(): filesystem fingerprinting stays outside the monitor so
+    * FUSE metadata stalls cannot serialize every query behind a parse.
      *
      * <p>Only the short MERGE ({@link #upsertRow}) is synchronized — the same
      * split the warmup pipeline already uses (4 unsynchronized parser threads
@@ -1386,60 +1387,58 @@ public final class RecordingsIndex {
     }
 
     /**
-     * Reconcile the index against the filesystem. Walks every dir,
-     * upserts unknown files, removes index rows whose mp4 is gone.
+      * Reconcile the index against the filesystem. Walks every dir,
+      * upserts new or changed files, removes index rows whose mp4 is gone.
      * Backstop for FileObserver event drops on FUSE-mounted SD cards.
-     * Cheap when the index is in sync — every existing row is one
-     * stat() call.
+      * Cheap when the index is in sync — existing rows compare filesystem
+      * fingerprints without parsing sidecar JSON.
      */
     public void reconcile() {
         if (!isAvailable()) return;
         long t0 = System.currentTimeMillis();
         StorageManager sm = StorageManager.getInstance();
 
-        Set<String> diskNames = new HashSet<>();
-        scanDirNames(diskNames, sm.getAllRecordingsDirs());
-        scanDirNames(diskNames, sm.getAllSurveillanceDirs());
-        scanDirNames(diskNames, sm.getAllProximityDirs());
+          Map<String, RecordingFileFingerprint> diskFiles = new LinkedHashMap<>();
+          scanDirFiles(diskFiles, sm.getAllRecordingsDirs());
+          scanDirFiles(diskFiles, sm.getAllSurveillanceDirs());
+          scanDirFiles(diskFiles, sm.getAllProximityDirs());
 
-        // Three-phase walk: index enumerate → drop missing → upsert new.
+          // Three-phase walk: index snapshot → drop missing → upsert new/changed.
         // The SELECT enumerate is synchronized so the snapshot is
         // consistent. The per-row remove()/upsert() calls re-acquire the
-        // monitor themselves; we deliberately do NOT hold the lock across
-        // the locateFile() stat() calls because on FUSE-mounted SD cards
-        // they can each block 100-500ms, serializing every concurrent
+          // monitor themselves; filesystem fingerprinting stays outside that
+          // monitor because FUSE metadata calls can block, serializing every concurrent
         // queryRecordings/queryCount/queryStats request behind reconcile.
         // Accept temporary inconsistency — a file deleted between the
         // collect and verify phases will be cleaned up on the next
         // periodic reconcile (the operation is idempotent).
         int removed = 0;
         int added = 0;
-        // Files seen by scanDirNames() (exists, readable, size>0) but not
-        // findable by locateFile() — usually means a mount path drift or a
-        // symlinked dir that scanDirNames() followed but locateFile()'s
-        // canonical dir list does not. Surfaced in the summary so operators
-        // can spot data-loss-shaped gaps instead of silent skips.
-        int unlocatable = 0;
+        int refreshed = 0;
 
         // Phase 1: snapshot the index under the monitor.
-        Set<String> indexNames;
+        Map<String, IndexedFileState> indexFiles;
         synchronized (this) {
             // Built inside the body so a reconnect-retry re-enumerates into a
-            // fresh set rather than merging two partial snapshots.
-            indexNames = withRetry("reconcile: index enumerate", null, () -> {
-                Set<String> names = new HashSet<>();
+            // fresh map rather than merging two partial snapshots.
+            indexFiles = withRetry("reconcile: index enumerate", null, () -> {
+                Map<String, IndexedFileState> rows = new HashMap<>();
                 try (PreparedStatement ps = connection.prepareStatement(
-                        "SELECT filename FROM recordings");
+                        "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"
+                                + " FROM recordings");
                      ResultSet rs = ps.executeQuery()) {
-                    while (rs.next()) names.add(rs.getString(1));
+                    while (rs.next()) {
+                        rows.put(rs.getString(1), new IndexedFileState(
+                                rs.getString(2), rs.getLong(3), rs.getLong(4), rs.getLong(5)));
+                    }
                 }
-                return names;
+                return rows;
             });
         }
         // null (not empty) distinguishes "enumerate failed" from "index is
         // legitimately empty". Bailing on failure is important: an empty
         // snapshot would make Phase 2 believe every indexed row is missing.
-        if (indexNames == null) {
+        if (indexFiles == null) {
             logger.warn("reconcile: index enumerate unavailable — skipping this pass");
             return;
         }
@@ -1447,31 +1446,66 @@ public final class RecordingsIndex {
         // Phase 2: drop rows whose file is gone. remove() takes the
         // monitor per call; that's fine — we want short critical sections
         // here so query threads can interleave.
-        for (String name : indexNames) {
-            if (!diskNames.contains(name)) {
+        for (String name : indexFiles.keySet()) {
+            if (!diskFiles.containsKey(name)) {
                 if (remove(name)) removed++;
             }
         }
 
-        // Phase 3: upsert anything not already known. locateFile() is
-        // intentionally OUTSIDE any synchronized block — its stat() calls
-        // can stall on FUSE mounts and would otherwise serialize queries.
-        for (String name : diskNames) {
-            if (!indexNames.contains(name)) {
-                File f = locateFile(name, sm);
-                if (f != null) {
-                    if (upsert(f)) added++;
-                } else {
-                    unlocatable++;
-                    logger.warn("reconcile: file seen on disk but not locatable: " + name);
-                }
+        // Phase 3: parse only new or fingerprint-changed files. Active-first
+        // map insertion also repairs abs_path when the same filename moved
+        // between roots or volumes.
+        for (Map.Entry<String, RecordingFileFingerprint> entry : diskFiles.entrySet()) {
+            RecordingFileFingerprint fingerprint = entry.getValue();
+            IndexedFileState indexed = indexFiles.get(entry.getKey());
+            RecordingFileFingerprint.Decision decision = fingerprint.decisionAgainst(
+                    indexed != null ? indexed.absolutePath : null,
+                    indexed != null ? indexed.sizeBytes : 0L,
+                    indexed != null ? indexed.mp4Mtime : 0L,
+                    indexed != null ? indexed.sidecarMtime : 0L);
+            switch (decision) {
+                case ADD:
+                    if (upsert(fingerprint.file)) added++;
+                    break;
+                case REFRESH:
+                    if (upsert(fingerprint.file)) refreshed++;
+                    break;
+                case UNCHANGED:
+                    break;
             }
         }
         long ms = System.currentTimeMillis() - t0;
-        if (added > 0 || removed > 0 || unlocatable > 0) {
-            logger.info("Reconcile: +" + added + " / -" + removed
-                    + (unlocatable > 0 ? " / unlocatable=" + unlocatable : "")
+        if (added > 0 || refreshed > 0 || removed > 0) {
+            logger.info("Reconcile: +" + added + " / ~" + refreshed + " / -" + removed
                     + " in " + ms + "ms");
+        }
+    }
+
+    private static final class IndexedFileState {
+        final String absolutePath;
+        final long sizeBytes;
+        final long mp4Mtime;
+        final long sidecarMtime;
+
+        IndexedFileState(String absolutePath, long sizeBytes,
+                         long mp4Mtime, long sidecarMtime) {
+            this.absolutePath = absolutePath;
+            this.sizeBytes = sizeBytes;
+            this.mp4Mtime = mp4Mtime;
+            this.sidecarMtime = sidecarMtime;
+        }
+    }
+
+    private void scanDirFiles(Map<String, RecordingFileFingerprint> out, List<File> dirs) {
+        StorageManager sm = StorageManager.getInstance();
+        for (File dir : dirs) {
+            if (dir == null) continue;
+            File[] files = sm.listMp4Files(dir);
+            for (File file : files) {
+                if (!file.isFile() || out.containsKey(file.getName())) continue;
+                RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(file);
+                if (fingerprint.sizeBytes > 0) out.put(file.getName(), fingerprint);
+            }
         }
     }
 
@@ -1486,22 +1520,6 @@ public final class RecordingsIndex {
                 if (f.isFile() && f.length() > 0) out.add(f.getName());
             }
         }
-    }
-
-    private File locateFile(String name, StorageManager sm) {
-        for (File dir : sm.getAllRecordingsDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        for (File dir : sm.getAllSurveillanceDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        for (File dir : sm.getAllProximityDirs()) {
-            File f = new File(dir, name);
-            if (f.exists() && f.canRead() && f.length() > 0) return f;
-        }
-        return null;
     }
 
     // =================================================================
@@ -1986,7 +2004,7 @@ public final class RecordingsIndex {
         // Sidecar enrichment — same logic as
         // RecordingsApiHandler.parseRecordingUncached, kept close to
         // identical so existing callers don't notice the swap.
-        File sidecar = new File(mp4.getParentFile(), name.replace(".mp4", ".json"));
+        File sidecar = RecordingFileFingerprint.sidecarFor(mp4);
         if (sidecar.exists() && sidecar.canRead()) {
             r.sidecarMtime = sidecar.lastModified();
             try {

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -1006,6 +1006,63 @@ public final class RecordingsIndex {
         });
     }
 
+    public static final class RecordingRef {
+        public final String id;
+        public final String filename;
+        public final String absolutePath;
+        public final String heroThumbnail;
+
+        RecordingRef(String id, String filename, String absolutePath, String heroThumbnail) {
+            this.id = id;
+            this.filename = filename;
+            this.absolutePath = absolutePath;
+            this.heroThumbnail = heroThumbnail;
+        }
+
+        public File file() {
+            return new File(absolutePath);
+        }
+    }
+
+    public synchronized RecordingRef resolveById(String recordingId) {
+        if (recordingId == null || recordingId.isEmpty()) return null;
+        final String id = recordingId;
+        return withRetry("resolveById", null, () -> {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT recording_id, filename, abs_path, hero_thumb FROM recordings"
+                            + " WHERE recording_id = ? AND is_available = TRUE LIMIT 1")) {
+                ps.setString(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? recordingRef(rs) : null;
+                }
+            }
+        });
+    }
+
+    public synchronized RecordingRef resolveByFilename(String filename) {
+        if (filename == null || filename.isEmpty()) return null;
+        final String name = filename;
+        return withRetry("resolveByFilename", null, () -> {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT recording_id, filename, abs_path, hero_thumb FROM recordings"
+                            + " WHERE filename = ? AND is_available = TRUE"
+                            + " ORDER BY root_rank ASC, ts_ms DESC LIMIT 1")) {
+                ps.setString(1, name);
+                try (ResultSet rs = ps.executeQuery()) {
+                    return rs.next() ? recordingRef(rs) : null;
+                }
+            }
+        });
+    }
+
+    private static RecordingRef recordingRef(ResultSet rs) throws Exception {
+        return new RecordingRef(
+                rs.getString("recording_id"),
+                rs.getString("filename"),
+                rs.getString("abs_path"),
+                rs.getString("hero_thumb"));
+    }
+
     // =================================================================
     // Warmup
     // =================================================================
@@ -2204,8 +2261,13 @@ public final class RecordingsIndex {
         rec.put("dateFormatted", FMT_DATE_DISPLAY.get().format(d));
         rec.put("timeFormatted", FMT_TIME_DISPLAY.get().format(d));
 
-        rec.put("videoUrl", "/video/" + name);
-        rec.put("thumbnailUrl", "/thumb/" + name);
+        String recordingId = rs.getString("recording_id");
+        rec.put("videoUrl", "/video/id/" + recordingId);
+        rec.put("thumbnailUrl", "/thumb/id/" + recordingId);
+        rec.put("deleteUrl", "/api/recordings/id/" + recordingId);
+        rec.put("eventUrl", "/api/events/id/" + recordingId);
+        rec.put("legacyVideoUrl", "/video/" + name);
+        rec.put("legacyThumbnailUrl", "/thumb/" + name);
 
         int sv = rs.getInt("schema_version");
         if (sv > 0) rec.put("schemaVersion", sv);
@@ -2225,7 +2287,7 @@ public final class RecordingsIndex {
         if (animal > 0) rec.put("animalCount", animal);
 
         String hero = rs.getString("hero_thumb");
-        if (hero != null) rec.put("heroThumbnailUrl", "/thumb/" + hero);
+        if (hero != null) rec.put("heroThumbnailUrl", "/thumb/id/" + recordingId);
 
         String classes = rs.getString("actor_classes");
         if (classes != null && !classes.isEmpty()) {

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -1218,19 +1218,6 @@ public final class RecordingsIndex {
         addDirFiles(entries, sm.getAllRecordingsDirs(), null);
         addDirFiles(entries, sm.getAllSurveillanceDirs(), null);
         addDirFiles(entries, sm.getAllProximityDirs(), null);
-        // Legacy paths — keep mirrored with RecordingsApiHandler.
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/recordings")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/sentry_events")),
-                null);
-        addDirFiles(entries,
-                List.of(new File("/storage/emulated/0/Android/data/com.overdrive.app/files/proximity_events")),
-                null);
 
         // Dedup by filename (mirror dirs hold the same .mp4).
         Set<String> seen = new HashSet<>(entries.size() * 2);

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndex.java
@@ -2287,7 +2287,10 @@ public final class RecordingsIndex {
         if (animal > 0) rec.put("animalCount", animal);
 
         String hero = rs.getString("hero_thumb");
-        if (hero != null) rec.put("heroThumbnailUrl", "/thumb/id/" + recordingId);
+        if (hero != null) {
+            rec.put("heroThumbnailName", hero);
+            rec.put("heroThumbnailUrl", "/thumb/id/" + recordingId);
+        }
 
         String classes = rs.getString("actor_classes");
         if (classes != null && !classes.isEmpty()) {

--- a/app/src/main/java/com/overdrive/app/server/RecordingsIndexSchema.java
+++ b/app/src/main/java/com/overdrive/app/server/RecordingsIndexSchema.java
@@ -1,0 +1,208 @@
+package com.overdrive.app.server;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+final class RecordingsIndexSchema {
+    static final int VERSION = 4;
+
+    private static final String[] LEGACY_COLUMNS = {
+        "filename", "abs_path", "type", "camera_id", "ts_ms", "size_bytes",
+        "mp4_mtime", "sidecar_mtime", "schema_version", "peak_severity",
+        "peak_proximity", "person_count", "vehicle_count", "bike_count",
+        "animal_count", "hero_thumb", "actor_classes", "place_short",
+        "place_medium", "place_display", "place_country", "place_source",
+        "start_lat", "start_lng", "ymd", "storage"
+    };
+
+    private RecordingsIndexSchema() {}
+
+    static void ensure(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            createMetaTable(statement);
+        }
+        if (!tableExists(connection, "RECORDINGS")) {
+            try (Statement statement = connection.createStatement()) {
+                createV4Table(statement);
+            }
+        } else if (!columnExists(connection, "RECORDINGS", "RECORDING_ID")) {
+            migrateV3(connection);
+        }
+        try (Statement statement = connection.createStatement()) {
+            createIndexes(statement);
+            statement.execute("UPDATE recordings SET type = 'replay'"
+                    + " WHERE type <> 'replay'"
+                    + " AND filename LIKE 'replay\\_%' ESCAPE '\\'");
+            statement.execute("MERGE INTO recordings_meta KEY(meta_key) VALUES"
+                    + "('schema_version', '" + VERSION + "')");
+        }
+    }
+
+    private static void migrateV3(Connection connection) throws Exception {
+        List<Map<String, Object>> legacyRows = readLegacyRows(connection);
+        boolean autoCommit = connection.getAutoCommit();
+        connection.setAutoCommit(false);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS recordings_v3_backup");
+            statement.execute("ALTER TABLE recordings RENAME TO recordings_v3_backup");
+            createV4Table(statement);
+            copyLegacyRows(connection, legacyRows);
+            statement.execute("DROP TABLE recordings_v3_backup");
+            connection.commit();
+        } catch (Exception migrationFailure) {
+            try { connection.rollback(); } catch (Exception ignored) {}
+            // The index is derived. Prefer a clean, warmup-rebuildable v4 table
+            // over a daemon lifetime with an unusable half-migrated store.
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS recordings");
+                statement.execute("DROP TABLE IF EXISTS recordings_v3_backup");
+                createV4Table(statement);
+                connection.commit();
+            }
+        } finally {
+            connection.setAutoCommit(autoCommit);
+        }
+    }
+
+    private static List<Map<String, Object>> readLegacyRows(Connection connection)
+            throws Exception {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("SELECT * FROM recordings")) {
+            ResultSetMetaData meta = result.getMetaData();
+            while (result.next()) {
+                Map<String, Object> row = new HashMap<>();
+                for (int index = 1; index <= meta.getColumnCount(); index++) {
+                    row.put(meta.getColumnLabel(index).toLowerCase(Locale.US),
+                            result.getObject(index));
+                }
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    private static void copyLegacyRows(Connection connection,
+                                       List<Map<String, Object>> rows) throws Exception {
+        String sql = "INSERT INTO recordings (recording_id, filename, abs_path, root_id,"
+                + " volume_id, relative_path, root_rank, is_available,"
+                + String.join(", ", LEGACY_COLUMNS).substring(
+                        "filename, abs_path, ".length())
+                + ") VALUES (" + placeholders(32) + ")";
+        try (PreparedStatement insert = connection.prepareStatement(sql)) {
+            for (Map<String, Object> legacy : rows) {
+                String absolutePath = String.valueOf(legacy.get("abs_path"));
+                RecordingIdentity identity = RecordingIdentity.fromPath(absolutePath);
+                int parameter = 1;
+                insert.setString(parameter++, identity.recordingId);
+                insert.setObject(parameter++, legacy.get("filename"));
+                insert.setString(parameter++, absolutePath);
+                insert.setString(parameter++, identity.rootId);
+                insert.setString(parameter++, identity.volumeId);
+                insert.setString(parameter++, identity.relativePath);
+                insert.setInt(parameter++, 100);
+                insert.setBoolean(parameter++, new File(absolutePath).isFile());
+                for (int index = 2; index < LEGACY_COLUMNS.length; index++) {
+                    insert.setObject(parameter++, legacy.get(LEGACY_COLUMNS[index]));
+                }
+                insert.addBatch();
+            }
+            insert.executeBatch();
+        }
+    }
+
+    private static void createV4Table(Statement statement) throws Exception {
+        statement.execute(
+            "CREATE TABLE IF NOT EXISTS recordings (" +
+            "  recording_id    VARCHAR(64) PRIMARY KEY," +
+            "  filename        VARCHAR(256) NOT NULL," +
+            "  abs_path        VARCHAR(768) NOT NULL," +
+            "  root_id         VARCHAR(64) NOT NULL," +
+            "  volume_id       VARCHAR(128) NOT NULL," +
+            "  relative_path   VARCHAR(768) NOT NULL," +
+            "  root_rank       INT NOT NULL DEFAULT 100," +
+            "  is_available    BOOLEAN NOT NULL DEFAULT TRUE," +
+            "  type            VARCHAR(16) NOT NULL," +
+            "  camera_id       INT DEFAULT 0," +
+            "  ts_ms           BIGINT NOT NULL," +
+            "  size_bytes      BIGINT NOT NULL DEFAULT 0," +
+            "  mp4_mtime       BIGINT NOT NULL DEFAULT 0," +
+            "  sidecar_mtime   BIGINT NOT NULL DEFAULT 0," +
+            "  schema_version  INT DEFAULT 0," +
+            "  peak_severity   VARCHAR(16)," +
+            "  peak_proximity  VARCHAR(16)," +
+            "  person_count    INT DEFAULT 0," +
+            "  vehicle_count   INT DEFAULT 0," +
+            "  bike_count      INT DEFAULT 0," +
+            "  animal_count    INT DEFAULT 0," +
+            "  hero_thumb      VARCHAR(256)," +
+            "  actor_classes   VARCHAR(256)," +
+            "  place_short     VARCHAR(128)," +
+            "  place_medium    VARCHAR(192)," +
+            "  place_display   VARCHAR(256)," +
+            "  place_country   VARCHAR(8)," +
+            "  place_source    VARCHAR(32)," +
+            "  start_lat       DOUBLE," +
+            "  start_lng       DOUBLE," +
+            "  ymd             VARCHAR(10)," +
+            "  storage         VARCHAR(16)," +
+            "  UNIQUE(volume_id, relative_path)" +
+            ")"
+        );
+    }
+
+    private static void createIndexes(Statement statement) throws Exception {
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_available_ts"
+                + " ON recordings(is_available, ts_ms DESC)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_filename_rank"
+                + " ON recordings(filename, is_available, root_rank, ts_ms DESC)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_root_id"
+                + " ON recordings(root_id)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_type_ts"
+                + " ON recordings(type, ts_ms DESC)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_ymd ON recordings(ymd)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_place ON recordings(place_short)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_country ON recordings(place_country)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_severity ON recordings(peak_severity)");
+        statement.execute("CREATE INDEX IF NOT EXISTS idx_rec_storage ON recordings(storage)");
+    }
+
+    private static void createMetaTable(Statement statement) throws Exception {
+        statement.execute("CREATE TABLE IF NOT EXISTS recordings_meta ("
+                + "meta_key VARCHAR(64) PRIMARY KEY, meta_value VARCHAR(256))");
+    }
+
+    private static boolean tableExists(Connection connection, String table) throws Exception {
+        DatabaseMetaData meta = connection.getMetaData();
+        try (ResultSet result = meta.getTables(null, null, table, new String[]{"TABLE"})) {
+            return result.next();
+        }
+    }
+
+    private static boolean columnExists(Connection connection, String table, String column)
+            throws Exception {
+        DatabaseMetaData meta = connection.getMetaData();
+        try (ResultSet result = meta.getColumns(null, null, table, column)) {
+            return result.next();
+        }
+    }
+
+    private static String placeholders(int count) {
+        StringBuilder sql = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            if (index > 0) sql.append(',');
+            sql.append('?');
+        }
+        return sql.toString();
+    }
+}

--- a/app/src/main/java/com/overdrive/app/storage/RecordingDirectoryRegistry.java
+++ b/app/src/main/java/com/overdrive/app/storage/RecordingDirectoryRegistry.java
@@ -1,0 +1,40 @@
+package com.overdrive.app.storage;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class RecordingDirectoryRegistry {
+    static final String LEGACY_BASE =
+            "/storage/emulated/0/Android/data/com.overdrive.app/files";
+    static final String LEGACY_RECORDINGS = LEGACY_BASE + "/recordings";
+    static final String LEGACY_SENTRY = LEGACY_BASE + "/sentry_events";
+    static final String LEGACY_PROXIMITY = LEGACY_BASE + "/proximity_events";
+
+    private RecordingDirectoryRegistry() {}
+
+    static List<File> recordings(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb,
+                new File(LEGACY_RECORDINGS), new File(LEGACY_BASE));
+    }
+
+    static List<File> surveillance(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb, new File(LEGACY_SENTRY));
+    }
+
+    static List<File> proximity(File active, File internal, File sd, File usb) {
+        return unique(active, internal, sd, usb, new File(LEGACY_PROXIMITY));
+    }
+
+    private static List<File> unique(File... candidates) {
+        List<File> directories = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (File candidate : candidates) {
+            if (candidate == null) continue;
+            if (seen.add(candidate.getAbsolutePath())) directories.add(candidate);
+        }
+        return directories;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -130,8 +130,8 @@ public class StorageManager {
     // Legacy paths from older app versions. Files here aren't written anymore
     // but they still count toward the user's configured limit and must be
     // reaped — otherwise a 500 MB limit can show 800 MB used in the UI.
-    private static final String LEGACY_APP_FILES_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files";
-    private static final String LEGACY_SURVEILLANCE_DIR = LEGACY_APP_FILES_DIR + "/sentry_events";
+    private static final String LEGACY_APP_FILES_DIR = RecordingDirectoryRegistry.LEGACY_BASE;
+    private static final String LEGACY_SURVEILLANCE_DIR = RecordingDirectoryRegistry.LEGACY_SENTRY;
 
     // Subdirectories
     public static final String RECORDINGS_SUBDIR = "recordings";
@@ -3530,15 +3530,18 @@ public class StorageManager {
      * Callers should iterate all returned directories to find all files.
      */
     public List<File> getAllRecordingsDirs() {
-        return getAllDirsForType(recordingsDir, internalRecordingsDir, sdCardRecordingsDir, usbRecordingsDir);
+        return RecordingDirectoryRegistry.recordings(
+            recordingsDir, internalRecordingsDir, sdCardRecordingsDir, usbRecordingsDir);
     }
 
     public List<File> getAllSurveillanceDirs() {
-        return getAllDirsForType(surveillanceDir, internalSurveillanceDir, sdCardSurveillanceDir, usbSurveillanceDir);
+        return RecordingDirectoryRegistry.surveillance(
+            surveillanceDir, internalSurveillanceDir, sdCardSurveillanceDir, usbSurveillanceDir);
     }
 
     public List<File> getAllProximityDirs() {
-        return getAllDirsForType(proximityDir, internalProximityDir, sdCardProximityDir, usbProximityDir);
+        return RecordingDirectoryRegistry.proximity(
+            proximityDir, internalProximityDir, sdCardProximityDir, usbProximityDir);
     }
 
     public List<File> getAllTripsDirs() {
@@ -3580,60 +3583,29 @@ public class StorageManager {
     }
 
     /**
-     * Same as {@link #getAllSurveillanceDirs()} et al, but additionally
-     * includes legacy app-files locations from older app versions where
-     * stale media may still be living and counting toward the limit.
+    * Same canonical roots as {@link #getAllSurveillanceDirs()} et al.
      *
      * Used by both the size accounting and the cleanup reaper so the two
      * agree about what "the surveillance pool" actually is — otherwise
      * the UI can show 800 MB used against a 500 MB limit while cleanup
      * (which only saw the active dir) thinks everything is fine.
      *
-     * Includes the flat legacy base ({@link #LEGACY_APP_FILES_DIR}) when a
-     * non-null filename prefix is supplied via {@link #namePrefixForCategory},
-     * because the flat base is shared across categories and only files
-     * matching the category's prefix should be touched.
+     * The flat legacy base is shared across categories, so callers use
+     * {@link #namePrefixForCategory} to touch only matching files.
      */
     private List<File> getReapableDirs(String category) {
-        List<File> dirs;
-        String legacyPath = null;
-        boolean includeFlatBase = false;
         switch (category) {
             case "recordings":
-                dirs = new ArrayList<>(getAllRecordingsDirs());
-                legacyPath = LEGACY_APP_FILES_DIR + "/recordings";
-                includeFlatBase = true;  // some old installs wrote cam_* into <base>
-                break;
+                return new ArrayList<>(getAllRecordingsDirs());
             case "surveillance":
-                dirs = new ArrayList<>(getAllSurveillanceDirs());
-                legacyPath = LEGACY_SURVEILLANCE_DIR;
-                break;
+                return new ArrayList<>(getAllSurveillanceDirs());
             case "proximity":
-                dirs = new ArrayList<>(getAllProximityDirs());
-                legacyPath = LEGACY_APP_FILES_DIR + "/proximity_events";
-                break;
+                return new ArrayList<>(getAllProximityDirs());
             case "trips":
-                dirs = new ArrayList<>(getAllTripsDirs());
-                break;
+                return new ArrayList<>(getAllTripsDirs());
             default:
                 return new ArrayList<>();
         }
-        if (legacyPath != null) {
-            addDirIfMissing(dirs, new File(legacyPath));
-        }
-        if (includeFlatBase) {
-            addDirIfMissing(dirs, new File(LEGACY_APP_FILES_DIR));
-        }
-        return dirs;
-    }
-
-    private static void addDirIfMissing(List<File> dirs, File candidate) {
-        if (candidate == null || !candidate.exists() || !candidate.isDirectory()) return;
-        String path = candidate.getAbsolutePath();
-        for (File d : dirs) {
-            if (d != null && d.getAbsolutePath().equals(path)) return;
-        }
-        dirs.add(candidate);
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -5923,8 +5923,8 @@ public class StorageManager {
                 // only knows about .mp4 filenames.
                 if (file.getName().endsWith(".mp4")) {
                     try {
-                        com.overdrive.app.server.RecordingsIndex
-                                .getInstance().remove(file.getName());
+                            com.overdrive.app.server.RecordingsIndex
+                                .getInstance().removeByPath(file.getAbsolutePath());
                     } catch (Throwable ignored) {}
                 }
 
@@ -7392,7 +7392,8 @@ public class StorageManager {
 
         if (file.getName().endsWith(".mp4")) {
             try {
-                com.overdrive.app.server.RecordingsIndex.getInstance().remove(file.getName());
+                com.overdrive.app.server.RecordingsIndex.getInstance()
+                    .removeByPath(file.getAbsolutePath());
             } catch (Throwable ignored) {}
         }
         if (sidecarExts.length > 0) {

--- a/app/src/main/java/com/overdrive/app/storage/StorageManager.java
+++ b/app/src/main/java/com/overdrive/app/storage/StorageManager.java
@@ -3548,6 +3548,25 @@ public class StorageManager {
         return getAllDirsForType(tripsDir, internalTripsDir, sdCardTripsDir, usbTripsDir);
     }
 
+    /** Active-first rank used only to resolve legacy filename-only requests. */
+    public int getRecordingRootRank(File file) {
+        if (file == null) return 100;
+        String path = file.getAbsolutePath();
+        List<File> roots = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (List<File> category : java.util.Arrays.asList(
+                getAllRecordingsDirs(), getAllSurveillanceDirs(), getAllProximityDirs())) {
+            for (File root : category) {
+                if (root != null && seen.add(root.getAbsolutePath())) roots.add(root);
+            }
+        }
+        for (int rank = 0; rank < roots.size(); rank++) {
+            String root = roots.get(rank).getAbsolutePath();
+            if (path.equals(root) || path.startsWith(root + File.separator)) return rank;
+        }
+        return 100;
+    }
+
     /**
      * Bounded directory listing for callers (e.g. trip recovery) that walk a
      * possibly-FUSE-bridged SD/USB trips dir. Runs the in-process
@@ -4867,7 +4886,21 @@ public class StorageManager {
      * This handles the case where UI app owns the directory but daemon needs to list files.
      * Returns every file in the directory regardless of extension.
      */
+    static final class FileListResult {
+        final File[] files;
+        final boolean complete;
+
+        FileListResult(File[] files, boolean complete) {
+            this.files = files;
+            this.complete = complete;
+        }
+    }
+
     private File[] listFilesViaShell(File dir) {
+        return listFilesViaShellWithStatus(dir).files;
+    }
+
+    private FileListResult listFilesViaShellWithStatus(File dir) {
         Process p = null;
         try {
             p = Runtime.getRuntime().exec(new String[]{"ls", dir.getAbsolutePath()});
@@ -4902,6 +4935,7 @@ public class StorageManager {
             drain.setDaemon(true);
             drain.start();
             drain.join(4_000);
+            boolean complete = false;
             if (drain.isAlive()) {
                 logWarn("listFilesViaShell(" + dir.getName() + "): `ls` drain exceeded 4s"
                     + " — killing child and returning partial list (" + files.size() + " so far)");
@@ -4911,7 +4945,8 @@ public class StorageManager {
                 drain.join(500);
             } else {
                 // Drain finished; reap the (now-exited or about-to-exit) child.
-                waitForBounded(p, 1_000, "listFilesViaShell(" + dir.getName() + ")");
+                complete = waitForBounded(
+                        p, 1_000, "listFilesViaShell(" + dir.getName() + ")") == 0;
             }
 
             File[] snapshot;
@@ -4919,13 +4954,13 @@ public class StorageManager {
                 snapshot = files.toArray(new File[0]);
             }
             logDebug("listFilesViaShell: found " + snapshot.length + " files in " + dir.getName());
-            return snapshot;
+            return new FileListResult(snapshot, complete);
         } catch (Exception e) {
             logWarn("listFilesViaShell failed: " + e.getMessage());
             if (p != null) {
                 try { p.destroyForcibly(); } catch (Exception ignored) {}
             }
-            return new File[0];
+            return new FileListResult(new File[0], false);
         }
     }
 
@@ -4958,6 +4993,68 @@ public class StorageManager {
      */
     public File[] listMp4Files(File dir) {
         return listFilesWithFallback(dir, ".mp4");
+    }
+
+    public static final class Mp4Listing {
+        public final File[] files;
+        public final boolean available;
+        public final boolean complete;
+
+        Mp4Listing(File[] files, boolean available, boolean complete) {
+            this.files = files;
+            this.available = available;
+            this.complete = complete;
+        }
+    }
+
+    /**
+     * MP4 listing with enough status for destructive reconciliation. A partial
+     * shell result may add/update rows, but callers must delete missing rows
+     * only when {@link Mp4Listing#complete} is true.
+     */
+    public Mp4Listing listMp4FilesWithStatus(File dir) {
+        if (dir == null || !dir.exists() || !dir.isDirectory()) {
+            return new Mp4Listing(new File[0], false, false);
+        }
+        java.io.FileFilter mp4Filter = file -> file.getName().endsWith(".mp4");
+        FileListResult direct = listFilesDirectWithStatus(dir, mp4Filter, 4_000L);
+        if (direct.complete) {
+            return new Mp4Listing(direct.files, true, true);
+        }
+        FileListResult shell = listFilesViaShellWithStatus(dir);
+        java.util.List<File> mp4 = new java.util.ArrayList<>();
+        for (File file : shell.files) {
+            if (file.getName().endsWith(".mp4")) mp4.add(file);
+        }
+        return new Mp4Listing(mp4.toArray(new File[0]), true, shell.complete);
+    }
+
+    static FileListResult listFilesDirectWithStatus(
+            File dir, java.io.FileFilter filter, long timeoutMs) {
+        java.util.concurrent.atomic.AtomicReference<File[]> files =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicBoolean finished =
+                new java.util.concurrent.atomic.AtomicBoolean(false);
+        Thread worker = new Thread(() -> {
+            try {
+                files.set(dir.listFiles(filter));
+            } catch (Throwable ignored) {
+                files.set(null);
+            } finally {
+                finished.set(true);
+            }
+        }, "StorageDirectList-" + dir.getName());
+        worker.setDaemon(true);
+        worker.start();
+        try {
+            worker.join(Math.max(1L, timeoutMs));
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return new FileListResult(new File[0], false);
+        }
+        File[] result = files.get();
+        return new FileListResult(result != null ? result : new File[0],
+                finished.get() && result != null);
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/ui/model/RecordingFile.kt
+++ b/app/src/main/java/com/overdrive/app/ui/model/RecordingFile.kt
@@ -49,7 +49,15 @@ data class RecordingFile(
     // silent SD→internal fallback (the SD card is bridged behind the USB power
     // rail, so cutting USB power unmounts it and clips fall back to internal).
     // Null = unknown/unclassified; the adapter omits the badge.
-    val storageType: String? = null
+    val storageType: String? = null,
+    // Stable server identity and action URLs. Null for direct-filesystem rows
+    // and daemons predating the volume-aware v4 index.
+    val recordingId: String? = null,
+    val videoUrl: String? = null,
+    val thumbnailUrl: String? = null,
+    val deleteUrl: String? = null,
+    val eventUrl: String? = null,
+    val available: Boolean = true
 ) {
     // Secondary constructor for MediaStore results
     constructor(

--- a/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
+++ b/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
@@ -95,7 +95,7 @@ object RecordingScanner {
         // row — so on success we only need to mop up any sibling thumbs
         // that live under directories the daemon's StorageManager view
         // doesn't enumerate (rare, but harmless to do).
-        val apiOk = RecordingsApiClient.deleteRecording(recording.file.name)
+        val apiOk = RecordingsApiClient.deleteRecording(recording)
         if (apiOk) {
             cleanupLocalSidecars(recording)
             invalidateCache()

--- a/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
+++ b/app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt
@@ -23,16 +23,6 @@ import java.util.Calendar
 object RecordingScanner {
     private const val TAG = "RecordingScanner"
 
-    // Legacy paths for backward compatibility (migration). The base dir
-    // historically held a `recordings/` subdir for dashcam clips and a
-    // `sentry_events/` subdir for surveillance clips; some very old builds
-    // wrote dashcam clips directly into the base dir, so we scan both.
-    private const val LEGACY_BASE_DIR = "/storage/emulated/0/Android/data/com.overdrive.app/files"
-    private const val LEGACY_RECORDINGS_DIR = "$LEGACY_BASE_DIR/recordings"
-    private const val LEGACY_RECORDINGS_DIR_FLAT = LEGACY_BASE_DIR
-    private const val LEGACY_SENTRY_DIR = "$LEGACY_BASE_DIR/sentry_events"
-    private const val LEGACY_PROXIMITY_DIR = "$LEGACY_BASE_DIR/proximity_events"
-
     // ==================== Public API ====================
 
     /**
@@ -246,35 +236,16 @@ object RecordingScanner {
         for (dir in sm.allRecordingsDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.NORMAL, normal, seenNormal)
         }
-        // Legacy locations (some installs wrote into <base>/recordings,
-        // others directly into the base dir). Both checked, deduped on name.
-        for (path in listOf(LEGACY_RECORDINGS_DIR, LEGACY_RECORDINGS_DIR_FLAT)) {
-            val dir = File(path)
-            if (dir.exists()) {
-                scanDirectoryDedup(dir, RecordingFile.RecordingType.NORMAL, normal, seenNormal)
-            }
-        }
-
         val sentry = mutableListOf<RecordingFile>()
         val seenSentry = mutableSetOf<String>()
         for (dir in sm.allSurveillanceDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.SENTRY, sentry, seenSentry)
         }
-        val legacySentryDir = File(LEGACY_SENTRY_DIR)
-        if (legacySentryDir.exists()) {
-            scanDirectoryDedup(legacySentryDir, RecordingFile.RecordingType.SENTRY, sentry, seenSentry)
-        }
-
         val proximity = mutableListOf<RecordingFile>()
         val seenProximity = mutableSetOf<String>()
         for (dir in sm.allProximityDirs) {
             scanDirectoryDedup(dir, RecordingFile.RecordingType.PROXIMITY, proximity, seenProximity)
         }
-        val legacyProximityDir = File(LEGACY_PROXIMITY_DIR)
-        if (legacyProximityDir.exists()) {
-            scanDirectoryDedup(legacyProximityDir, RecordingFile.RecordingType.PROXIMITY, proximity, seenProximity)
-        }
-
         // OEM Dashcam clips (dvr_*.mp4) live in the same physical directory
         // as cam_*.mp4 (StorageManager.allRecordingsDirs), but parse as a
         // distinct type so the segmented control / library can show them

--- a/app/src/main/java/com/overdrive/app/ui/util/RecordingsApiClient.kt
+++ b/app/src/main/java/com/overdrive/app/ui/util/RecordingsApiClient.kt
@@ -403,17 +403,31 @@ object RecordingsApiClient {
      * {success:true}. Body of the DELETE response is otherwise ignored.
      */
     fun deleteRecording(filename: String): Boolean {
+        return deleteRecordingUrl("$BASE_URL/api/recordings/${enc(filename)}", filename)
+    }
+
+    fun deleteRecording(recording: RecordingFile): Boolean {
+        val id = recording.recordingId
+        val url = if (!id.isNullOrEmpty()) {
+            "$BASE_URL/api/recordings/id/${enc(id)}"
+        } else {
+            "$BASE_URL/api/recordings/${enc(recording.file.name)}"
+        }
+        return deleteRecordingUrl(url, recording.file.name)
+    }
+
+    private fun deleteRecordingUrl(url: String, label: String): Boolean {
         return try {
-            if (filename.isEmpty() || filename.contains("..") || filename.contains("/")) {
+            if (label.isEmpty() || label.contains("..") || label.contains("/")) {
                 return false
             }
             val req = Request.Builder()
-                .url("$BASE_URL/api/recordings/${enc(filename)}")
+                .url(url)
                 .delete()
                 .build()
             http.newCall(req).execute().use { resp ->
                 if (!resp.isSuccessful) {
-                    Log.w(TAG, "deleteRecording HTTP ${resp.code} for $filename")
+                    Log.w(TAG, "deleteRecording HTTP ${resp.code} for $label")
                     return false
                 }
                 val body = resp.body?.string() ?: return false
@@ -488,9 +502,9 @@ object RecordingsApiClient {
         // mirrors. If we can't find it on disk, leave heroThumbnailFile
         // null — adapters tolerate that and fall back to the daemon's
         // thumbnail endpoint anyway.
-        val heroThumbnailFile = rec.optString("heroThumbnailUrl")
-            .takeIf { it.isNotEmpty() }
-            ?.let { resolveHeroJpeg(it, absPath) }
+        val heroName = rec.optString("heroThumbnailName").takeIf { it.isNotEmpty() }
+            ?: rec.optString("heroThumbnailUrl").takeIf { it.isNotEmpty() }
+        val heroThumbnailFile = heroName?.let { resolveHeroJpeg(it, absPath) }
 
         val actorsArr = rec.optJSONArray("actors")
         val actorClasses = if (actorsArr != null && actorsArr.length() > 0) {
@@ -546,7 +560,13 @@ object RecordingsApiClient {
             startLat = startLat,
             startLng = startLng,
             bucketLabel = bucketLabel,
-            storageType = storageType
+            storageType = storageType,
+            recordingId = rec.optString("id").takeIf { it.isNotEmpty() },
+            videoUrl = rec.optString("videoUrl").takeIf { it.isNotEmpty() },
+            thumbnailUrl = rec.optString("thumbnailUrl").takeIf { it.isNotEmpty() },
+            deleteUrl = rec.optString("deleteUrl").takeIf { it.isNotEmpty() },
+            eventUrl = rec.optString("eventUrl").takeIf { it.isNotEmpty() },
+            available = rec.optBoolean("available", true)
         )
     }
 

--- a/app/src/test/java/com/overdrive/app/server/RecordingFileFingerprintTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingFileFingerprintTest.java
@@ -1,0 +1,120 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+public class RecordingFileFingerprintTest {
+
+    @Test
+    public void exactStoredStateMatches() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_120000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_120000.json"), "{}");
+        Files.setLastModifiedTime(mp4.toPath(), FileTime.fromMillis(10_000L));
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(20_000L));
+
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertTrue(fingerprint.matches(mp4.getAbsolutePath(), mp4.length(),
+                mp4.lastModified(), sidecar.lastModified()));
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                fingerprint.decisionAgainst(mp4.getAbsolutePath(), mp4.length(),
+                        mp4.lastModified(), sidecar.lastModified()));
+    }
+
+    @Test
+    public void pathSizeAndMtimeChangesRequireRefresh() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("cam_20260810_120000.mp4"), "video");
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(RecordingFileFingerprint.Decision.ADD,
+                fingerprint.decisionAgainst(null, 0L, 0L, 0L));
+        assertFalse(fingerprint.matches("/old/volume/" + mp4.getName(),
+                fingerprint.sizeBytes, fingerprint.mp4Mtime, fingerprint.sidecarMtime));
+        assertFalse(fingerprint.matches(fingerprint.absolutePath,
+                fingerprint.sizeBytes + 1L, fingerprint.mp4Mtime, fingerprint.sidecarMtime));
+        assertFalse(fingerprint.matches(fingerprint.absolutePath,
+                fingerprint.sizeBytes, fingerprint.mp4Mtime + 1L, fingerprint.sidecarMtime));
+        assertEquals(RecordingFileFingerprint.Decision.REFRESH,
+                fingerprint.decisionAgainst("/old/volume/" + mp4.getName(),
+                        fingerprint.sizeBytes, fingerprint.mp4Mtime,
+                        fingerprint.sidecarMtime));
+    }
+
+    @Test
+    public void sidecarCreationChangeAndDeletionRequireRefresh() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("proximity_20260810_120000.mp4"), "video");
+        RecordingFileFingerprint withoutSidecar = RecordingFileFingerprint.from(mp4);
+
+        File sidecar = write(dir.resolve("proximity_20260810_120000.json"), "{}");
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(30_000L));
+        RecordingFileFingerprint withSidecar = RecordingFileFingerprint.from(mp4);
+
+        assertFalse(withSidecar.matches(withoutSidecar.absolutePath,
+                withoutSidecar.sizeBytes, withoutSidecar.mp4Mtime,
+                withoutSidecar.sidecarMtime));
+        assertTrue(sidecar.delete());
+        RecordingFileFingerprint afterDelete = RecordingFileFingerprint.from(mp4);
+        assertFalse(afterDelete.matches(withSidecar.absolutePath,
+                withSidecar.sizeBytes, withSidecar.mp4Mtime, withSidecar.sidecarMtime));
+    }
+
+    @Test
+    public void sidecarMtimeUpdateRefreshesOnceThenConverges() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_130000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_130000.json"), "{}");
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(30_000L));
+        RecordingFileFingerprint before = RecordingFileFingerprint.from(mp4);
+
+        Files.setLastModifiedTime(sidecar.toPath(), FileTime.fromMillis(40_000L));
+        RecordingFileFingerprint after = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(RecordingFileFingerprint.Decision.REFRESH,
+                after.decisionAgainst(before.absolutePath, before.sizeBytes,
+                        before.mp4Mtime, before.sidecarMtime));
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                after.decisionAgainst(after.absolutePath, after.sizeBytes,
+                        after.mp4Mtime, after.sidecarMtime));
+    }
+
+    @Test
+    public void unreadableSidecarUsesSameZeroMtimeAsParser() throws Exception {
+        Path dir = Files.createTempDirectory("recording-fingerprint");
+        File mp4 = write(dir.resolve("event_20260810_140000.mp4"), "video");
+        File sidecar = write(dir.resolve("event_20260810_140000.json"), "{}");
+        sidecar.setReadable(false, false);
+        Assume.assumeFalse("filesystem did not make sidecar unreadable", sidecar.canRead());
+
+        RecordingFileFingerprint fingerprint = RecordingFileFingerprint.from(mp4);
+
+        assertEquals(0L, fingerprint.sidecarMtime);
+        assertEquals(RecordingFileFingerprint.Decision.UNCHANGED,
+                fingerprint.decisionAgainst(fingerprint.absolutePath,
+                        fingerprint.sizeBytes, fingerprint.mp4Mtime, 0L));
+    }
+
+    @Test
+    public void sidecarNameOnlyReplacesTrailingMp4Suffix() {
+        File mp4 = new File("/recordings/event_a.mp4_2.mp4");
+
+        assertTrue(RecordingFileFingerprint.sidecarFor(mp4).getPath()
+                .endsWith("/recordings/event_a.mp4_2.json"));
+    }
+
+    private static File write(Path path, String content) throws Exception {
+        Files.write(path, content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return path.toFile();
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingIdApiContractTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingIdApiContractTest.java
@@ -1,0 +1,97 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingIdApiContractTest {
+
+    @Test
+    public void exactIdRoutesPrecedeLegacyFilenameRoutes() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String handle = methodBody(source, "public static boolean handle(");
+        String range = methodBody(source, "public static boolean handleWithRange(");
+
+        assertBefore(handle, "path.startsWith(\"/thumb/id/\")",
+                "path.startsWith(\"/thumb/\")");
+        assertBefore(handle, "path.startsWith(\"/video/id/\")",
+                "path.startsWith(\"/video/\")");
+        assertBefore(handle, "path.startsWith(\"/api/recordings/id/\")",
+                "path.startsWith(\"/api/recordings/\")");
+        assertBefore(range, "path.startsWith(\"/video/id/\")",
+                "path.startsWith(\"/video/\")");
+        assertTrue(source.contains("RecordingsIndex.getInstance().resolveById(recordingId)"));
+    }
+
+    @Test
+    public void knownPathMutationSitesNeverRemoveByFilename() throws IOException {
+        String api = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String watcher = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/daemon/RecordingsIndexFileWatcher.java");
+        String storage = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        assertTrue(methodBody(api, "public static void invalidateRecordingCache")
+                .contains("removeByPath(absMp4Path)"));
+        assertFalse(methodBody(api, "private static void deleteSidecars")
+                .contains("remove(filename)"));
+        assertTrue(watcher.contains("removeByPath(new File(dir, path).getAbsolutePath())"));
+        assertFalse(storage.contains("remove(file.getName())"));
+        assertTrue(methodBody(api, "private static void deleteSidecars")
+                .contains("RecordingIdentity.fromPath(mp4File.getAbsolutePath()).recordingId"));
+        assertTrue(methodBody(api, "private static void batchDeleteRecordings")
+                .contains("request.optJSONArray(\"ids\")"));
+        assertTrue(methodBody(api, "private static void batchDeleteRecordings")
+                .contains("int batchSize = idCount + filenameCount"));
+        assertTrue(methodBody(api, "private static void serveEventTimeline")
+                .contains("filename.substring(0, filename.length() - \".mp4\".length())"));
+    }
+
+    private static void assertBefore(String source, String first, String second) {
+        int firstIndex = source.indexOf(first);
+        int secondIndex = source.indexOf(second);
+        assertTrue(first + " must precede " + second,
+                firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex);
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingIdentityTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingIdentityTest.java
@@ -1,0 +1,63 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.File;
+
+public class RecordingIdentityTest {
+
+    @Test
+    public void samePathProducesStableOpaqueIdentity() {
+        RecordingIdentity first = RecordingIdentity.fromPath(
+                "/storage/emulated/0/Overdrive/recordings/cam_20260810_120000.mp4");
+        RecordingIdentity second = RecordingIdentity.fromPath(
+                "/storage/emulated/0/Overdrive/recordings/cam_20260810_120000.mp4");
+
+        assertEquals(first.recordingId, second.recordingId);
+        assertEquals("internal", first.volumeId);
+        assertEquals("Overdrive/recordings/cam_20260810_120000.mp4", first.relativePath);
+        assertTrue(first.recordingId.matches("[0-9a-f]{32}"));
+    }
+
+    @Test
+    public void duplicateFilenameOnDifferentVolumesGetsDifferentIdentity() {
+        RecordingIdentity internal = RecordingIdentity.fromPath(
+                "/storage/emulated/0/Overdrive/recordings/cam_20260810_120000.mp4");
+        RecordingIdentity sd = RecordingIdentity.fromPath(
+                "/storage/ABCD-1234/Overdrive/recordings/cam_20260810_120000.mp4");
+        RecordingIdentity usb = RecordingIdentity.fromPath(
+                "/storage/9876-DCBA/Overdrive/recordings/cam_20260810_120000.mp4");
+
+        assertNotEquals(internal.recordingId, sd.recordingId);
+        assertNotEquals(sd.recordingId, usb.recordingId);
+        assertEquals("portable:abcd-1234", sd.volumeId);
+    }
+
+    @Test
+    public void filesInSameDirectoryShareRootIdentity() {
+        RecordingIdentity first = RecordingIdentity.fromPath(
+                "/storage/ABCD-1234/Overdrive/surveillance/event_20260810_120000.mp4");
+        RecordingIdentity second = RecordingIdentity.fromPath(
+                "/storage/ABCD-1234/Overdrive/surveillance/event_20260810_120100.mp4");
+
+        assertEquals(first.rootId, second.rootId);
+        assertEquals(first.rootId,
+                RecordingIdentity.rootIdFor(new File(
+                        "/storage/ABCD-1234/Overdrive/surveillance")));
+    }
+
+    @Test
+    public void mediaRwAndPublicStorageUseSamePortableIdentity() {
+        RecordingIdentity publicPath = RecordingIdentity.fromPath(
+                "/storage/ABCD-1234/Overdrive/recordings/cam.mp4");
+        RecordingIdentity mediaRwPath = RecordingIdentity.fromPath(
+                "/mnt/media_rw/ABCD-1234/Overdrive/recordings/cam.mp4");
+
+        assertEquals(publicPath.volumeId, mediaRwPath.volumeId);
+        assertEquals(publicPath.recordingId, mediaRwPath.recordingId);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingReconcilePolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingReconcilePolicyTest.java
@@ -1,0 +1,18 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RecordingReconcilePolicyTest {
+
+    @Test
+    public void deletesOnlyMissingRowsFromCompleteAvailableRoots() {
+        assertTrue(RecordingReconcilePolicy.shouldDeleteMissingRow(true, true, false));
+        assertFalse(RecordingReconcilePolicy.shouldDeleteMissingRow(true, true, true));
+        assertFalse(RecordingReconcilePolicy.shouldDeleteMissingRow(false, true, false));
+        assertFalse(RecordingReconcilePolicy.shouldDeleteMissingRow(true, false, false));
+        assertFalse(RecordingReconcilePolicy.shouldDeleteMissingRow(false, false, false));
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingRootParityTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingRootParityTest.java
@@ -1,0 +1,52 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingRootParityTest {
+
+    @Test
+    public void consumersUseStorageManagerInsteadOfDuplicatingLegacyPaths() throws IOException {
+        String index = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String api = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsApiHandler.java");
+        String scanner = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt");
+        String storage = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/storage/StorageManager.java");
+
+        String legacyPrefix = "/storage/emulated/0/Android/data/com.overdrive.app/files";
+        assertFalse(index.contains(legacyPrefix));
+        assertFalse(api.contains(legacyPrefix));
+        assertFalse(scanner.contains(legacyPrefix));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.recordings"));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.surveillance"));
+        assertTrue(storage.contains("RecordingDirectoryRegistry.proximity"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingsIndexSchemaTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsIndexSchemaTest.java
@@ -1,0 +1,146 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class RecordingsIndexSchemaTest {
+
+    @Test
+    public void freshSchemaUsesVolumeAwarePrimaryKey() throws Exception {
+        try (Connection connection = open("fresh")) {
+            RecordingsIndexSchema.ensure(connection);
+
+            assertTrue(hasColumn(connection, "RECORDING_ID"));
+            assertTrue(hasColumn(connection, "VOLUME_ID"));
+            assertTrue(hasColumn(connection, "RELATIVE_PATH"));
+            assertTrue(hasColumn(connection, "IS_AVAILABLE"));
+            assertEquals("4", metaValue(connection, "schema_version"));
+        }
+    }
+
+    @Test
+    public void v3MigrationPreservesMetadataAndDerivesIdentity() throws Exception {
+        try (Connection connection = open("migration")) {
+            createV3(connection);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("INSERT INTO recordings (filename, abs_path, type, ts_ms,"
+                        + " size_bytes, mp4_mtime, sidecar_mtime, storage) VALUES ("
+                        + "'cam_20260810_120000.mp4',"
+                        + "'/storage/ABCD-1234/Overdrive/recordings/cam_20260810_120000.mp4',"
+                        + "'normal', 1234, 5678, 100, 200, 'SD_CARD')");
+            }
+
+            RecordingsIndexSchema.ensure(connection);
+
+            try (Statement statement = connection.createStatement();
+                 ResultSet row = statement.executeQuery("SELECT * FROM recordings")) {
+                assertTrue(row.next());
+                assertEquals("cam_20260810_120000.mp4", row.getString("filename"));
+                assertEquals("portable:abcd-1234", row.getString("volume_id"));
+                assertEquals("Overdrive/recordings/cam_20260810_120000.mp4",
+                        row.getString("relative_path"));
+                assertEquals(5678L, row.getLong("size_bytes"));
+                assertFalse(row.getBoolean("is_available"));
+                assertFalse(row.next());
+            }
+        }
+    }
+
+    @Test
+    public void duplicateFilenamesOnDifferentVolumesCanCoexist() throws Exception {
+        try (Connection connection = open("duplicates")) {
+            RecordingsIndexSchema.ensure(connection);
+            RecordingIdentity internal = RecordingIdentity.fromPath(
+                    "/storage/emulated/0/Overdrive/recordings/cam.mp4");
+            RecordingIdentity sd = RecordingIdentity.fromPath(
+                    "/storage/ABCD-1234/Overdrive/recordings/cam.mp4");
+            try (java.sql.PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO recordings (recording_id, filename, abs_path, root_id,"
+                    + " volume_id, relative_path, root_rank, is_available, type, ts_ms)"
+                    + " VALUES (?, 'cam.mp4', ?, ?, ?, ?, ?, TRUE, 'normal', 1)")) {
+                insertIdentity(insert, internal,
+                        "/storage/emulated/0/Overdrive/recordings/cam.mp4", 0);
+                insert.executeUpdate();
+                insertIdentity(insert, sd,
+                        "/storage/ABCD-1234/Overdrive/recordings/cam.mp4", 1);
+                insert.executeUpdate();
+            }
+            try (Statement statement = connection.createStatement();
+                 ResultSet count = statement.executeQuery(
+                         "SELECT COUNT(*) FROM recordings WHERE filename='cam.mp4'")) {
+                assertTrue(count.next());
+                assertEquals(2, count.getInt(1));
+                assertNotEquals(internal.recordingId, sd.recordingId);
+            }
+        }
+    }
+
+    @Test
+    public void ensureIsIdempotent() throws Exception {
+        try (Connection connection = open("idempotent")) {
+            RecordingsIndexSchema.ensure(connection);
+            RecordingsIndexSchema.ensure(connection);
+            assertEquals("4", metaValue(connection, "schema_version"));
+        }
+    }
+
+    private static Connection open(String name) throws Exception {
+        Class.forName("org.h2.Driver");
+        return DriverManager.getConnection("jdbc:h2:mem:" + name + ";DB_CLOSE_DELAY=-1", "sa", "");
+    }
+
+    private static void createV3(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE recordings ("
+                    + "filename VARCHAR(256) PRIMARY KEY, abs_path VARCHAR(512) NOT NULL,"
+                    + "type VARCHAR(16) NOT NULL, camera_id INT DEFAULT 0, ts_ms BIGINT NOT NULL,"
+                    + "size_bytes BIGINT DEFAULT 0, mp4_mtime BIGINT DEFAULT 0,"
+                    + "sidecar_mtime BIGINT DEFAULT 0, schema_version INT DEFAULT 0,"
+                    + "peak_severity VARCHAR(16), peak_proximity VARCHAR(16),"
+                    + "person_count INT DEFAULT 0, vehicle_count INT DEFAULT 0,"
+                    + "bike_count INT DEFAULT 0, animal_count INT DEFAULT 0,"
+                    + "hero_thumb VARCHAR(256), actor_classes VARCHAR(256),"
+                    + "place_short VARCHAR(128), place_medium VARCHAR(192),"
+                    + "place_display VARCHAR(256), place_country VARCHAR(8),"
+                    + "place_source VARCHAR(32), start_lat DOUBLE, start_lng DOUBLE,"
+                    + "ymd VARCHAR(10), storage VARCHAR(16))");
+        }
+    }
+
+    private static boolean hasColumn(Connection connection, String column) throws Exception {
+        try (ResultSet columns = connection.getMetaData()
+                .getColumns(null, null, "RECORDINGS", column)) {
+            return columns.next();
+        }
+    }
+
+    private static String metaValue(Connection connection, String key) throws Exception {
+        try (java.sql.PreparedStatement query = connection.prepareStatement(
+                "SELECT meta_value FROM recordings_meta WHERE meta_key=?")) {
+            query.setString(1, key);
+            try (ResultSet result = query.executeQuery()) {
+                return result.next() ? result.getString(1) : null;
+            }
+        }
+    }
+
+    private static void insertIdentity(java.sql.PreparedStatement insert,
+                                       RecordingIdentity identity,
+                                       String absolutePath, int rank) throws Exception {
+        insert.setString(1, identity.recordingId);
+        insert.setString(2, absolutePath);
+        insert.setString(3, identity.rootId);
+        insert.setString(4, identity.volumeId);
+        insert.setString(5, identity.relativePath);
+        insert.setInt(6, rank);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingsIndexVolumeMutationTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsIndexVolumeMutationTest.java
@@ -44,6 +44,13 @@ public class RecordingsIndexVolumeMutationTest {
         assertEquals(2, rows.size());
         assertEquals(rows.get(0).getString("filename"), rows.get(1).getString("filename"));
         assertNotEquals(rows.get(0).getString("id"), rows.get(1).getString("id"));
+        assertTrue(rows.get(0).getString("videoUrl").startsWith("/video/id/"));
+        assertTrue(rows.get(0).getString("thumbnailUrl").startsWith("/thumb/id/"));
+        assertTrue(rows.get(0).getString("deleteUrl").startsWith("/api/recordings/id/"));
+
+        String firstId = RecordingIdentity.fromFile(first).recordingId;
+        RecordingsIndex.RecordingRef exact = index.resolveById(firstId);
+        assertEquals(first.getAbsolutePath(), exact.absolutePath);
 
         assertTrue(index.removeByPath(first.getAbsolutePath()));
         assertEquals(1, index.queryCount(new RecordingsIndex.Filter()));

--- a/app/src/test/java/com/overdrive/app/server/RecordingsIndexVolumeMutationTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsIndexVolumeMutationTest.java
@@ -1,0 +1,109 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.util.List;
+
+public class RecordingsIndexVolumeMutationTest {
+    private Connection connection;
+
+    @After
+    public void closeConnection() throws Exception {
+        if (connection != null) connection.close();
+    }
+
+    @Test
+    public void duplicateFilenamesCanBeQueriedAndDeletedByPath() throws Exception {
+        RecordingsIndex index = newIndex("mutations");
+        Path firstDir = Files.createTempDirectory("recordings-volume-a");
+        Path secondDir = Files.createTempDirectory("recordings-volume-b");
+        File first = write(firstDir.resolve("cam_20260810_120000.mp4"));
+        File second = write(secondDir.resolve("cam_20260810_120000.mp4"));
+
+        assertTrue(index.upsert(first));
+        assertTrue(index.upsert(second));
+        assertEquals(2, index.queryCount(new RecordingsIndex.Filter()));
+
+        List<JSONObject> rows = index.queryRecordings(new RecordingsIndex.Filter(), 10, 0);
+        assertEquals(2, rows.size());
+        assertEquals(rows.get(0).getString("filename"), rows.get(1).getString("filename"));
+        assertNotEquals(rows.get(0).getString("id"), rows.get(1).getString("id"));
+
+        assertTrue(index.removeByPath(first.getAbsolutePath()));
+        assertEquals(1, index.queryCount(new RecordingsIndex.Filter()));
+        assertFalse(index.containsPath(first.getAbsolutePath()));
+        assertTrue(index.containsPath(second.getAbsolutePath()));
+    }
+
+    @Test
+    public void offlineRowsArePreservedButHiddenFromQueriesAndStats() throws Exception {
+        RecordingsIndex index = newIndex("offline");
+        Path firstDir = Files.createTempDirectory("recordings-online");
+        Path secondDir = Files.createTempDirectory("recordings-offline");
+        File online = write(firstDir.resolve("event_20260810_120000.mp4"));
+        File offline = write(secondDir.resolve("event_20260810_120001.mp4"));
+        assertTrue(index.upsert(online));
+        assertTrue(index.upsert(offline));
+
+        String offlineId = RecordingIdentity.fromFile(offline).recordingId;
+        try (PreparedStatement update = connection.prepareStatement(
+                "UPDATE recordings SET is_available=FALSE WHERE recording_id=?")) {
+            update.setString(1, offlineId);
+            update.executeUpdate();
+        }
+
+        assertEquals(1, index.queryCount(new RecordingsIndex.Filter()));
+        assertEquals(1, index.queryRecordings(new RecordingsIndex.Filter(), 10, 0).size());
+        RecordingsIndex.Stats stats = index.queryStats();
+        assertEquals(1L, stats.sentryCount);
+        try (PreparedStatement count = connection.prepareStatement(
+                "SELECT COUNT(*) FROM recordings")) {
+            try (java.sql.ResultSet result = count.executeQuery()) {
+                assertTrue(result.next());
+                assertEquals(2, result.getInt(1));
+            }
+        }
+    }
+
+    private RecordingsIndex newIndex(String name) throws Exception {
+        Class.forName("org.h2.Driver");
+        connection = DriverManager.getConnection(
+                "jdbc:h2:mem:volume_" + name + ";DB_CLOSE_DELAY=-1", "sa", "");
+        RecordingsIndexSchema.ensure(connection);
+
+        Constructor<RecordingsIndex> constructor = RecordingsIndex.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        RecordingsIndex index = constructor.newInstance();
+        setField(index, "connection", connection);
+        setField(index, "initialized", true);
+        setField(index, "everInitialized", true);
+        return index;
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = RecordingsIndex.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static File write(Path path) throws Exception {
+        Files.write(path, "video".getBytes(StandardCharsets.UTF_8));
+        return path.toFile();
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
@@ -21,9 +21,10 @@ public class RecordingsReconcileFreshnessTest {
 
         assertTrue(reconcile.contains("Map<String, RecordingFileFingerprint> diskFiles"));
         assertTrue(source.contains(
-                "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"));
+            "SELECT recording_id, filename, root_id, abs_path, size_bytes"));
         assertTrue(source.contains("fingerprint.decisionAgainst("));
         assertTrue(source.contains("if (upsert(fingerprint.file)) refreshed++"));
+        assertTrue(source.contains("RecordingReconcilePolicy.shouldDeleteMissingRow("));
         assertFalse(source.contains("private File locateFile("));
     }
 

--- a/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RecordingsReconcileFreshnessTest.java
@@ -1,0 +1,61 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingsReconcileFreshnessTest {
+
+    @Test
+    public void reconcileSnapshotsAndComparesStoredFingerprints() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/RecordingsIndex.java");
+        String reconcile = methodBody(source, "public void reconcile()");
+
+        assertTrue(reconcile.contains("Map<String, RecordingFileFingerprint> diskFiles"));
+        assertTrue(source.contains(
+                "SELECT filename, abs_path, size_bytes, mp4_mtime, sidecar_mtime"));
+        assertTrue(source.contains("fingerprint.decisionAgainst("));
+        assertTrue(source.contains("if (upsert(fingerprint.file)) refreshed++"));
+        assertFalse(source.contains("private File locateFile("));
+    }
+
+    private static String methodBody(String source, String signature) {
+        int start = source.indexOf(signature);
+        if (start < 0) throw new AssertionError("Could not locate " + signature);
+        int openingBrace = source.indexOf('{', start);
+        int depth = 0;
+        for (int i = openingBrace; i < source.length(); i++) {
+            char current = source.charAt(i);
+            if (current == '{') depth++;
+            if (current == '}' && --depth == 0) {
+                return source.substring(openingBrace, i + 1);
+            }
+        }
+        throw new AssertionError("Unbalanced method body for " + signature);
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/RecordingDirectoryRegistryTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/RecordingDirectoryRegistryTest.java
@@ -1,0 +1,48 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RecordingDirectoryRegistryTest {
+
+    @Test
+    public void recordingsAreActiveFirstAndIncludeBothLegacyLayouts() {
+        File active = new File("/active/recordings");
+        File internal = new File("/internal/recordings");
+
+        assertEquals(List.of(
+                active.getAbsolutePath(),
+                internal.getAbsolutePath(),
+                RecordingDirectoryRegistry.LEGACY_RECORDINGS,
+                RecordingDirectoryRegistry.LEGACY_BASE
+        ), paths(RecordingDirectoryRegistry.recordings(active, internal, null, null)));
+    }
+
+    @Test
+    public void categoryRegistriesIncludeTheirLegacyRoots() {
+        assertEquals(List.of(RecordingDirectoryRegistry.LEGACY_SENTRY),
+                paths(RecordingDirectoryRegistry.surveillance(null, null, null, null)));
+        assertEquals(List.of(RecordingDirectoryRegistry.LEGACY_PROXIMITY),
+                paths(RecordingDirectoryRegistry.proximity(null, null, null, null)));
+    }
+
+    @Test
+    public void duplicatePathsAreReturnedOnce() {
+        File same = new File("/same/recordings");
+
+        List<File> directories = RecordingDirectoryRegistry.recordings(
+                same, same, same, same);
+
+        assertEquals(3, directories.size());
+        assertEquals(same.getAbsolutePath(), directories.get(0).getAbsolutePath());
+    }
+
+    private static List<String> paths(List<File> directories) {
+        return directories.stream().map(File::getAbsolutePath).collect(Collectors.toList());
+    }
+}

--- a/app/src/test/java/com/overdrive/app/storage/StorageManagerMp4ListingTest.java
+++ b/app/src/test/java/com/overdrive/app/storage/StorageManagerMp4ListingTest.java
@@ -1,0 +1,80 @@
+package com.overdrive.app.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+
+public class StorageManagerMp4ListingTest {
+
+    @Test
+    public void missingRootIsUnavailableAndIncomplete() throws Exception {
+        StorageManager manager = allocateWithoutConstructor();
+        File missing = new File(Files.createTempDirectory("missing-root").toFile(), "gone");
+
+        StorageManager.Mp4Listing listing = manager.listMp4FilesWithStatus(missing);
+
+        assertFalse(listing.available);
+        assertFalse(listing.complete);
+        assertEquals(0, listing.files.length);
+    }
+
+    @Test
+    public void directListingIsAvailableCompleteAndFiltered() throws Exception {
+        StorageManager manager = allocateWithoutConstructor();
+        Path directory = Files.createTempDirectory("complete-root");
+        Files.write(directory.resolve("cam.mp4"), "video".getBytes(StandardCharsets.UTF_8));
+        Files.write(directory.resolve("cam.json"), "{}".getBytes(StandardCharsets.UTF_8));
+
+        StorageManager.Mp4Listing listing =
+                manager.listMp4FilesWithStatus(directory.toFile());
+
+        assertTrue(listing.available);
+        assertTrue(listing.complete);
+        assertEquals(1, listing.files.length);
+        assertEquals("cam.mp4", listing.files[0].getName());
+    }
+
+    @Test
+    public void stuckDirectListingReturnsAtDeadline() {
+        File blocking = new File("/blocking") {
+            private final CountDownLatch never = new CountDownLatch(1);
+
+            @Override
+            public File[] listFiles(java.io.FileFilter filter) {
+                try {
+                    never.await();
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            }
+        };
+        long started = System.nanoTime();
+
+        StorageManager.FileListResult result = StorageManager.listFilesDirectWithStatus(
+                blocking, file -> true, 25L);
+
+        long elapsedMs = (System.nanoTime() - started) / 1_000_000L;
+        assertFalse(result.complete);
+        assertEquals(0, result.files.length);
+        assertTrue("bounded listing took " + elapsedMs + "ms", elapsedMs < 1_000L);
+    }
+
+    private static StorageManager allocateWithoutConstructor() throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        return (StorageManager) unsafeClass.getMethod("allocateInstance", Class.class)
+                .invoke(unsafe, StorageManager.class);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/RecordingIdentityClientContractTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/RecordingIdentityClientContractTest.java
@@ -1,0 +1,63 @@
+package com.overdrive.app.ui;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RecordingIdentityClientContractTest {
+
+    @Test
+    public void nativeDeletePrefersRecordingIdentity() throws IOException {
+        String model = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/model/RecordingFile.kt");
+        String client = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/util/RecordingsApiClient.kt");
+        String scanner = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/util/RecordingScanner.kt");
+
+        assertTrue(model.contains("val recordingId: String? = null"));
+        assertTrue(client.contains("/api/recordings/id/${enc(id)}"));
+        assertTrue(client.contains("recordingId = rec.optString(\"id\")"));
+        assertTrue(scanner.contains("RecordingsApiClient.deleteRecording(recording)"));
+    }
+
+    @Test
+    public void webMirrorsUseStableKeysAndServerActionUrls() throws IOException {
+        byte[] shared = readRepositoryBytes("app/src/main/assets/web/shared/events.js");
+        byte[] local = readRepositoryBytes("app/src/main/assets/web/local/shared/events.js");
+        assertArrayEquals(shared, local);
+
+        String script = new String(shared, StandardCharsets.UTF_8);
+        assertTrue(script.contains("return rec && rec.id ? rec.id"));
+        assertTrue(script.contains("data-recording-key="));
+        assertTrue(script.contains("const deleteUrl = rec.deleteUrl"));
+        assertTrue(script.contains("const eventUrl = recording.eventUrl"));
+        assertTrue(script.contains("const payload = { ids: ids, filenames: filenames }"));
+        assertFalse(script.contains("this.selectedFiles.add(rec.filename)"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        return new String(readRepositoryBytes(relativePath), StandardCharsets.UTF_8);
+    }
+
+    private static byte[] readRepositoryBytes(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) return Files.readAllBytes(candidate);
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) return Files.readAllBytes(fromModule);
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Dependency

This PR is intentionally stacked on #217 and includes its commits in the current GitHub diff. **Merge #217 first**, then rebase this branch onto the updated `main` before merging.

PR #216 also changes `RecordingsIndex`; whichever PR merges second will need a rebase and conflict-resolution pass while preserving both reconcile coalescing and the volume-aware schema.

## Problem

The recordings index currently treats `filename` as a globally unique key. Equal filenames on internal, SD, and USB storage can overwrite or address the wrong row. Reconciliation also cannot distinguish a truly deleted recording from a temporarily unavailable or partially scanned volume, so unplugging storage can discard useful metadata.

Filename-only media, timeline, and delete routes carry the same ambiguity into native and web clients.

## Changes

- introduce a schema-v4 recording identity derived from normalized volume identity and relative path
- migrate existing v3 rows while preserving metadata and rebuilding the derived index cleanly if migration cannot complete
- allow equal filenames on different volumes to coexist
- retain offline-volume rows while hiding unavailable recordings from normal lists, counts, dates, places, and statistics
- delete missing rows only after a complete scan of an available root
- bound direct and shell-backed directory enumeration
- remove known recordings by exact path rather than filename
- add exact ID video, thumbnail, timeline, single-delete, and batch-delete routes
- retain deterministic active-first filename routes for compatibility with older clients and notifications
- isolate generated thumbnail caches by recording ID
- propagate row IDs and action URLs through native and web clients
- support mixed ID/legacy filename batch deletion and optional `?id` web deep links
- replace only a trailing `.mp4` suffix when resolving legacy event sidecars

## Compatibility and scope

The H2 database is a derived index, so the migration fallback deliberately favors a clean rebuild over retaining an unusable database. Existing filename routes remain available while clients transition to exact IDs.

This PR does not change Android storage permissions, storage ownership, MediaStore integration, or BYD vendor mount fallbacks. Those changes require separate device and Perfetto validation.

## Commits

1. `feat(recordings): add volume-aware index identity`
2. `feat(recordings): add exact ID media routes`
3. `feat(recordings): adopt stable row IDs in clients`

Each commit contains its own detailed rationale, implementation notes, and focused test command.

## Validation

```bash
ANDROID_HOME="$HOME/aurora/artifacts/android-sdk" \
ANDROID_SDK_ROOT="$HOME/aurora/artifacts/android-sdk" \
./gradlew :app:testDebugUnitTest \
  --tests com.overdrive.app.server.RecordingIdentityTest \
  --tests com.overdrive.app.server.RecordingsIndexSchemaTest \
  --tests com.overdrive.app.server.RecordingsIndexVolumeMutationTest \
  --tests com.overdrive.app.server.RecordingReconcilePolicyTest \
  --tests com.overdrive.app.storage.StorageManagerMp4ListingTest \
  --tests com.overdrive.app.server.RecordingIdApiContractTest \
  --tests com.overdrive.app.ui.RecordingIdentityClientContractTest \
  --tests com.overdrive.app.server.RecordingsReconcileFreshnessTest

ANDROID_HOME="$HOME/aurora/artifacts/android-sdk" \
ANDROID_SDK_ROOT="$HOME/aurora/artifacts/android-sdk" \
./gradlew :app:testDebugUnitTest

node --check app/src/main/assets/web/shared/events.js
node --check app/src/main/assets/web/local/shared/events.js
cmp -s app/src/main/assets/web/shared/events.js app/src/main/assets/web/local/shared/events.js
git diff --check 887ef6ab...HEAD
```

All commands pass. Gradle continues to report the pre-existing warning that `minSdkVersion` 28 is greater than `targetSdkVersion` 25.
