### PR TITLE
feat: allow editing total cost of a completed charging session

### DIFF
--- a/app/src/main/assets/web/i18n/en.json
+++ b/app/src/main/assets/web/i18n/en.json
@@ -632,7 +632,12 @@
     "tariff_fallback_global": "Charges outside every tariff use {rate}/kWh.",
     "tariff_auto_hint": "Saved. Charges within {radius} m of here will use this tariff automatically.",
     "tariff_label_placeholder": "Home",
-    "per_kwh_unit": "/kWh"
+    "per_kwh_unit": "/kWh",
+    "edit_cost_prompt": "Enter total cost of this charge (leave empty to reset):",
+    "cannot_edit_in_progress_cost": "Cannot edit cost of an in-progress session",
+    "invalid_cost": "Please enter a valid non-negative number",
+    "cost_updated": "Cost updated",
+    "cost_update_failed": "Could not update cost"
   },
   "trip": {
     "tab_trips": "Trips",

--- a/app/src/main/assets/web/local/charging.html
+++ b/app/src/main/assets/web/local/charging.html
@@ -413,6 +413,15 @@
         }
         .ch-stat span { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; }
         .ch-stat strong { font-size: 18px; font-weight: 700; color: var(--text-primary); }
+        .ch-stat.interactive {
+            cursor: pointer;
+            transition: background 0.15s, border-color 0.15s;
+            border: 1px solid transparent;
+        }
+        .ch-stat.interactive:hover {
+            background: var(--bg-hover);
+            border-color: var(--border-subtle);
+        }
 
         .load-more-btn {
             display: block;
@@ -876,7 +885,16 @@
                             <div class="ch-stat"><span data-i18n="charge.detail_peak_power">Peak power</span><strong id="detailPeakPower">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_range_gained">Range gained</span><strong id="detailRangeGained">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_odometer">Odometer</span><strong id="detailOdometer">--</strong></div>
-                            <div class="ch-stat"><span data-i18n="charge.detail_cost">Cost</span><strong id="detailCost">--</strong></div>
+                            <div class="ch-stat interactive" onclick="CHARGING.editCost()" title="Edit cost">
+                                <span style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
+                                    <span data-i18n="charge.detail_cost" style="margin-bottom: 0;">Cost</span>
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;color:var(--text-muted);"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                </span>
+                                <div>
+                                    <strong id="detailCost">--</strong>
+                                    <span id="detailCostRate" style="font-size: 11px; font-weight: normal; color: var(--text-muted); display: inline-block; margin-left: 4px;"></span>
+                                </div>
+                            </div>
                             <!-- Hidden unless the session was priced by a named tariff. -->
                             <div class="ch-stat" id="detailTariffStat" style="display:none;"><span data-i18n="charge.detail_tariff">Tariff</span><strong id="detailTariff">--</strong></div>
                             <div class="ch-stat"><span data-i18n="charge.detail_type">Type</span><strong id="detailType">--</strong></div>

--- a/app/src/main/assets/web/shared/charging.js
+++ b/app/src/main/assets/web/shared/charging.js
@@ -1212,10 +1212,7 @@ var CHARGING = {
         if (detail) { detail.classList.remove('hidden'); detail.classList.add('active'); }
 
         // Find the row we already have for the header; fetch full + samples.
-        var row = null;
-        for (var i = 0; i < this.sessions.length; i++) {
-            if (this.sessions[i].id === id) { row = this.sessions[i]; break; }
-        }
+        var row = this._getSession(id);
         if (row) this._fillDetailHeader(row, id);
 
         this._fetchJson('/api/charging/' + id)
@@ -1352,7 +1349,8 @@ var CHARGING = {
         this._setText('detailPeakPower', displayedPeak > 0 ? displayedPeak.toFixed(1) + ' kW' : '--');
         this._setText('detailRangeGained', (s.rangeGained != null && s.rangeGained > 0) ? this._dist(s.rangeGained) : '--');
         this._setText('detailOdometer', (s.startOdometerKm != null && s.startOdometerKm > 0) ? this._dist(s.startOdometerKm) : '--');
-        this._setText('detailCost', (s.cost != null && s.cost > 0) ? this._money(s.cost) : '--');
+        this._setText('detailCost', (s.cost != null && s.cost >= 0) ? this._money(s.cost) : '--');
+        this._setText('detailCostRate', (s.cost != null && s.cost >= 0 && s.electricityRate != null && s.electricityRate >= 0 && !s.tariffLabel) ? '(' + this._money(s.electricityRate) + this._t('charge.per_kwh', '/kWh') + ')' : '');
         this._setText('detailType', this._typeLabel(s));
         this._setText('detailTimeToFull', (chargingNow
                 && s.timeToFullMin != null && s.timeToFullMin > 0)
@@ -1489,6 +1487,72 @@ var CHARGING = {
               // remain dirty and the user can correct/retry in place.
               self._refreshConfigDirty();
           });
+    },
+
+    editCost: async function () {
+        var self = this;
+        if (this.currentSessionId == null) return;
+        
+        var s = this._getSession(this.currentSessionId);
+        if (!s) return;
+        
+        if (s.endTime == null || s.endTime <= 0) {
+            this._toast(this._t('charge.cannot_edit_in_progress_cost', 'Cannot edit cost of an in-progress session'), 'error');
+            return;
+        }
+
+        var oldCostVal = (s.cost != null && s.cost >= 0) ? s.cost.toFixed(2) : '';
+        var msg = this._t('charge.edit_cost_prompt', 'Enter total cost of this charge (leave empty to reset):');
+        
+        var input;
+        if (window.BYD && BYD.utils && typeof BYD.utils.promptDialog === 'function') {
+            input = await BYD.utils.promptDialog({
+                title: this._t('charge.detail_cost', 'Cost'),
+                body: msg,
+                value: oldCostVal,
+                placeholder: '0.00'
+            });
+        } else {
+            input = window.prompt(msg, oldCostVal);
+        }
+        if (input === null) return;
+        
+        var newCost = parseFloat(input.trim());
+        if (input.trim() === '') {
+            newCost = -1;
+        } else if (isNaN(newCost) || newCost < 0) {
+            this._toast(this._t('charge.invalid_cost', 'Please enter a valid non-negative number'), 'error');
+            return;
+        }
+
+        var currentCost = (s.cost != null && s.cost >= 0) ? s.cost : -1;
+        if (newCost === currentCost) return;
+
+        var showError = function () {
+            self._toast(self._t('charge.cost_update_failed', 'Could not update cost'), 'error');
+        };
+        
+        fetch('/api/charging/' + this.currentSessionId + '/cost', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cost: newCost })
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            if (d && d.success) {
+                self._toast(self._t('charge.cost_updated', 'Cost updated'));
+                s.cost = newCost >= 0 ? newCost : null;
+                s.electricityRate = (newCost >= 0 && s.energyAdded != null && s.energyAdded > 0) ? (newCost / s.energyAdded) : null;
+                s.tariffId = null;
+                s.tariffLabel = null;
+                self._renderSessionCards();
+                self._fillDetailHeader(s);
+                self.loadSummary();
+            } else {
+                showError();
+            }
+        })
+        .catch(showError);
     },
 
     deleteCurrent: function () {
@@ -2999,6 +3063,13 @@ var CHARGING = {
         }
         this.loadTariffs();
         this._loadCurrentLivePair();
+    },
+
+    _getSession: function (id) {
+        for (var i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i] && this.sessions[i].id === id) return this.sessions[i];
+        }
+        return null;
     },
 
     // ==================== FORMAT / DOM HELPERS ====================

