### PR TITLE
fix(daemon): recover loopback ADB and watchdog paths after updates

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt
@@ -19,6 +19,13 @@ class AdbShellExecutor(private val context: Context) {
         private const val ADB_PORT = 5555
         private const val ADB_KEY_FILE = "adbkey"
         private const val ADB_PUB_KEY_FILE = "adbkey.pub"
+        // Dadb defaults both values to 0 (infinite). A stale loopback transport
+        // can therefore strand the single shell executor forever, leaving every
+        // daemon switch disabled at STARTING. Keep connection setup short and
+        // give legitimate longer shell commands (for example zrok's 30s probe)
+        // room to finish while still guaranteeing recovery from a dead socket.
+        private const val ADB_CONNECT_TIMEOUT_MS = 3_000
+        private const val ADB_SOCKET_TIMEOUT_MS = 45_000
         
         @Volatile
         private var cachedKeyPair: AdbKeyPair? = null
@@ -382,11 +389,10 @@ class AdbShellExecutor(private val context: Context) {
      * Try to connect with a timeout. Returns null if times out (auth pending).
      *
      * NOTE: java.net.Socket I/O is NOT interruptible — `Thread.interrupt()`
-     * does not unblock a thread blocked inside connect/read. The
-     * connectThread therefore keeps running until the OS times out the
-     * TCP handshake / SSL handshake (typically <75s on Android), or
-     * until the dadb internal socket aborts. We can't shorten that
-     * without rewriting the Dadb internals.
+     * does not unblock a thread blocked inside connect/read. Dadb 1.2.8 does,
+     * however, expose native connect + socket timeouts. Every connection below
+     * uses those bounds, so a probe thread that outlives this quick wrapper can
+     * survive for at most [ADB_SOCKET_TIMEOUT_MS], never indefinitely.
      *
      * Mitigation: mark the orphan thread as daemon + named so it
      *   (a) doesn't hold the JVM alive (Android process death is
@@ -397,7 +403,8 @@ class AdbShellExecutor(private val context: Context) {
      *   (c) is bounded — the thread terminates naturally when its
      *       blocked I/O times out.
      *
-     * Each timed-out call leaks ONE thread for ≤~75s. Under normal
+     * Each timed-out call can leave ONE daemon thread for at most
+     * [ADB_SOCKET_TIMEOUT_MS]. Under normal
      * operation (good ADB transport) this path is rarely hit.
      */
     private fun tryConnectWithTimeout(keyPair: AdbKeyPair, timeoutMs: Long): Dadb? {
@@ -412,7 +419,13 @@ class AdbShellExecutor(private val context: Context) {
 
         val connectThread = Thread({
             try {
-                val dadb = Dadb.create("127.0.0.1", ADB_PORT, keyPair)
+                val dadb = Dadb.create(
+                    "127.0.0.1",
+                    ADB_PORT,
+                    keyPair,
+                    ADB_CONNECT_TIMEOUT_MS,
+                    ADB_SOCKET_TIMEOUT_MS
+                )
                 val testResult = dadb.shell("echo ok")
                 if (testResult.exitCode == 0) {
                     result = dadb

--- a/app/src/main/java/com/overdrive/app/launcher/DaemonLauncher.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/DaemonLauncher.kt
@@ -383,12 +383,12 @@ class DaemonLauncher(
             // daemon is the highest-volume stdout logger, so real-time
             // bounding of cam_daemon.log (the UI-shown file) matters most here.
             val appProcessLine =
-                "  CLASSPATH=/system/framework/bmmcamera.jar:$apkPath app_process " +
-                "-Djava.library.path=$nativeLibDir:/system/lib64:/vendor/lib64:/product/lib64:/odm/lib64 " +
+                "  CLASSPATH=/system/framework/bmmcamera.jar:\$APK_PATH app_process " +
+                "-Djava.library.path=\$NATIVE_LIB_DIR:/system/lib64:/vendor/lib64:/product/lib64:/odm/lib64 " +
                 "${proxyArgs}/system/bin " +
                 "--nice-name=$CAMERA_DAEMON_PROCESS " +
                 "com.overdrive.app.daemon.CameraDaemon " +
-                "$outputDir $nativeLibDir >> \"\$LOG_FILE\" 2>&1 &"
+                "$outputDir \$NATIVE_LIB_DIR >> \"\$LOG_FILE\" 2>&1 &"
 
             return listOf(
                 "#!/system/bin/sh",
@@ -397,6 +397,8 @@ class DaemonLauncher(
                 "LOCK_FILE=\"/data/local/tmp/camera_daemon.lock\"",
                 "SENTINEL=\"/data/local/tmp/camera_daemon.disabled\"",
                 "PARKED=\"/data/local/tmp/overdrive_parked_shutdown\"",
+                "FALLBACK_APK_PATH=\"$apkPath\"",
+                "FALLBACK_NATIVE_LIB_DIR=\"$nativeLibDir\"",
                 "RETRY_COUNT=0",
                 "HEALTHY_UPTIME_SEC=300",
                 // Record THIS supervisor loop's PID so the kill-readers
@@ -415,7 +417,20 @@ class DaemonLauncher(
                 "    echo \"[\$(date)] Daemon disabled by user (sentinel file exists). Exiting watchdog.\" >> \"\$LOG_FILE\"",
                 "    exit 0",
                 "  fi",
-                "  echo \"[\$(date)] Starting CameraDaemon...\" >> \"\$LOG_FILE\"",
+                // Resolve the package path for every launch. `adb install -r`
+                // can move base.apk while this watchdog survives, so baking the
+                // path captured when the script was written can restart stale
+                // code or fail forever after an update.
+                "  APK_PATH=\$(pm path com.overdrive.app 2>/dev/null | grep '/base.apk\$' | head -n 1 | sed 's/^package://')",
+                "  if [ -z \"\$APK_PATH\" ] && [ -f \"\$FALLBACK_APK_PATH\" ]; then APK_PATH=\"\$FALLBACK_APK_PATH\"; fi",
+                "  if [ -z \"\$APK_PATH\" ]; then",
+                "    echo \"[\$(date)] Installed OverDrive APK not found, retrying in 10s...\" >> \"\$LOG_FILE\"",
+                "    sleep 10",
+                "    continue",
+                "  fi",
+                "  NATIVE_LIB_DIR=\"\${APK_PATH%/base.apk}/lib/arm64\"",
+                "  if [ ! -d \"\$NATIVE_LIB_DIR\" ] && [ \"\$APK_PATH\" = \"\$FALLBACK_APK_PATH\" ]; then NATIVE_LIB_DIR=\"\$FALLBACK_NATIVE_LIB_DIR\"; fi",
+                "  echo \"[\$(date)] Starting CameraDaemon from \$APK_PATH...\" >> \"\$LOG_FILE\"",
                 "  START_EPOCH=\$(awk '{print int(\$1)}' /proc/uptime 2>/dev/null || date +%s)",
                 "",
                 appProcessLine,

--- a/app/src/test/java/com/overdrive/app/launcher/AdbShellExecutorTimeoutAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/launcher/AdbShellExecutorTimeoutAssetTest.java
@@ -1,0 +1,45 @@
+package com.overdrive.app.launcher;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Prevents loopback ADB from regressing to Dadb's infinite socket defaults. */
+public class AdbShellExecutorTimeoutAssetTest {
+
+    @Test
+    public void dadbConnectionsUseFiniteConnectAndSocketTimeouts() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/launcher/AdbShellExecutor.kt")
+                .replace("\r\n", "\n");
+
+        assertTrue(source.contains("private const val ADB_CONNECT_TIMEOUT_MS = 3_000"));
+        assertTrue(source.contains("private const val ADB_SOCKET_TIMEOUT_MS = 45_000"));
+        assertTrue(source.contains("ADB_CONNECT_TIMEOUT_MS,\n                    ADB_SOCKET_TIMEOUT_MS"));
+        assertFalse(source.contains(
+                "Dadb.create(\"127.0.0.1\", ADB_PORT, keyPair)"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/launcher/CameraWatchdogApkPathAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/launcher/CameraWatchdogApkPathAssetTest.java
@@ -1,0 +1,48 @@
+package com.overdrive.app.launcher;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Prevents the camera watchdog from retaining a stale base.apk after replacement. */
+public class CameraWatchdogApkPathAssetTest {
+
+    @Test
+    public void watchdogResolvesTheInstalledPackageBeforeEveryLaunch() throws IOException {
+        String source = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/launcher/DaemonLauncher.kt")
+                .replace("\r\n", "\n");
+
+        assertTrue(source.contains(
+                "APK_PATH=\\$(pm path com.overdrive.app 2>/dev/null"));
+        assertTrue(source.contains(
+                "NATIVE_LIB_DIR=\\\"\\${APK_PATH%/base.apk}/lib/arm64\\\""));
+        assertTrue(source.contains(
+                "CLASSPATH=/system/framework/bmmcamera.jar:\\$APK_PATH app_process"));
+        assertTrue(source.contains(
+                "-Djava.library.path=\\$NATIVE_LIB_DIR:/system/lib64"));
+        assertTrue(source.contains(
+                "Installed OverDrive APK not found, retrying in 10s"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- give Dadb loopback connections bounded three-second connect and 45-second
  socket timeouts instead of `main`'s unbounded defaults
- retain enough time for legitimate longer shell operations while ensuring a
  dead transport releases the single command executor and daemon transitions
- resolve the installed OverDrive `base.apk` whenever the camera watchdog
  launches
- derive the native-library directory from that current package path, using
  captured values only as existence-checked fallbacks

## Why

A stale loopback ADB socket can leave daemon operations in STARTING or STOPPING
indefinitely. Separately, `adb install -r` can move `base.apk` while the
external camera watchdog survives, leaving a launcher that restarts stale code
or fails after an otherwise successful app update.

## Impact

Dead transports fail within a bounded interval, and surviving watchdogs resolve
the currently installed package before each restart. Normal long-running shell
operations retain their existing allowance.

## Validation

- focused tests cover timeout construction and current watchdog APK-path
  resolution
- `test`, `testDebugUnitTest`, and `assembleDebug` passed in exact
  aggregate `743354e5687da24d0b273646a3d8fb4db8addbeb`
- aggregate ARM64 APK SHA-256:
  `49355A2DC0D19A05CC17B88262FC1984A33A49C68C4500B0C871435AF04F77D8`
- the installed APK hash matched the aggregate, CameraDaemon mapped that exact
  current `base.apk`, and the loopback API served the current web bundle

## Visual evidence

Not applicable. This changes recovery behaviour and has no UI delta from
`main`.
