### PR TITLE
fix(telegram): gate OEM surveillance uploads with their parent event

### DIFF
--- a/app/src/main/java/com/overdrive/app/camera/OemDashcamPipeline.java
+++ b/app/src/main/java/com/overdrive/app/camera/OemDashcamPipeline.java
@@ -593,7 +593,9 @@ public class OemDashcamPipeline {
         }
         String path = generateOutputPath();
         long clampedPost = Math.max(0L, postRecordMs);
-        boolean ok = encoder != null && encoder.triggerEventRecording(path, clampedPost);
+        HardwareEventRecorderGpu.VideoUploadPolicy uploadPolicy = uploadPolicyFor(eventOwned);
+        boolean ok = encoder != null
+                && encoder.triggerEventRecording(path, clampedPost, uploadPolicy);
         if (!ok) {
             synchronized (recordingStateLock) {
                 recording.set(false);
@@ -605,6 +607,13 @@ public class OemDashcamPipeline {
         // refcount on start and release on stop.
         reconcileTelemetryHold();
         return ok;
+    }
+
+    /** Package-visible ownership-to-upload policy seam for regression tests. */
+    static HardwareEventRecorderGpu.VideoUploadPolicy uploadPolicyFor(boolean eventOwned) {
+        return eventOwned
+                ? HardwareEventRecorderGpu.VideoUploadPolicy.SURVEILLANCE_GATED
+                : HardwareEventRecorderGpu.VideoUploadPolicy.AUTOMATIC;
     }
 
     /** True iff the in-flight clip (if any) is surveillance-event-owned.
@@ -628,13 +637,42 @@ public class OemDashcamPipeline {
      * by deferring muxer finalization until the tail elapses.
      */
     public void stopRecording(long postRecordMs) {
-        synchronized (recordingStateLock) {
-            if (!recording.getAndSet(false)) return;
-            recordingEventOwned.set(false);
+        stopRecordingAndGetFinalizedClip(postRecordMs);
+    }
+
+    /**
+     * Finalized OEM clip metadata returned to the surveillance owner. The
+     * recorder itself suppresses automatic Telegram delivery for event-owned
+     * clips; SurveillanceEngineGpu uses this result only after its tier gate
+     * passes.
+     */
+    public static final class FinalizedClip {
+        private final String path;
+        private final int durationSeconds;
+
+        FinalizedClip(String path, int durationSeconds) {
+            this.path = path;
+            this.durationSeconds = durationSeconds;
         }
-        if (encoder != null) encoder.stopEventRecording(true, Math.max(0L, postRecordMs));
+
+        public String getPath() { return path; }
+        public int getDurationSeconds() { return durationSeconds; }
+    }
+
+    private FinalizedClip stopRecordingAndGetFinalizedClip(long postRecordMs) {
+        HardwareEventRecorderGpu enc;
+        String path;
+        synchronized (recordingStateLock) {
+            if (!recording.getAndSet(false)) return null;
+            recordingEventOwned.set(false);
+            enc = encoder;
+            path = enc != null ? enc.getCurrentOutputPath() : null;
+        }
+        if (enc != null) enc.stopEventRecording(true, Math.max(0L, postRecordMs));
         reapplyIdleStrideAfterStop();
         reconcileTelemetryHold();
+        if (path == null || !new File(path).isFile()) return null;
+        return new FinalizedClip(path, enc != null ? enc.getLastFinalizedDurationSec() : 0);
     }
 
     /** Back-compat overload — no post-roll. */
@@ -701,12 +739,21 @@ public class OemDashcamPipeline {
     /** Stop only if the caller (e.g. surveillance) owns the recording.
      *  Pass the engine's post-window so the OEM tail matches pano's. */
     public void stopRecordingIfOwned(boolean owned, long postRecordMs) {
-        if (owned) stopRecording(postRecordMs);
+        if (owned) stopRecordingAndGetFinalizedClip(postRecordMs);
     }
 
     /** Back-compat overload — no post-roll. */
     public void stopRecordingIfOwned(boolean owned) {
         stopRecordingIfOwned(owned, 0L);
+    }
+
+    /**
+     * Surveillance stop variant that returns the finalized OEM mirror for
+     * delivery after the parent event passes its Telegram severity gate.
+     */
+    public FinalizedClip stopRecordingIfOwnedAndGetFinalizedClip(
+            boolean owned, long postRecordMs) {
+        return owned ? stopRecordingAndGetFinalizedClip(postRecordMs) : null;
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/surveillance/HardwareEventRecorderGpu.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/HardwareEventRecorderGpu.java
@@ -1147,6 +1147,29 @@ public class HardwareEventRecorderGpu {
     private volatile boolean recording = false;
     private String outputPath;
     private File tempFile;
+    /**
+     * Controls who may initiate the Telegram upload when a clip is finalized.
+     * Most recorder clients retain the historical automatic behaviour.
+     * Surveillance-owned clips are emitted later by SurveillanceEngineGpu,
+     * after the event's Notice/Alert/Critical tier has been evaluated.
+     */
+    public enum VideoUploadPolicy {
+        AUTOMATIC,
+        SURVEILLANCE_GATED;
+
+        /** Pure policy check kept Android-runtime independent for local tests. */
+        boolean shouldAutoUpload(String fileName) {
+            if (this != AUTOMATIC) return false;
+            if (fileName == null) return true;
+            String name = fileName;
+            int slash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+            if (slash >= 0 && slash + 1 < name.length()) {
+                name = name.substring(slash + 1);
+            }
+            return !name.startsWith("event_");
+        }
+    }
+    private VideoUploadPolicy videoUploadPolicy = VideoUploadPolicy.AUTOMATIC;
     private int recordedFrames = 0;
     private long firstFramePtsUs = -1;   // PTS of first frame written to muxer
     private long lastFramePtsUs = -1;    // PTS of last frame written to muxer
@@ -2416,6 +2439,21 @@ public class HardwareEventRecorderGpu {
      * @return true if started successfully, false otherwise
      */
     public boolean triggerEventRecording(String outputPath, long postRecordDurationMs) {
+        return triggerEventRecording(outputPath, postRecordDurationMs,
+                VideoUploadPolicy.AUTOMATIC);
+    }
+
+    /**
+     * Trigger event recording with an explicit Telegram upload owner.
+     *
+     * <p>{@link VideoUploadPolicy#SURVEILLANCE_GATED} suppresses this low-level
+     * recorder's automatic upload. The surveillance engine must then emit the
+     * finalized clip only after its severity-tier gate passes. This is required
+     * for OEM {@code dvr_*} mirrors of parked events: their filename otherwise
+     * looks like an ordinary driving clip and bypasses the parent event gate.
+     */
+    public boolean triggerEventRecording(String outputPath, long postRecordDurationMs,
+            VideoUploadPolicy uploadPolicy) {
         // Format barrier (LOCK-FREE): refuse to build a muxer until the encoder
         // has published its OUTPUT_FORMAT_CHANGED. Run BEFORE startStopLock
         // entry so a 2-s busy poll doesn't block concurrent stopEventRecording
@@ -2468,6 +2506,8 @@ public class HardwareEventRecorderGpu {
 
         try {
             this.outputPath = outputPath;
+            this.videoUploadPolicy = uploadPolicy != null
+                    ? uploadPolicy : VideoUploadPolicy.AUTOMATIC;
             
             // Write to temp file during recording
             tempFile = new File(outputPath + ".tmp");
@@ -3101,17 +3141,18 @@ public class HardwareEventRecorderGpu {
                         logger.warn("Index upsert failed for " + finalFile.getName() + ": " + e.getMessage());
                     }
 
-                    // Telegram auto video-upload. Surveillance (event_*.mp4) is
+                    // Telegram auto video-upload. Surveillance (event_*.mp4)
+                    // and explicitly SURVEILLANCE_GATED OEM mirrors are
                     // DELIBERATELY excluded here: those clips are sent from
                     // SurveillanceEngineGpu.sendFinalTelegramNotification, which
                     // is the only place that knows the event's peak severity and
                     // therefore the only place that can honour the per-tier
                     // Telegram toggles (NOTICE/ALERT/CRITICAL). Sending from here
                     // too would bypass that gate — the "NOTICE muted but video
-                    // still arrives" bug — and double-send. Dashcam (cam_*) and
-                    // proximity (proximity_*) clips have no severity concept, so
-                    // they keep the simple videoUploads-only auto-send.
-                    if (!"surveillance".equals(inferGeocodingFlow(finalFile.getName()))) {
+                    // still arrives" bug — and double-send. Ordinary dashcam
+                    // (cam_*/dvr_*) and proximity clips have no severity concept,
+                    // so they keep the simple videoUploads-only auto-send.
+                    if (videoUploadPolicy.shouldAutoUpload(finalFile.getName())) {
                         try {
                             TelegramNotifier.notifyVideoRecorded(
                                     finalFile.getAbsolutePath(), null, (int) durationSec);

--- a/app/src/main/java/com/overdrive/app/surveillance/SurveillanceEngineGpu.java
+++ b/app/src/main/java/com/overdrive/app/surveillance/SurveillanceEngineGpu.java
@@ -6383,7 +6383,8 @@ public class SurveillanceEngineGpu {
      * text-only message. Falls back gracefully on the daemon side if the photo
      * can't be sent.
      */
-    private void sendFinalTelegramNotification(String videoFilename, String heroPhotoPath) {
+    private void sendFinalTelegramNotification(String videoFilename, String heroPhotoPath,
+            com.overdrive.app.camera.OemDashcamPipeline.FinalizedClip oemFinalizedClip) {
         // Event-peak union (not the TTL-pruned lastActors) so the caption names
         // the same actor the hero shows — see finalNotificationActors().
         java.util.List<Actor> snap = finalNotificationActors();
@@ -6530,6 +6531,24 @@ public class SurveillanceEngineGpu {
             }
         } catch (Throwable t) {
             logger.debug("Telegram surveillance video send failed: " + t.getMessage());
+        }
+
+        // The OEM forward-camera mirror is opened with SURVEILLANCE_GATED, so
+        // HardwareEventRecorderGpu deliberately does not auto-upload it when
+        // the dvr_* file closes. We are past the same tier gate as the parent
+        // event here; emitting it now preserves OEM video delivery for allowed
+        // events without leaking muted/empty parked events as bare dashcam clips.
+        try {
+            if (oemFinalizedClip != null
+                    && oemFinalizedClip.getPath() != null
+                    && new java.io.File(oemFinalizedClip.getPath()).exists()) {
+                String label = threat != null ? Actor.groupLabel(threat.classGroup) : null;
+                TelegramNotifier.notifyVideoRecorded(
+                        oemFinalizedClip.getPath(), label,
+                        oemFinalizedClip.getDurationSeconds());
+            }
+        } catch (Throwable t) {
+            logger.debug("Telegram OEM surveillance video send failed: " + t.getMessage());
         }
     }
 
@@ -8533,7 +8552,9 @@ public class SurveillanceEngineGpu {
         // joins the encoder drainer thread, after which no further frames or
         // segment-rotation listener calls can fire.
         recorder.stopEventRecording(true, 0);
-        // Symmetric OEM stop — fire-and-forget; never block pano teardown.
+        // Capture the finalized surveillance-owned OEM mirror so it can be
+        // delivered only if the parent event passes the Telegram tier gate.
+        com.overdrive.app.camera.OemDashcamPipeline.FinalizedClip oemFinalizedClip = null;
         try {
             com.overdrive.app.camera.OemDashcamPipeline oemPipe =
                 com.overdrive.app.daemon.CameraDaemon.getOemDashcamPipeline();
@@ -8548,7 +8569,10 @@ public class SurveillanceEngineGpu {
             // Engine has already absorbed the post-record window via its
             // own loop (lastMotionTime + postRecordMs gate). Pass 0 so the
             // OEM recorder finalizes promptly, matching pano's behaviour.
-            if (oemPipe != null) oemPipe.stopRecordingIfOwned(canStop, 0L);
+            if (oemPipe != null) {
+                oemFinalizedClip = oemPipe.stopRecordingIfOwnedAndGetFinalizedClip(
+                        canStop, 0L);
+            }
             oemEventOwned = false;
             oemEventOwnedGeneration = -1;
         } catch (Throwable t) {
@@ -8682,7 +8706,7 @@ public class SurveillanceEngineGpu {
             if (!videoName.equals(lastFinalNotifiedEvent.getAndSet(videoName))) {
                 try { publishMotionFinal(videoName, heroName, heroIsCloseUp); }
                 catch (Throwable t) { logger.debug("publishMotionFinal threw: " + t.getMessage()); }
-                try { sendFinalTelegramNotification(videoName, heroPath); }
+                try { sendFinalTelegramNotification(videoName, heroPath, oemFinalizedClip); }
                 catch (Throwable t) { logger.debug("sendFinalTelegramNotification threw: " + t.getMessage()); }
             } else {
                 logger.debug("Final notification already sent for " + videoName + "; skipping duplicate");

--- a/app/src/test/java/com/overdrive/app/camera/OemDashcamTelegramUploadPolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/camera/OemDashcamTelegramUploadPolicyTest.java
@@ -1,0 +1,22 @@
+package com.overdrive.app.camera;
+
+import com.overdrive.app.surveillance.HardwareEventRecorderGpu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OemDashcamTelegramUploadPolicyTest {
+
+    @Test
+    public void surveillanceOwnerSelectsTierGatedUpload() {
+        assertEquals(HardwareEventRecorderGpu.VideoUploadPolicy.SURVEILLANCE_GATED,
+                OemDashcamPipeline.uploadPolicyFor(true));
+    }
+
+    @Test
+    public void resolverOwnerKeepsAutomaticUpload() {
+        assertEquals(HardwareEventRecorderGpu.VideoUploadPolicy.AUTOMATIC,
+                OemDashcamPipeline.uploadPolicyFor(false));
+    }
+}

--- a/app/src/test/java/com/overdrive/app/surveillance/HardwareEventRecorderGpuVideoUploadPolicyTest.java
+++ b/app/src/test/java/com/overdrive/app/surveillance/HardwareEventRecorderGpuVideoUploadPolicyTest.java
@@ -1,0 +1,33 @@
+package com.overdrive.app.surveillance;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HardwareEventRecorderGpuVideoUploadPolicyTest {
+
+    @Test
+    public void ordinaryOemDashcamClipStillUploadsAutomatically() {
+        assertTrue(HardwareEventRecorderGpu.VideoUploadPolicy.AUTOMATIC
+                .shouldAutoUpload("dvr_20260812_170103.mp4"));
+    }
+
+    @Test
+    public void surveillanceOwnedOemMirrorWaitsForParentTierGate() {
+        assertFalse(HardwareEventRecorderGpu.VideoUploadPolicy.SURVEILLANCE_GATED
+                .shouldAutoUpload("dvr_20260812_170103.mp4"));
+    }
+
+    @Test
+    public void panoramicSurveillanceClipNeverUsesGenericUploadPath() {
+        assertFalse(HardwareEventRecorderGpu.VideoUploadPolicy.AUTOMATIC
+                .shouldAutoUpload("event_20260812_170103.mp4"));
+    }
+
+    @Test
+    public void proximityClipKeepsHistoricalAutomaticUpload() {
+        assertTrue(HardwareEventRecorderGpu.VideoUploadPolicy.AUTOMATIC
+                .shouldAutoUpload("proximity_20260812_153155.mp4"));
+    }
+}


### PR DESCRIPTION
## Summary

- carry explicit Telegram upload ownership into `main`'s shared hardware
  event recorder
- mark OEM dashcam clips opened for parked surveillance as surveillance-gated
  instead of treating their `dvr_*` filename as ordinary driving recordings
- return the final OEM mirror to the surveillance engine and deliver it only
  after the parent event passes its existing Notice/Alert/Critical gate
- leave ordinary driving and proximity recording uploads unchanged

## Why

Parked surveillance can create both a panoramic `event_*.mp4` and an OEM
forward-camera `dvr_*.mp4` mirror. `main` filters the panoramic clip by event
severity, but the shared recorder can independently upload the OEM mirror. A
muted event can therefore produce an unexplained video without its matching
notification.

## Impact

Both clips belonging to one surveillance event now share one delivery decision.
Muted or discarded events do not leak a bare OEM video; allowed events retain
both videos, while ordinary driving and proximity uploads are unchanged.

## Validation

- focused recorder-policy and OEM ownership-mapping tests
- `test`, `testDebugUnitTest`, and `assembleDebug` passed in exact
  aggregate `743354e5687da24d0b273646a3d8fb4db8addbeb`
- all 104 Gradle actions were rerun
- aggregate ARM64 APK SHA-256:
  `49355A2DC0D19A05CC17B88262FC1984A33A49C68C4500B0C871435AF04F77D8`

## Visual evidence

Not applicable. Visible screens are unchanged from `main`; this fixes delivery
ownership for a filtered surveillance event.