--- a/app/src/main/assets/web/shared/core.js
+++ b/app/src/main/assets/web/shared/core.js
@@ -1883,6 +1883,121 @@ BYD.utils.confirmDialog = function (opts) {
     });
 };
 
+/**
+ * Themed text input prompt. Returns a Promise<string|null> resolving with the input value,
+ * or null when canceled.
+ */
+BYD.utils.promptDialog = function (opts) {
+    opts = opts || {};
+    var t = BYD.i18n && BYD.i18n.t ? BYD.i18n.t.bind(BYD.i18n) : null;
+    return new Promise(function (resolve) {
+        BYD.utils._ensureModalEscHandler();
+
+        var backdrop = document.createElement('div');
+        backdrop.className = 'modal-backdrop';
+        backdrop.setAttribute('role', 'presentation');
+        backdrop.style.display = 'flex';
+
+        var card = document.createElement('div');
+        card.className = 'modal-card';
+        card.setAttribute('role', 'dialog');
+        card.setAttribute('aria-modal', 'true');
+
+        if (opts.title) {
+            var h = document.createElement('h3');
+            h.className = 'soh-modal-title';
+            h.textContent = opts.title;
+            card.appendChild(h);
+        }
+        if (opts.body) {
+            var p = document.createElement('p');
+            p.style.margin = '0 0 12px 0';
+            p.style.fontSize = '14px';
+            p.style.lineHeight = '1.5';
+            p.style.color = 'var(--text-secondary, var(--text-primary))';
+            p.style.whiteSpace = 'pre-wrap';
+            p.textContent = opts.body;
+            card.appendChild(p);
+        }
+
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.value = opts.value || '';
+        input.placeholder = opts.placeholder || '';
+        input.style.width = '100%';
+        input.style.boxSizing = 'border-box';
+        input.style.padding = '10px 12px';
+        input.style.marginBottom = '18px';
+        input.style.border = '1px solid var(--border-subtle, #ccc)';
+        input.style.borderRadius = 'var(--radius-md, 8px)';
+        input.style.background = 'var(--bg-surface, #fff)';
+        input.style.color = 'var(--text-primary, #000)';
+        input.style.fontSize = '15px';
+        input.style.outline = 'none';
+        input.addEventListener('focus', function () {
+            input.style.borderColor = 'var(--brand-primary, #007AFF)';
+        });
+        input.addEventListener('blur', function () {
+            input.style.borderColor = 'var(--border-subtle, #ccc)';
+        });
+        card.appendChild(input);
+
+        var actions = document.createElement('div');
+        actions.className = 'soh-modal-actions';
+
+        var cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn btn-secondary';
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = opts.cancelLabel || (t && t('common.cancel')) || 'Cancel';
+        cancelBtn.addEventListener('click', function () { dismiss(null); });
+        actions.appendChild(cancelBtn);
+
+        var confirmBtn = document.createElement('button');
+        confirmBtn.className = 'btn btn-primary';
+        confirmBtn.type = 'button';
+        confirmBtn.textContent = opts.confirmLabel || (t && t('common.ok')) || 'OK';
+        confirmBtn.addEventListener('click', function () { dismiss(input.value); });
+        actions.appendChild(confirmBtn);
+
+        input.addEventListener('keydown', function (ev) {
+            if (ev.key === 'Enter') {
+                ev.preventDefault();
+                dismiss(input.value);
+            }
+        });
+
+        card.appendChild(actions);
+        backdrop.appendChild(card);
+
+        backdrop.addEventListener('click', function (ev) {
+            if (ev.target === backdrop) dismiss(null);
+        });
+
+        var prevFocus = document.activeElement;
+        document.body.appendChild(backdrop);
+
+        try {
+            input.focus();
+            if (opts.value) {
+                input.setSelectionRange(input.value.length, input.value.length);
+            }
+        } catch (e) {}
+
+        var entry = { dismiss: function () { dismiss(null); } };
+        BYD.utils._modalStack.push(entry);
+
+        function dismiss(result) {
+            if (entry._done) return;
+            entry._done = true;
+            try { backdrop.remove(); } catch (e) {}
+            try { if (prevFocus && prevFocus.focus) prevFocus.focus(); } catch (e) {}
+            var idx = BYD.utils._modalStack.indexOf(entry);
+            if (idx !== -1) BYD.utils._modalStack.splice(idx, 1);
+            resolve(result);
+        }
+    });
+};
+
 // Auto-load the language picker on every page that includes core.js so we
 // don't have to touch every HTML file. Picker mounts itself once the DOM is
 // ready and a sidebar-footer is found (login page has no sidebar — picker

--- a/app/src/main/assets/web/shared/core.js
+++ b/app/src/main/assets/web/shared/core.js
@@ -1784,13 +1784,45 @@ BYD.utils._showModal = function (opts) {
         }
         if (opts.body) {
             var p = document.createElement('p');
-            p.style.margin = '0 0 4px 0';
+            p.style.margin = opts.prompt ? '0 0 12px 0' : '0 0 4px 0';
             p.style.fontSize = '14px';
             p.style.lineHeight = '1.5';
             p.style.color = 'var(--text-secondary, var(--text-primary))';
             p.style.whiteSpace = 'pre-wrap';
             p.textContent = opts.body;
             card.appendChild(p);
+        }
+
+        var input = null;
+        if (opts.prompt) {
+            input = document.createElement('input');
+            input.type = 'text';
+            input.value = opts.promptValue || '';
+            input.placeholder = opts.promptPlaceholder || '';
+            input.style.width = '100%';
+            input.style.boxSizing = 'border-box';
+            input.style.padding = '10px 12px';
+            input.style.marginBottom = '18px';
+            input.style.border = '1px solid var(--border-subtle, #ccc)';
+            input.style.borderRadius = 'var(--radius-md, 8px)';
+            input.style.background = 'var(--bg-surface, #fff)';
+            input.style.color = 'var(--text-primary, #000)';
+            input.style.fontSize = '15px';
+            input.style.outline = 'none';
+            input.addEventListener('focus', function () {
+                input.style.borderColor = 'var(--brand-primary, #007AFF)';
+            });
+            input.addEventListener('blur', function () {
+                input.style.borderColor = 'var(--border-subtle, #ccc)';
+            });
+            card.appendChild(input);
+
+            input.addEventListener('keydown', function (ev) {
+                if (ev.key === 'Enter') {
+                    ev.preventDefault();
+                    dismiss(true);
+                }
+            });
         }
 
         var actions = document.createElement('div');
@@ -1826,10 +1858,18 @@ BYD.utils._showModal = function (opts) {
         var prevFocus = document.activeElement;
         document.body.appendChild(backdrop);
 
-        // Focus the primary action so Enter confirms without an extra tap.
-        try { confirmBtn.focus(); } catch (e) {}
+        try {
+            if (input) {
+                input.focus();
+                if (opts.promptValue) {
+                    input.setSelectionRange(opts.promptValue.length, opts.promptValue.length);
+                }
+            } else {
+                confirmBtn.focus();
+            }
+        } catch (e) {}
 
-        var entry = { dismiss: dismiss };
+        var entry = { dismiss: function () { dismiss(false); } };
         BYD.utils._modalStack.push(entry);
 
         function dismiss(result) {
@@ -1841,7 +1881,12 @@ BYD.utils._showModal = function (opts) {
             // Pop from stack if still there (e.g. button click path).
             var idx = BYD.utils._modalStack.indexOf(entry);
             if (idx !== -1) BYD.utils._modalStack.splice(idx, 1);
-            resolve(result);
+            
+            if (opts.prompt) {
+                resolve(result ? input.value : null);
+            } else {
+                resolve(result);
+            }
         }
     });
 };
@@ -1890,111 +1935,14 @@ BYD.utils.confirmDialog = function (opts) {
 BYD.utils.promptDialog = function (opts) {
     opts = opts || {};
     var t = BYD.i18n && BYD.i18n.t ? BYD.i18n.t.bind(BYD.i18n) : null;
-    return new Promise(function (resolve) {
-        BYD.utils._ensureModalEscHandler();
-
-        var backdrop = document.createElement('div');
-        backdrop.className = 'modal-backdrop';
-        backdrop.setAttribute('role', 'presentation');
-        backdrop.style.display = 'flex';
-
-        var card = document.createElement('div');
-        card.className = 'modal-card';
-        card.setAttribute('role', 'dialog');
-        card.setAttribute('aria-modal', 'true');
-
-        if (opts.title) {
-            var h = document.createElement('h3');
-            h.className = 'soh-modal-title';
-            h.textContent = opts.title;
-            card.appendChild(h);
-        }
-        if (opts.body) {
-            var p = document.createElement('p');
-            p.style.margin = '0 0 12px 0';
-            p.style.fontSize = '14px';
-            p.style.lineHeight = '1.5';
-            p.style.color = 'var(--text-secondary, var(--text-primary))';
-            p.style.whiteSpace = 'pre-wrap';
-            p.textContent = opts.body;
-            card.appendChild(p);
-        }
-
-        var input = document.createElement('input');
-        input.type = 'text';
-        input.value = opts.value || '';
-        input.placeholder = opts.placeholder || '';
-        input.style.width = '100%';
-        input.style.boxSizing = 'border-box';
-        input.style.padding = '10px 12px';
-        input.style.marginBottom = '18px';
-        input.style.border = '1px solid var(--border-subtle, #ccc)';
-        input.style.borderRadius = 'var(--radius-md, 8px)';
-        input.style.background = 'var(--bg-surface, #fff)';
-        input.style.color = 'var(--text-primary, #000)';
-        input.style.fontSize = '15px';
-        input.style.outline = 'none';
-        input.addEventListener('focus', function () {
-            input.style.borderColor = 'var(--brand-primary, #007AFF)';
-        });
-        input.addEventListener('blur', function () {
-            input.style.borderColor = 'var(--border-subtle, #ccc)';
-        });
-        card.appendChild(input);
-
-        var actions = document.createElement('div');
-        actions.className = 'soh-modal-actions';
-
-        var cancelBtn = document.createElement('button');
-        cancelBtn.className = 'btn btn-secondary';
-        cancelBtn.type = 'button';
-        cancelBtn.textContent = opts.cancelLabel || (t && t('common.cancel')) || 'Cancel';
-        cancelBtn.addEventListener('click', function () { dismiss(null); });
-        actions.appendChild(cancelBtn);
-
-        var confirmBtn = document.createElement('button');
-        confirmBtn.className = 'btn btn-primary';
-        confirmBtn.type = 'button';
-        confirmBtn.textContent = opts.confirmLabel || (t && t('common.ok')) || 'OK';
-        confirmBtn.addEventListener('click', function () { dismiss(input.value); });
-        actions.appendChild(confirmBtn);
-
-        input.addEventListener('keydown', function (ev) {
-            if (ev.key === 'Enter') {
-                ev.preventDefault();
-                dismiss(input.value);
-            }
-        });
-
-        card.appendChild(actions);
-        backdrop.appendChild(card);
-
-        backdrop.addEventListener('click', function (ev) {
-            if (ev.target === backdrop) dismiss(null);
-        });
-
-        var prevFocus = document.activeElement;
-        document.body.appendChild(backdrop);
-
-        try {
-            input.focus();
-            if (opts.value) {
-                input.setSelectionRange(input.value.length, input.value.length);
-            }
-        } catch (e) {}
-
-        var entry = { dismiss: function () { dismiss(null); } };
-        BYD.utils._modalStack.push(entry);
-
-        function dismiss(result) {
-            if (entry._done) return;
-            entry._done = true;
-            try { backdrop.remove(); } catch (e) {}
-            try { if (prevFocus && prevFocus.focus) prevFocus.focus(); } catch (e) {}
-            var idx = BYD.utils._modalStack.indexOf(entry);
-            if (idx !== -1) BYD.utils._modalStack.splice(idx, 1);
-            resolve(result);
-        }
+    return BYD.utils._showModal({
+        title: opts.title || (t && t('common.notice')) || 'Notice',
+        body: opts.body || '',
+        confirmLabel: opts.confirmLabel || (t && t('common.ok')) || 'OK',
+        cancelLabel: opts.cancelLabel || (t && t('common.cancel')) || 'Cancel',
+        prompt: true,
+        promptValue: opts.value || '',
+        promptPlaceholder: opts.placeholder || ''
     });
 };
 

--- a/app/src/main/java/com/overdrive/app/charging/ChargingApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/charging/ChargingApiHandler.java
@@ -39,6 +39,7 @@ public class ChargingApiHandler {
     private static final Pattern SESSION_SAMPLES_PATTERN = Pattern.compile("^/api/charging/(\\d+)/samples$");
     // POST fallback for per-session delete (the in-app WebView can drop DELETE).
     private static final Pattern SESSION_DELETE_PATTERN = Pattern.compile("^/api/charging/(\\d+)/delete$");
+    private static final Pattern SESSION_COST_PATTERN = Pattern.compile("^/api/charging/(\\d+)/cost$");
 
     private final ChargingSessionManager manager;
     private final Supplier<TripAnalyticsManager>
@@ -129,6 +130,13 @@ public class ChargingApiHandler {
             if (delMatcher.matches() && "POST".equals(method)) {
                 long id = Long.parseLong(delMatcher.group(1));
                 return handleDeleteSession(id);
+            }
+
+            // POST /api/charging/{id}/cost — update cost
+            Matcher costMatcher = SESSION_COST_PATTERN.matcher(path);
+            if (costMatcher.matches() && "POST".equals(method)) {
+                long id = Long.parseLong(costMatcher.group(1));
+                return handleUpdateSessionCost(id, body);
             }
 
             // GET/DELETE /api/charging/{id}
@@ -442,6 +450,31 @@ public class ChargingApiHandler {
         } catch (Exception e) {
             logger.error("Error deleting charging session " + id, e);
             return errorResponse("Failed to delete session", 500);
+        }
+    }
+
+    /** POST /api/charging/{id}/cost — update cost of a completed session. */
+    private JSONObject handleUpdateSessionCost(long id, String body) {
+        try {
+            JSONObject bodyJson;
+            try {
+                bodyJson = new JSONObject(body != null ? body : "{}");
+            } catch (org.json.JSONException je) {
+                return errorResponse("Invalid JSON payload", 400);
+            }
+            if (!bodyJson.has("cost")) {
+                return errorResponse("Missing 'cost' parameter", 400);
+            }
+            double cost = bodyJson.getDouble("cost");
+            boolean ok = db().updateChargingSessionCost(id, cost);
+            if (!ok) return errorResponse("Failed to update session cost (session may be in progress or not found)", 500);
+            
+            JSONObject response = new JSONObject();
+            response.put("success", true);
+            return response;
+        } catch (Exception e) {
+            logger.error("Error updating cost for session " + id, e);
+            return errorResponse("Failed to update cost: " + e.getMessage(), 500);
         }
     }
 

--- a/app/src/main/java/com/overdrive/app/logging/DaemonLogger.java
+++ b/app/src/main/java/com/overdrive/app/logging/DaemonLogger.java
@@ -212,20 +212,22 @@ public class DaemonLogger {
         
         // Console log if enabled (standard Android Log for app context)
         if (globalConfig.enableConsoleLog) {
-            switch (level) {
-                case DEBUG:
-                    Log.d(tag, message);
-                    break;
-                case INFO:
-                    Log.i(tag, message);
-                    break;
-                case WARN:
-                    Log.w(tag, message);
-                    break;
-                case ERROR:
-                    Log.e(tag, message);
-                    break;
-            }
+            try {
+                switch (level) {
+                    case DEBUG:
+                        Log.d(tag, message);
+                        break;
+                    case INFO:
+                        Log.i(tag, message);
+                        break;
+                    case WARN:
+                        Log.w(tag, message);
+                        break;
+                    case ERROR:
+                        Log.e(tag, message);
+                        break;
+                }
+            } catch (Throwable ignored) {}
         }
         
         // Print to stdout for daemon processes running via app_process.

--- a/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
+++ b/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
@@ -10394,7 +10394,12 @@ public class SocHistoryDatabase {
      */
     public synchronized boolean updateChargingSessionCost(long id, double newCost) {
         if (!isInitialized || connection == null) return false;
+        boolean priorAutoCommit = false;
+        boolean committed = false;
         try {
+            priorAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+
             long startTime = -1, endTime = 0;
             double energyAdded = 0;
             double oldCost = 0;
@@ -10407,27 +10412,20 @@ public class SocHistoryDatabase {
                         endTime = rs.getLong("end_time");
                         if (endTime == 0 || endTime <= startTime) {
                             logger.warn("updateChargingSessionCost: cannot edit cost of an in-progress session " + id);
-                            return false; // cannot edit in-progress session
+                            return false;
                         }
                         double energyRead = rs.getDouble("energy_added_kwh");
                         energyAdded = (rs.wasNull() || energyRead < 0) ? 0 : energyRead;
                         double costRead = rs.getDouble("session_cost");
                         oldCost = (rs.wasNull() || costRead < 0) ? 0 : costRead;
                     } else {
-                        return false; // not found
+                        return false;
                     }
                 }
             }
 
-            // Calculate the new rate
-            double newRate;
-            if (newCost < 0) {
-                newRate = -1;
-            } else {
-                newRate = (energyAdded > 0) ? (newCost / energyAdded) : 0;
-            }
+            double newRate = (newCost < 0) ? -1 : ((energyAdded > 0) ? (newCost / energyAdded) : 0);
 
-            // Update the session rate, cost, and clear tariff fields in charging_sessions
             try (PreparedStatement updSession = connection.prepareStatement(
                     "UPDATE " + TABLE_CHARGING + " SET electricity_rate = ?, session_cost = ?, tariff_id = '', tariff_label = '' WHERE id = ?;")) {
                 updSession.setDouble(1, newRate);
@@ -10436,25 +10434,31 @@ public class SocHistoryDatabase {
                 updSession.executeUpdate();
             }
 
-            // Adjust the daily rollup if there's a non-zero change
-            long dayBasis = endTime > 0 ? endTime : startTime;
-            if (dayBasis > 0) {
-                double delta = (newCost >= 0 ? newCost : 0) - (oldCost >= 0 ? oldCost : 0);
-                if (delta != 0) {
-                    long day = (dayBasis / 86_400_000L) * 86_400_000L;
-                    try (PreparedStatement updDaily = connection.prepareStatement(
-                            "UPDATE " + TABLE_CHARGING_DAILY + " SET cost = GREATEST(cost + ?, 0) WHERE day_epoch = ?;")) {
-                        updDaily.setDouble(1, delta);
-                        updDaily.setLong(2, day);
-                        updDaily.executeUpdate();
-                    }
+            double delta = (newCost >= 0 ? newCost : 0) - (oldCost >= 0 ? oldCost : 0);
+            if (delta != 0 && endTime > 0) {
+                long day = (endTime / 86_400_000L) * 86_400_000L;
+                try (PreparedStatement updDaily = connection.prepareStatement(
+                        "UPDATE " + TABLE_CHARGING_DAILY + " SET cost = GREATEST(cost + ?, 0) WHERE day_epoch = ?;")) {
+                    updDaily.setDouble(1, delta);
+                    updDaily.setLong(2, day);
+                    updDaily.executeUpdate();
                 }
             }
+
+            connection.commit();
+            committed = true;
             logger.info("Updated charging session " + id + " to cost " + newCost + ", calculated rate " + newRate);
             return true;
         } catch (Exception e) {
             logger.error("updateChargingSessionCost failed for " + id, e);
             return false;
+        } finally {
+            if (!committed && connection != null) {
+                try { connection.rollback(); } catch (Exception ignored) {}
+            }
+            if (connection != null) {
+                try { connection.setAutoCommit(priorAutoCommit); } catch (Exception ignored) {}
+            }
         }
     }
 

--- a/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
+++ b/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
@@ -10388,6 +10388,77 @@ public class SocHistoryDatabase {
     }
 
     /**
+     * Update the total cost of a single charging session, recalculate its
+     * rate (cost per kWh), clear any location-based tariff fields (as it's now a manual cost),
+     * and adjust the daily rollup so lifetime / monthly-cost totals stay consistent.
+     */
+    public synchronized boolean updateChargingSessionCost(long id, double newCost) {
+        if (!isInitialized || connection == null) return false;
+        try {
+            long startTime = -1, endTime = 0;
+            double energyAdded = 0;
+            double oldCost = 0;
+            try (PreparedStatement sel = connection.prepareStatement(
+                    "SELECT start_time, end_time, energy_added_kwh, session_cost FROM " + TABLE_CHARGING + " WHERE id = ?;")) {
+                sel.setLong(1, id);
+                try (ResultSet rs = sel.executeQuery()) {
+                    if (rs.next()) {
+                        startTime = rs.getLong("start_time");
+                        endTime = rs.getLong("end_time");
+                        if (endTime == 0 || endTime <= startTime) {
+                            logger.warn("updateChargingSessionCost: cannot edit cost of an in-progress session " + id);
+                            return false; // cannot edit in-progress session
+                        }
+                        double energyRead = rs.getDouble("energy_added_kwh");
+                        energyAdded = (rs.wasNull() || energyRead < 0) ? 0 : energyRead;
+                        double costRead = rs.getDouble("session_cost");
+                        oldCost = (rs.wasNull() || costRead < 0) ? 0 : costRead;
+                    } else {
+                        return false; // not found
+                    }
+                }
+            }
+
+            // Calculate the new rate
+            double newRate;
+            if (newCost < 0) {
+                newRate = -1;
+            } else {
+                newRate = (energyAdded > 0) ? (newCost / energyAdded) : 0;
+            }
+
+            // Update the session rate, cost, and clear tariff fields in charging_sessions
+            try (PreparedStatement updSession = connection.prepareStatement(
+                    "UPDATE " + TABLE_CHARGING + " SET electricity_rate = ?, session_cost = ?, tariff_id = '', tariff_label = '' WHERE id = ?;")) {
+                updSession.setDouble(1, newRate);
+                updSession.setDouble(2, newCost);
+                updSession.setLong(3, id);
+                updSession.executeUpdate();
+            }
+
+            // Adjust the daily rollup if there's a non-zero change
+            long dayBasis = endTime > 0 ? endTime : startTime;
+            if (dayBasis > 0) {
+                double delta = (newCost >= 0 ? newCost : 0) - (oldCost >= 0 ? oldCost : 0);
+                if (delta != 0) {
+                    long day = (dayBasis / 86_400_000L) * 86_400_000L;
+                    try (PreparedStatement updDaily = connection.prepareStatement(
+                            "UPDATE " + TABLE_CHARGING_DAILY + " SET cost = GREATEST(cost + ?, 0) WHERE day_epoch = ?;")) {
+                        updDaily.setDouble(1, delta);
+                        updDaily.setLong(2, day);
+                        updDaily.executeUpdate();
+                    }
+                }
+            }
+            logger.info("Updated charging session " + id + " to cost " + newCost + ", calculated rate " + newRate);
+            return true;
+        } catch (Exception e) {
+            logger.error("updateChargingSessionCost failed for " + id, e);
+            return false;
+        }
+    }
+
+    /**
      * Get SOC statistics.
      */
     public synchronized JSONObject getSocStats(int hoursBack) {

--- a/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
+++ b/app/src/main/java/com/overdrive/app/monitor/SocHistoryDatabase.java
@@ -431,7 +431,7 @@ public class SocHistoryDatabase {
         this(new java.io.File(CHARGING_LIFECYCLE_JOURNAL_PATH));
     }
 
-    SocHistoryDatabase(java.io.File chargingLifecycleJournalFile) {
+    protected SocHistoryDatabase(java.io.File chargingLifecycleJournalFile) {
         this.chargingLifecycleJournalFile = chargingLifecycleJournalFile;
         // Load the H2 JDBC driver (pure Java - always works)
         try {

--- a/app/src/test/java/com/overdrive/app/charging/ChargingApiHandlerTest.java
+++ b/app/src/test/java/com/overdrive/app/charging/ChargingApiHandlerTest.java
@@ -729,6 +729,67 @@ public class ChargingApiHandlerTest {
         return database;
     }
 
+    @Test
+    public void updateSessionCostReturns400ForInvalidJson() throws Exception {
+        TrackingManager manager = new TrackingManager(true);
+        ChargingApiHandler handler = new ChargingApiHandler(manager);
+        JSONObject response = handler.handleRequest(
+                "/api/charging/42/cost", "POST", null, "invalid json");
+        assertEquals(400, response.optInt("_status"));
+        assertEquals("Invalid JSON payload", response.optString("error"));
+    }
+
+    @Test
+    public void updateSessionCostReturns400WhenCostMissing() throws Exception {
+        TrackingManager manager = new TrackingManager(true);
+        ChargingApiHandler handler = new ChargingApiHandler(manager);
+        JSONObject response = handler.handleRequest(
+                "/api/charging/42/cost", "POST", null, "{}");
+        assertEquals(400, response.optInt("_status"));
+        assertEquals("Missing 'cost' parameter", response.optString("error"));
+    }
+
+    @Test
+    public void updateSessionCostSuccess() throws Exception {
+        TrackingManager manager = new TrackingManager(true);
+        final long[] capturedId = new long[1];
+        final double[] capturedCost = new double[1];
+        manager.socDbOverride = new SocHistoryDatabase(null) {
+            @Override
+            public synchronized boolean updateChargingSessionCost(long id, double newCost) {
+                capturedId[0] = id;
+                capturedCost[0] = newCost;
+                return true;
+            }
+        };
+        ChargingApiHandler handler = new ChargingApiHandler(manager);
+        JSONObject response = handler.handleRequest(
+                "/api/charging/42/cost", "POST", null,
+                new JSONObject().put("cost", 15.50).toString());
+
+        assertTrue(response.optBoolean("success"));
+        assertEquals(42L, capturedId[0]);
+        assertEquals(15.50, capturedCost[0], 0.001);
+    }
+
+    @Test
+    public void updateSessionCostDatabaseFailure() throws Exception {
+        TrackingManager manager = new TrackingManager(true);
+        manager.socDbOverride = new SocHistoryDatabase(null) {
+            @Override
+            public synchronized boolean updateChargingSessionCost(long id, double newCost) {
+                return false;
+            }
+        };
+        ChargingApiHandler handler = new ChargingApiHandler(manager);
+        JSONObject response = handler.handleRequest(
+                "/api/charging/42/cost", "POST", null,
+                new JSONObject().put("cost", 15.50).toString());
+
+        assertEquals(500, response.optInt("_status"));
+        assertTrue(response.optString("error").contains("Failed to update session cost"));
+    }
+
     /**
      * Captures the tariff the handler mirrors into the trips config, which is
      * how a saved charging rate reaches trip costing.


### PR DESCRIPTION
### PR Description

  This PR introduces support for editing the total cost of completed charging sessions, dynamically calculating the
  corresponding rate based on energy added, and updating database daily rollups.

### Key Changes

 **Database & Business Logic**:
      * Implemented `updateChargingSessionCost` in `SocHistoryDatabase.java` to update the session's total cost, recalculate its rate (`cost / energy`), clear named tariff labels/IDs (as it is now a manual override), and adjust the daily rollup.
      * Added validation to prevent editing of in-progress sessions.
     
 **API Endpoints**:
      * Added `POST /api/charging/{id}/cost` in `ChargingApiHandler.java`.
 
 **Frontend UI**:
      * Implemented `BYD.utils.promptDialog` in `core.js` to replace browser-default prompt popups with a beautiful, fully themed custom modal dialog that respects the app's dark mode design system.
      * Made the **Cost** stat card interactive in `charging.html` with hover states and a pencil edit icon.
      * Added parenthetical rate display (e.g. `($0.15/kWh)`) next to the cost value in `charging.html` / `charging.js` when no location-specific named tariff is active.

### Verification
    * Successfully built debug APK and ran all unit tests.
    * Validated frontend changes locally using a mock HTTP server.
    
    
    
    
<img width="182" height="170" alt="Screenshot 2026-08-12 at 11 15 21" src="https://github.com/user-attachments/assets/1ab6a2f0-55bd-46f4-aa0b-f585fbd6fbe4" />
<img width="482" height="294" alt="Screenshot 2026-08-12 at 11 15 16" src="https://github.com/user-attachments/assets/803f4db7-da6d-4912-8e92-2dcbf6f5b47d" />
