### PR TITLE
feat(remote): add an authenticated virtual-display developer view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -542,6 +542,16 @@
             android:foregroundServiceType="mediaPlayback"
             android:exported="true" />
 
+        <!-- Authenticated Remote Overdrive Dev View bridge. The CameraDaemon
+             runs as shell and is the only external caller. android.permission.DUMP
+             is signature-level and held by shell/system, preventing ordinary apps
+             from starting this exported component. The service then requires a
+             fresh in-memory secret and binds its data socket to 127.0.0.1 only. -->
+        <service
+            android:name="com.overdrive.app.remote.RemoteDevViewBridgeService"
+            android:exported="true"
+            android:permission="android.permission.DUMP" />
+
         <!-- Vehicle Actuator Service - runs BYD SDK writes (mirror fold, HUD) in the REAL
              app process (UID 10xxx, real Context), as a SECOND attempt after the daemon's
              own write, in case this HAL only honours the call from a normal app process.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -263,6 +263,20 @@
             </intent-filter>
         </activity>
 
+        <!-- Private-display instance used only by authenticated Remote Dev View.
+             A distinct component/task keeps it separate from the physical
+             MainActivity while executing the same UI implementation. -->
+        <activity
+            android:name="com.overdrive.app.ui.RemoteMainActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.overdrive.app.remote_dev"
+            android:launchMode="singleTask"
+            android:resizeableActivity="true"
+            android:screenOrientation="landscape"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden|density|fontScale|uiMode"
+            android:theme="@style/Theme.Overdrive.M3" />
+
 
 
         <!-- PIN Lock Activity. Gates MainActivity only — never the cam
@@ -543,8 +557,8 @@
             android:exported="true" />
 
         <!-- Remote Overdrive Dev View app-process bridge. It is never externally
-             startable; Overdrive starts it itself. Its abstract Unix socket checks
-             kernel peer credentials and accepts only the shell CameraDaemon. -->
+             startable; Overdrive starts it itself. Its loopback-only protocol is
+             time-bounded, replay-protected, and HMAC-authenticated. -->
         <service
             android:name="com.overdrive.app.remote.RemoteDevViewBridgeService"
             android:exported="false" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -542,15 +542,12 @@
             android:foregroundServiceType="mediaPlayback"
             android:exported="true" />
 
-        <!-- Authenticated Remote Overdrive Dev View bridge. The CameraDaemon
-             runs as shell and is the only external caller. android.permission.DUMP
-             is signature-level and held by shell/system, preventing ordinary apps
-             from starting this exported component. The service then requires a
-             fresh in-memory secret and binds its data socket to 127.0.0.1 only. -->
+        <!-- Remote Overdrive Dev View app-process bridge. It is never externally
+             startable; Overdrive starts it itself. Its abstract Unix socket checks
+             kernel peer credentials and accepts only the shell CameraDaemon. -->
         <service
             android:name="com.overdrive.app.remote.RemoteDevViewBridgeService"
-            android:exported="true"
-            android:permission="android.permission.DUMP" />
+            android:exported="false" />
 
         <!-- Vehicle Actuator Service - runs BYD SDK writes (mirror fold, HUD) in the REAL
              app process (UID 10xxx, real Context), as a SECOND attempt after the daemon's

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -148,6 +148,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=6"></script>
+<script src="../shared/remote-dev-view.js?v=7"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -148,6 +148,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=3"></script>
+<script src="../shared/remote-dev-view.js?v=4"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -28,7 +28,10 @@
         .dev-button:disabled { opacity: .45; cursor: default; }
         .viewer-card { width: 100%; min-width: 0; display: flex; flex-direction: column; box-sizing: border-box; }
         .viewer-card:focus { outline: none; }
-        .frame-shell { width: 100%; min-width: 0; min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
+        .head-unit-bezel { position: relative; width: 100%; min-width: 0; padding: 18px 19px 22px; display: flex; flex-direction: column; box-sizing: border-box; border: 1px solid rgba(164, 179, 183, .25); border-radius: 28px; background: linear-gradient(145deg, #343c3e 0%, #171c1e 30%, #080b0c 70%, #252c2e 100%); box-shadow: 0 18px 38px rgba(0, 0, 0, .38), inset 0 1px 0 rgba(255, 255, 255, .12), inset 0 -1px 0 rgba(255, 255, 255, .04); }
+        .head-unit-bezel::before { content: ''; position: absolute; z-index: 2; top: 7px; left: 50%; width: 6px; height: 6px; border-radius: 50%; transform: translateX(-50%); pointer-events: none; background: radial-gradient(circle at 40% 35%, #22454b 0, #071012 35%, #010203 72%); box-shadow: 0 0 0 1px rgba(255, 255, 255, .08), inset 0 0 2px rgba(89, 206, 224, .35); }
+        .head-unit-bezel::after { content: ''; position: absolute; bottom: 8px; left: 50%; width: 34px; height: 2px; border-radius: 2px; transform: translateX(-50%); pointer-events: none; background: rgba(255, 255, 255, .13); box-shadow: 0 1px 0 rgba(0, 0, 0, .55); }
+        .frame-shell { width: 100%; min-width: 0; min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 11px; overflow: hidden; position: relative; box-shadow: 0 0 0 1px rgba(0, 0, 0, .92), 0 0 0 2px rgba(255, 255, 255, .035), inset 0 0 18px rgba(0, 0, 0, .7); }
         #remoteFrame { display: none; width: 100%; height: 100%; object-fit: contain; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
         .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
         .viewer-footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 10px; }
@@ -43,6 +46,9 @@
         #viewerCard:fullscreen, #viewerCard:-webkit-full-screen, body.dev-view-focus #viewerCard { width: 100vw; height: 100vh; max-width: none; margin: 0; padding: 0; border: 0; border-radius: 0; background: #050608; }
         body.dev-view-focus { overflow: hidden; }
         body.dev-view-focus #viewerCard { position: fixed; inset: 0; z-index: 10000; }
+        #viewerCard:fullscreen .head-unit-bezel, #viewerCard:-webkit-full-screen .head-unit-bezel, body.dev-view-focus #viewerCard .head-unit-bezel { flex: 1 1 auto; min-height: 0; padding: 0; border: 0; border-radius: 0; background: #050608; box-shadow: none; }
+        #viewerCard:fullscreen .head-unit-bezel::before, #viewerCard:-webkit-full-screen .head-unit-bezel::before, body.dev-view-focus #viewerCard .head-unit-bezel::before,
+        #viewerCard:fullscreen .head-unit-bezel::after, #viewerCard:-webkit-full-screen .head-unit-bezel::after, body.dev-view-focus #viewerCard .head-unit-bezel::after { display: none; }
         #viewerCard:fullscreen .frame-shell, #viewerCard:-webkit-full-screen .frame-shell, body.dev-view-focus #viewerCard .frame-shell { flex: 1 1 auto; min-height: 0; aspect-ratio: auto; border-radius: 0; }
         #viewerCard:fullscreen #remoteFrame, #viewerCard:-webkit-full-screen #remoteFrame, body.dev-view-focus #viewerCard #remoteFrame { width: 100%; height: 100%; object-fit: contain; }
         #viewerCard:fullscreen .viewer-footer, #viewerCard:-webkit-full-screen .viewer-footer, body.dev-view-focus #viewerCard .viewer-footer { display: none; }
@@ -55,6 +61,10 @@
         @media (max-width: 620px) {
             .session-strip { grid-template-columns: 1fr; }
             .session-actions .dev-button { width: 100%; }
+            .head-unit-bezel { padding: 10px 10px 14px; border-radius: 19px; }
+            .head-unit-bezel::before { top: 3px; width: 4px; height: 4px; }
+            .head-unit-bezel::after { bottom: 5px; width: 26px; }
+            .frame-shell { min-height: 0; border-radius: 8px; }
         }
     </style>
 </head>
@@ -81,17 +91,19 @@
 
             <div class="dev-view-grid">
                 <section id="viewerCard" class="dev-card viewer-card" tabindex="0">
-                    <div class="frame-shell">
-                        <div class="fullscreen-toolbar">
-                            <button id="fullscreenBackButton" class="dev-button compact" disabled>Back</button>
-                            <button id="fullscreenKeyboardButton" class="dev-button compact" disabled>Keyboard</button>
-                            <button id="fullscreenScreenshotButton" class="dev-button compact" disabled>Screenshot</button>
-                            <button id="fullscreenRefreshButton" class="dev-button compact" disabled>Refresh</button>
-                            <button id="fullscreenStopButton" class="dev-button compact danger" disabled>End</button>
-                            <button id="fullscreenExitButton" class="dev-button compact">Exit fullscreen</button>
+                    <div class="head-unit-bezel">
+                        <div class="frame-shell">
+                            <div class="fullscreen-toolbar">
+                                <button id="fullscreenBackButton" class="dev-button compact" disabled>Back</button>
+                                <button id="fullscreenKeyboardButton" class="dev-button compact" disabled>Keyboard</button>
+                                <button id="fullscreenScreenshotButton" class="dev-button compact" disabled>Screenshot</button>
+                                <button id="fullscreenRefreshButton" class="dev-button compact" disabled>Refresh</button>
+                                <button id="fullscreenStopButton" class="dev-button compact danger" disabled>End</button>
+                                <button id="fullscreenExitButton" class="dev-button compact">Exit fullscreen</button>
+                            </div>
+                            <div id="framePlaceholder" class="frame-placeholder">Start a session to view Overdrive.</div>
+                            <img id="remoteFrame" alt="Live Overdrive app window">
                         </div>
-                        <div id="framePlaceholder" class="frame-placeholder">Start a session to view Overdrive.</div>
-                        <img id="remoteFrame" alt="Live Overdrive app window">
                     </div>
                     <div class="viewer-footer">
                         <div class="frame-status">

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -13,7 +13,7 @@
         .dev-view-header { margin-bottom: 14px; }
         .dev-view-header h1 { margin: 0 0 4px; color: var(--text-primary); font-size: clamp(24px, 3vw, 34px); }
         .dev-view-header p { margin: 0; color: var(--text-secondary); line-height: 1.4; }
-        .dev-view-grid { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 14px; }
+        .dev-view-grid { display: block; }
         .dev-card { background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: 14px; }
         .session-strip { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px 16px; min-height: 76px; padding-bottom: 30px; margin-bottom: 14px; box-sizing: border-box; }
         .session-copy { display: flex; flex-direction: column; gap: 2px; min-width: 0; color: var(--text-primary); line-height: 1.3; }
@@ -27,6 +27,7 @@
         .dev-button.danger { border-color: var(--danger); color: var(--danger); }
         .dev-button:disabled { opacity: .45; cursor: default; }
         .viewer-card { width: 100%; min-width: 0; display: flex; flex-direction: column; box-sizing: border-box; }
+        .viewer-card:focus { outline: none; }
         .frame-shell { width: 100%; min-width: 0; min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
         #remoteFrame { display: none; width: 100%; height: 100%; object-fit: contain; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
         .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
@@ -34,17 +35,7 @@
         .frame-status { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
         .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 6px; background: #777; }
         .status-dot.live { background: #22c55e; box-shadow: 0 0 8px rgba(34, 197, 94, .7); }
-        .control-stack { display: flex; flex-direction: column; gap: 14px; }
-        .control-stack h2 { margin: 0 0 10px; font-size: 16px; color: var(--text-primary); }
-        .control-note { color: var(--text-secondary); font-size: 13px; line-height: 1.45; margin: 0; }
-        .control-divider { border: 0; border-top: 1px solid var(--border-subtle); margin: 14px 0; }
-        .text-send { display: flex; gap: 8px; }
-        .text-send input { min-width: 0; flex: 1; border: 1px solid var(--border-subtle); border-radius: 9px; background: var(--bg-primary); color: var(--text-primary); padding: 10px; }
-        .dpad { display: grid; grid-template-columns: repeat(3, 48px); grid-template-rows: repeat(3, 42px); gap: 5px; justify-content: center; }
-        .dpad .dev-button { padding: 0; }
-        .dpad-up { grid-column: 2; } .dpad-left { grid-column: 1; grid-row: 2; }
-        .dpad-center { grid-column: 2; grid-row: 2; } .dpad-right { grid-column: 3; grid-row: 2; }
-        .dpad-down { grid-column: 2; grid-row: 3; }
+        .keyboard-capture { position: fixed; left: 0; bottom: 0; width: 1px; height: 1px; padding: 0; border: 0; opacity: .01; resize: none; pointer-events: none; }
         #message { position: absolute; left: 14px; right: 14px; bottom: 9px; min-height: 16px; color: var(--text-secondary); font-size: 12px; line-height: 16px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         #message:empty { visibility: hidden; }
         #message.error { color: var(--danger); }
@@ -57,7 +48,6 @@
         #viewerCard:fullscreen .viewer-footer, #viewerCard:-webkit-full-screen .viewer-footer, body.dev-view-focus #viewerCard .viewer-footer { display: none; }
         #viewerCard:fullscreen .fullscreen-toolbar, #viewerCard:-webkit-full-screen .fullscreen-toolbar, body.dev-view-focus #viewerCard .fullscreen-toolbar { display: flex; }
         @media (max-width: 980px) {
-            .dev-view-grid { grid-template-columns: 1fr; }
             .dev-view-page { padding: 14px; }
             .viewer-footer { align-items: flex-start; flex-direction: column; }
             .frame-shell { min-height: 220px; }
@@ -90,10 +80,11 @@
             </section>
 
             <div class="dev-view-grid">
-                <section id="viewerCard" class="dev-card viewer-card">
+                <section id="viewerCard" class="dev-card viewer-card" tabindex="0">
                     <div class="frame-shell">
                         <div class="fullscreen-toolbar">
                             <button id="fullscreenBackButton" class="dev-button compact" disabled>Back</button>
+                            <button id="fullscreenKeyboardButton" class="dev-button compact" disabled>Keyboard</button>
                             <button id="fullscreenScreenshotButton" class="dev-button compact" disabled>Screenshot</button>
                             <button id="fullscreenRefreshButton" class="dev-button compact" disabled>Refresh</button>
                             <button id="fullscreenStopButton" class="dev-button compact danger" disabled>End</button>
@@ -111,43 +102,20 @@
                         </div>
                         <div class="button-row">
                             <button id="fullscreenButton" class="dev-button compact" disabled>Fullscreen</button>
+                            <button id="keyboardButton" class="dev-button compact" disabled>Keyboard</button>
                             <button id="screenshotButton" class="dev-button compact" disabled>Screenshot</button>
                             <button id="refreshButton" class="dev-button compact" disabled>Refresh</button>
                             <button id="stopButton" class="dev-button compact danger" disabled>End</button>
                         </div>
                     </div>
+                    <textarea id="keyboardCapture" class="keyboard-capture" aria-label="Remote keyboard input" autocomplete="off" autocapitalize="sentences" spellcheck="false" disabled></textarea>
                 </section>
-
-                <aside class="control-stack">
-                    <section class="dev-card">
-                        <h2>Input tools</h2>
-                        <div class="button-row">
-                            <button class="dev-button key-button" data-key="back" disabled>Back</button>
-                            <button class="dev-button key-button" data-key="enter" disabled>Enter</button>
-                            <button class="dev-button key-button" data-key="tab" disabled>Tab</button>
-                            <button class="dev-button key-button" data-key="escape" disabled>Esc</button>
-                        </div>
-                        <div class="dpad" style="margin-top:12px">
-                            <button class="dev-button key-button dpad-up" data-key="dpad_up" disabled>&#8593;</button>
-                            <button class="dev-button key-button dpad-left" data-key="dpad_left" disabled>&#8592;</button>
-                            <button class="dev-button key-button dpad-center" data-key="dpad_center" disabled>&#9679;</button>
-                            <button class="dev-button key-button dpad-right" data-key="dpad_right" disabled>&#8594;</button>
-                            <button class="dev-button key-button dpad-down" data-key="dpad_down" disabled>&#8595;</button>
-                        </div>
-                        <hr class="control-divider">
-                        <div class="text-send">
-                            <input id="textInput" type="text" maxlength="256" placeholder="Type into focused field" disabled>
-                            <button id="textButton" class="dev-button" disabled>Send</button>
-                        </div>
-                        <p class="control-note" style="margin-top:12px">Tap or drag directly on the live frame.</p>
-                    </section>
-                </aside>
             </div>
         </div>
     </main>
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=7"></script>
+<script src="../shared/remote-dev-view.js?v=8"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -9,31 +9,37 @@
     <script src="../shared/app-shell.js?v=3"></script>
     <link rel="stylesheet" href="../shared/styles.css?v=20">
     <style>
-        .dev-view-page { max-width: 1500px; margin: 0 auto; padding: 24px; }
-        .dev-view-header { margin-bottom: 20px; }
-        .dev-view-header h1 { margin: 0 0 8px; color: var(--text-primary); }
-        .dev-view-header p { margin: 0; color: var(--text-secondary); line-height: 1.5; }
-        .dev-view-grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 18px; }
-        .dev-card { background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: 18px; }
-        .warning-card { border-color: rgba(245, 158, 11, .55); background: rgba(245, 158, 11, .08); margin-bottom: 18px; }
-        .warning-card strong { color: var(--warning); }
-        .warning-card p { color: var(--text-secondary); margin: 8px 0 0; line-height: 1.5; }
-        .confirm-row { display: flex; align-items: flex-start; gap: 10px; margin: 16px 0; color: var(--text-primary); line-height: 1.4; }
-        .confirm-row input { margin-top: 3px; width: 18px; height: 18px; }
-        .button-row { display: flex; flex-wrap: wrap; gap: 10px; }
+        .dev-view-page { max-width: 1600px; margin: 0 auto; padding: 20px; }
+        .dev-view-header { margin-bottom: 14px; }
+        .dev-view-header h1 { margin: 0 0 4px; color: var(--text-primary); font-size: clamp(24px, 3vw, 34px); }
+        .dev-view-header p { margin: 0; color: var(--text-secondary); line-height: 1.4; }
+        .dev-view-grid { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 14px; }
+        .dev-card { background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: 14px; }
+        .session-strip { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px 16px; margin-bottom: 14px; }
+        .confirm-row { display: flex; align-items: center; gap: 10px; margin: 0; color: var(--text-primary); line-height: 1.3; cursor: pointer; }
+        .confirm-row input { flex: 0 0 auto; width: 18px; height: 18px; }
+        .confirm-copy { display: flex; flex-direction: column; gap: 2px; }
+        .confirm-copy strong { font-size: 14px; }
+        .confirm-copy small { color: var(--text-secondary); font-size: 12px; }
+        .session-actions { display: flex; gap: 8px; }
+        .button-row { display: flex; flex-wrap: wrap; gap: 8px; }
         .dev-button { appearance: none; border: 1px solid var(--border-subtle); border-radius: 10px; background: var(--bg-elevated); color: var(--text-primary); padding: 10px 14px; font: inherit; font-weight: 600; cursor: pointer; }
+        .dev-button.compact { padding: 7px 10px; border-radius: 8px; font-size: 12px; }
         .dev-button.primary { border-color: var(--brand-primary); background: var(--brand-primary); color: #fff; }
         .dev-button.danger { border-color: var(--danger); color: var(--danger); }
         .dev-button:disabled { opacity: .45; cursor: default; }
-        .frame-shell { min-height: 360px; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
-        #remoteFrame { display: none; width: 100%; height: auto; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
+        .viewer-card { min-width: 0; display: flex; flex-direction: column; }
+        .frame-shell { min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
+        #remoteFrame { display: none; width: auto; height: auto; max-width: 100%; max-height: 100%; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
         .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
-        .frame-status { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-top: 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
+        .viewer-footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 10px; }
+        .frame-status { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
         .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 6px; background: #777; }
         .status-dot.live { background: #22c55e; box-shadow: 0 0 8px rgba(34, 197, 94, .7); }
         .control-stack { display: flex; flex-direction: column; gap: 14px; }
         .control-stack h2 { margin: 0 0 10px; font-size: 16px; color: var(--text-primary); }
         .control-note { color: var(--text-secondary); font-size: 13px; line-height: 1.45; margin: 0; }
+        .control-divider { border: 0; border-top: 1px solid var(--border-subtle); margin: 14px 0; }
         .text-send { display: flex; gap: 8px; }
         .text-send input { min-width: 0; flex: 1; border: 1px solid var(--border-subtle); border-radius: 9px; background: var(--bg-primary); color: var(--text-primary); padding: 10px; }
         .dpad { display: grid; grid-template-columns: repeat(3, 48px); grid-template-rows: repeat(3, 42px); gap: 5px; justify-content: center; }
@@ -41,12 +47,23 @@
         .dpad-up { grid-column: 2; } .dpad-left { grid-column: 1; grid-row: 2; }
         .dpad-center { grid-column: 2; grid-row: 2; } .dpad-right { grid-column: 3; grid-row: 2; }
         .dpad-down { grid-column: 2; grid-row: 3; }
-        #message { min-height: 20px; margin-top: 10px; color: var(--text-secondary); font-size: 13px; }
+        #message { grid-column: 1 / -1; color: var(--text-secondary); font-size: 12px; }
+        #message:empty { display: none; }
         #message.error { color: var(--danger); }
+        .fullscreen-toolbar { display: none; position: absolute; z-index: 3; top: max(10px, env(safe-area-inset-top)); right: max(10px, env(safe-area-inset-right)); gap: 7px; padding: 6px; border-radius: 10px; background: rgba(8, 11, 16, .78); backdrop-filter: blur(10px); }
+        #viewerCard:fullscreen, #viewerCard:-webkit-full-screen, body.dev-view-focus #viewerCard { width: 100vw; height: 100vh; max-width: none; margin: 0; padding: 0; border: 0; border-radius: 0; background: #050608; }
+        body.dev-view-focus { overflow: hidden; }
+        body.dev-view-focus #viewerCard { position: fixed; inset: 0; z-index: 10000; }
+        #viewerCard:fullscreen .frame-shell, #viewerCard:-webkit-full-screen .frame-shell, body.dev-view-focus #viewerCard .frame-shell { flex: 1 1 auto; min-height: 0; aspect-ratio: auto; border-radius: 0; }
+        #viewerCard:fullscreen .viewer-footer, #viewerCard:-webkit-full-screen .viewer-footer, body.dev-view-focus #viewerCard .viewer-footer { display: none; }
+        #viewerCard:fullscreen .fullscreen-toolbar, #viewerCard:-webkit-full-screen .fullscreen-toolbar, body.dev-view-focus #viewerCard .fullscreen-toolbar { display: flex; }
         @media (max-width: 980px) {
             .dev-view-grid { grid-template-columns: 1fr; }
-            .dev-view-page { padding: 16px; }
-            .frame-shell { min-height: 240px; }
+            .dev-view-page { padding: 14px; }
+            .session-strip { grid-template-columns: 1fr; }
+            .session-actions .dev-button { width: 100%; }
+            .viewer-footer { align-items: flex-start; flex-direction: column; }
+            .frame-shell { min-height: 220px; }
         }
     </style>
 </head>
@@ -56,47 +73,54 @@
     <main class="main-content">
         <div class="dev-view-page">
             <header class="dev-view-header">
-                <h1>Remote Overdrive Dev View</h1>
-                <p>Inspect and operate Overdrive's live Android window when BYD's ACC-off cover makes whole-display capture black.</p>
+                <h1>Remote Dev View</h1>
+                <p>Control Overdrive's live app window beneath the ACC-off cover.</p>
             </header>
 
-            <section id="startCard" class="dev-card warning-card">
-                <strong>This is a real, interactive app session.</strong>
-                <p>Touches and keys act inside Overdrive exactly as local input would. They can reach vehicle-control screens. The physical head-unit display is not turned on or uncovered by this feature; frames come from Overdrive's window underneath the OEM layer.</p>
+            <section id="startCard" class="dev-card session-strip">
                 <label class="confirm-row">
                     <input id="confirmStart" type="checkbox">
-                    <span>I understand that remote input operates the live Overdrive app and will use it only while the vehicle is safely parked.</span>
+                    <span class="confirm-copy">
+                        <strong>Enable live control</strong>
+                        <small>Remote input operates the real Overdrive app. Use only while parked.</small>
+                    </span>
                 </label>
-                <div class="button-row">
-                    <button id="startButton" class="dev-button primary" disabled>Start developer view</button>
+                <div class="session-actions">
+                    <button id="startButton" class="dev-button primary" disabled>Start session</button>
                 </div>
                 <div id="message" role="status" aria-live="polite"></div>
             </section>
 
             <div class="dev-view-grid">
-                <section class="dev-card">
+                <section id="viewerCard" class="dev-card viewer-card">
                     <div class="frame-shell">
-                        <div id="framePlaceholder" class="frame-placeholder">Start a confirmed session to launch Overdrive and request its first app-window frame.</div>
+                        <div class="fullscreen-toolbar">
+                            <button id="fullscreenBackButton" class="dev-button compact" disabled>Back</button>
+                            <button id="fullscreenRefreshButton" class="dev-button compact" disabled>Refresh</button>
+                            <button id="fullscreenStopButton" class="dev-button compact danger" disabled>End</button>
+                            <button id="fullscreenExitButton" class="dev-button compact">Exit fullscreen</button>
+                        </div>
+                        <div id="framePlaceholder" class="frame-placeholder">Start a session to view Overdrive.</div>
                         <img id="remoteFrame" alt="Live Overdrive app window">
                     </div>
-                    <div class="frame-status">
-                        <span><span id="liveDot" class="status-dot"></span><span id="connectionState">Stopped</span></span>
-                        <span id="frameDimensions">--</span>
-                        <span id="pixelCopyState">PixelCopy --</span>
-                        <span id="activityState">Activity --</span>
+                    <div class="viewer-footer">
+                        <div class="frame-status">
+                            <span><span id="liveDot" class="status-dot"></span><span id="connectionState">Stopped</span></span>
+                            <span id="frameDimensions">--</span>
+                            <span id="pixelCopyState">PixelCopy --</span>
+                            <span id="activityState">Activity --</span>
+                        </div>
+                        <div class="button-row">
+                            <button id="fullscreenButton" class="dev-button compact" disabled>Fullscreen</button>
+                            <button id="refreshButton" class="dev-button compact" disabled>Refresh</button>
+                            <button id="stopButton" class="dev-button compact danger" disabled>End</button>
+                        </div>
                     </div>
                 </section>
 
                 <aside class="control-stack">
                     <section class="dev-card">
-                        <h2>Session</h2>
-                        <div class="button-row">
-                            <button id="refreshButton" class="dev-button" disabled>Refresh</button>
-                            <button id="stopButton" class="dev-button danger" disabled>End session</button>
-                        </div>
-                    </section>
-                    <section class="dev-card">
-                        <h2>Keys</h2>
+                        <h2>Input tools</h2>
                         <div class="button-row">
                             <button class="dev-button key-button" data-key="back" disabled>Back</button>
                             <button class="dev-button key-button" data-key="enter" disabled>Enter</button>
@@ -104,23 +128,18 @@
                             <button class="dev-button key-button" data-key="escape" disabled>Esc</button>
                         </div>
                         <div class="dpad" style="margin-top:12px">
-                            <button class="dev-button key-button dpad-up" data-key="dpad_up" disabled>↑</button>
-                            <button class="dev-button key-button dpad-left" data-key="dpad_left" disabled>←</button>
-                            <button class="dev-button key-button dpad-center" data-key="dpad_center" disabled>●</button>
-                            <button class="dev-button key-button dpad-right" data-key="dpad_right" disabled>→</button>
-                            <button class="dev-button key-button dpad-down" data-key="dpad_down" disabled>↓</button>
+                            <button class="dev-button key-button dpad-up" data-key="dpad_up" disabled>&#8593;</button>
+                            <button class="dev-button key-button dpad-left" data-key="dpad_left" disabled>&#8592;</button>
+                            <button class="dev-button key-button dpad-center" data-key="dpad_center" disabled>&#9679;</button>
+                            <button class="dev-button key-button dpad-right" data-key="dpad_right" disabled>&#8594;</button>
+                            <button class="dev-button key-button dpad-down" data-key="dpad_down" disabled>&#8595;</button>
                         </div>
-                    </section>
-                    <section class="dev-card">
-                        <h2>Text input</h2>
+                        <hr class="control-divider">
                         <div class="text-send">
                             <input id="textInput" type="text" maxlength="256" placeholder="Type into focused field" disabled>
                             <button id="textButton" class="dev-button" disabled>Send</button>
                         </div>
-                    </section>
-                    <section class="dev-card">
-                        <h2>Pointer</h2>
-                        <p class="control-note">Click or drag directly on the frame. Touch coordinates are normalized to the captured app window and remain inside Overdrive's process.</p>
+                        <p class="control-note" style="margin-top:12px">Tap or drag directly on the live frame.</p>
                     </section>
                 </aside>
             </div>
@@ -129,6 +148,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=2"></script>
+<script src="../shared/remote-dev-view.js?v=3"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -148,6 +148,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=4"></script>
+<script src="../shared/remote-dev-view.js?v=5"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -129,6 +129,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=1"></script>
+<script src="../shared/remote-dev-view.js?v=2"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -9,18 +9,16 @@
     <script src="../shared/app-shell.js?v=3"></script>
     <link rel="stylesheet" href="../shared/styles.css?v=20">
     <style>
-        .dev-view-page { max-width: 1600px; margin: 0 auto; padding: 20px; }
+        .dev-view-page { width: 100%; max-width: 1600px; margin: 0 auto; padding: 20px; box-sizing: border-box; }
         .dev-view-header { margin-bottom: 14px; }
         .dev-view-header h1 { margin: 0 0 4px; color: var(--text-primary); font-size: clamp(24px, 3vw, 34px); }
         .dev-view-header p { margin: 0; color: var(--text-secondary); line-height: 1.4; }
         .dev-view-grid { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 14px; }
         .dev-card { background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: 14px; }
-        .session-strip { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px 16px; margin-bottom: 14px; }
-        .confirm-row { display: flex; align-items: center; gap: 10px; margin: 0; color: var(--text-primary); line-height: 1.3; cursor: pointer; }
-        .confirm-row input { flex: 0 0 auto; width: 18px; height: 18px; }
-        .confirm-copy { display: flex; flex-direction: column; gap: 2px; }
-        .confirm-copy strong { font-size: 14px; }
-        .confirm-copy small { color: var(--text-secondary); font-size: 12px; }
+        .session-strip { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px 16px; min-height: 76px; padding-bottom: 30px; margin-bottom: 14px; box-sizing: border-box; }
+        .session-copy { display: flex; flex-direction: column; gap: 2px; min-width: 0; color: var(--text-primary); line-height: 1.3; }
+        .session-copy strong { font-size: 14px; }
+        .session-copy small { color: var(--text-secondary); font-size: 12px; }
         .session-actions { display: flex; gap: 8px; }
         .button-row { display: flex; flex-wrap: wrap; gap: 8px; }
         .dev-button { appearance: none; border: 1px solid var(--border-subtle); border-radius: 10px; background: var(--bg-elevated); color: var(--text-primary); padding: 10px 14px; font: inherit; font-weight: 600; cursor: pointer; }
@@ -28,9 +26,9 @@
         .dev-button.primary { border-color: var(--brand-primary); background: var(--brand-primary); color: #fff; }
         .dev-button.danger { border-color: var(--danger); color: var(--danger); }
         .dev-button:disabled { opacity: .45; cursor: default; }
-        .viewer-card { min-width: 0; display: flex; flex-direction: column; }
-        .frame-shell { min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
-        #remoteFrame { display: none; width: auto; height: auto; max-width: 100%; max-height: 100%; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
+        .viewer-card { width: 100%; min-width: 0; display: flex; flex-direction: column; box-sizing: border-box; }
+        .frame-shell { width: 100%; min-width: 0; min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
+        #remoteFrame { display: none; width: 100%; height: 100%; object-fit: contain; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
         .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
         .viewer-footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 10px; }
         .frame-status { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
@@ -47,23 +45,26 @@
         .dpad-up { grid-column: 2; } .dpad-left { grid-column: 1; grid-row: 2; }
         .dpad-center { grid-column: 2; grid-row: 2; } .dpad-right { grid-column: 3; grid-row: 2; }
         .dpad-down { grid-column: 2; grid-row: 3; }
-        #message { grid-column: 1 / -1; color: var(--text-secondary); font-size: 12px; }
-        #message:empty { display: none; }
+        #message { position: absolute; left: 14px; right: 14px; bottom: 9px; min-height: 16px; color: var(--text-secondary); font-size: 12px; line-height: 16px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        #message:empty { visibility: hidden; }
         #message.error { color: var(--danger); }
-        .fullscreen-toolbar { display: none; position: absolute; z-index: 3; top: max(10px, env(safe-area-inset-top)); right: max(10px, env(safe-area-inset-right)); gap: 7px; padding: 6px; border-radius: 10px; background: rgba(8, 11, 16, .78); backdrop-filter: blur(10px); }
+        .fullscreen-toolbar { display: none; position: absolute; z-index: 3; top: max(10px, env(safe-area-inset-top)); right: max(10px, env(safe-area-inset-right)); max-width: calc(100vw - 20px); flex-wrap: wrap; justify-content: flex-end; gap: 7px; padding: 6px; border-radius: 10px; background: rgba(8, 11, 16, .78); backdrop-filter: blur(10px); }
         #viewerCard:fullscreen, #viewerCard:-webkit-full-screen, body.dev-view-focus #viewerCard { width: 100vw; height: 100vh; max-width: none; margin: 0; padding: 0; border: 0; border-radius: 0; background: #050608; }
         body.dev-view-focus { overflow: hidden; }
         body.dev-view-focus #viewerCard { position: fixed; inset: 0; z-index: 10000; }
         #viewerCard:fullscreen .frame-shell, #viewerCard:-webkit-full-screen .frame-shell, body.dev-view-focus #viewerCard .frame-shell { flex: 1 1 auto; min-height: 0; aspect-ratio: auto; border-radius: 0; }
+        #viewerCard:fullscreen #remoteFrame, #viewerCard:-webkit-full-screen #remoteFrame, body.dev-view-focus #viewerCard #remoteFrame { width: 100%; height: 100%; object-fit: contain; }
         #viewerCard:fullscreen .viewer-footer, #viewerCard:-webkit-full-screen .viewer-footer, body.dev-view-focus #viewerCard .viewer-footer { display: none; }
         #viewerCard:fullscreen .fullscreen-toolbar, #viewerCard:-webkit-full-screen .fullscreen-toolbar, body.dev-view-focus #viewerCard .fullscreen-toolbar { display: flex; }
         @media (max-width: 980px) {
             .dev-view-grid { grid-template-columns: 1fr; }
             .dev-view-page { padding: 14px; }
-            .session-strip { grid-template-columns: 1fr; }
-            .session-actions .dev-button { width: 100%; }
             .viewer-footer { align-items: flex-start; flex-direction: column; }
             .frame-shell { min-height: 220px; }
+        }
+        @media (max-width: 620px) {
+            .session-strip { grid-template-columns: 1fr; }
+            .session-actions .dev-button { width: 100%; }
         }
     </style>
 </head>
@@ -78,15 +79,12 @@
             </header>
 
             <section id="startCard" class="dev-card session-strip">
-                <label class="confirm-row">
-                    <input id="confirmStart" type="checkbox">
-                    <span class="confirm-copy">
-                        <strong>Enable live control</strong>
-                        <small>Remote input operates the real Overdrive app. Use only while parked.</small>
-                    </span>
-                </label>
+                <div class="session-copy">
+                    <strong>Live control session</strong>
+                    <small>Controls the real Overdrive app. Use only while parked.</small>
+                </div>
                 <div class="session-actions">
-                    <button id="startButton" class="dev-button primary" disabled>Start session</button>
+                    <button id="startButton" class="dev-button primary">Start session</button>
                 </div>
                 <div id="message" role="status" aria-live="polite"></div>
             </section>
@@ -96,6 +94,7 @@
                     <div class="frame-shell">
                         <div class="fullscreen-toolbar">
                             <button id="fullscreenBackButton" class="dev-button compact" disabled>Back</button>
+                            <button id="fullscreenScreenshotButton" class="dev-button compact" disabled>Screenshot</button>
                             <button id="fullscreenRefreshButton" class="dev-button compact" disabled>Refresh</button>
                             <button id="fullscreenStopButton" class="dev-button compact danger" disabled>End</button>
                             <button id="fullscreenExitButton" class="dev-button compact">Exit fullscreen</button>
@@ -112,6 +111,7 @@
                         </div>
                         <div class="button-row">
                             <button id="fullscreenButton" class="dev-button compact" disabled>Fullscreen</button>
+                            <button id="screenshotButton" class="dev-button compact" disabled>Screenshot</button>
                             <button id="refreshButton" class="dev-button compact" disabled>Refresh</button>
                             <button id="stopButton" class="dev-button compact danger" disabled>End</button>
                         </div>
@@ -148,6 +148,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=5"></script>
+<script src="../shared/remote-dev-view.js?v=6"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -32,7 +32,7 @@
         .head-unit-bezel::before { content: ''; position: absolute; z-index: 2; top: 7px; left: 50%; width: 6px; height: 6px; border-radius: 50%; transform: translateX(-50%); pointer-events: none; background: radial-gradient(circle at 40% 35%, #22454b 0, #071012 35%, #010203 72%); box-shadow: 0 0 0 1px rgba(255, 255, 255, .08), inset 0 0 2px rgba(89, 206, 224, .35); }
         .head-unit-bezel::after { content: ''; position: absolute; bottom: 8px; left: 50%; width: 34px; height: 2px; border-radius: 2px; transform: translateX(-50%); pointer-events: none; background: rgba(255, 255, 255, .13); box-shadow: 0 1px 0 rgba(0, 0, 0, .55); }
         .frame-shell { width: 100%; min-width: 0; min-height: 280px; aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 11px; overflow: hidden; position: relative; box-shadow: 0 0 0 1px rgba(0, 0, 0, .92), 0 0 0 2px rgba(255, 255, 255, .035), inset 0 0 18px rgba(0, 0, 0, .7); }
-        #remoteFrame { display: none; width: 100%; height: 100%; object-fit: contain; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
+        #remoteFrame { display: none; width: 100%; height: 100%; object-fit: contain; user-select: none; touch-action: none; cursor: crosshair; }
         .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
         .viewer-footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 10px; }
         .frame-status { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
@@ -102,14 +102,14 @@
                                 <button id="fullscreenExitButton" class="dev-button compact">Exit fullscreen</button>
                             </div>
                             <div id="framePlaceholder" class="frame-placeholder">Start a session to view Overdrive.</div>
-                            <img id="remoteFrame" alt="Live Overdrive app window">
+                            <canvas id="remoteFrame" width="960" height="540" role="img" aria-label="Live Overdrive app window"></canvas>
                         </div>
                     </div>
                     <div class="viewer-footer">
                         <div class="frame-status">
                             <span><span id="liveDot" class="status-dot"></span><span id="connectionState">Stopped</span></span>
                             <span id="frameDimensions">--</span>
-                            <span id="pixelCopyState">PixelCopy --</span>
+                            <span id="pixelCopyState">Capture --</span>
                             <span id="activityState">Activity --</span>
                         </div>
                         <div class="button-row">
@@ -128,6 +128,6 @@
 </div>
 
 <script src="../shared/auth.js"></script>
-<script src="../shared/remote-dev-view.js?v=8"></script>
+<script src="../shared/remote-dev-view.js?v=9"></script>
 </body>
 </html>

--- a/app/src/main/assets/web/local/remote-dev-view.html
+++ b/app/src/main/assets/web/local/remote-dev-view.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <title>Remote Overdrive Dev View</title>
+    <link rel="icon" type="image/webp" href="../shared/app-icon-dark.webp">
+    <script src="../shared/theme.js?v=5"></script>
+    <script src="../shared/app-shell.js?v=3"></script>
+    <link rel="stylesheet" href="../shared/styles.css?v=20">
+    <style>
+        .dev-view-page { max-width: 1500px; margin: 0 auto; padding: 24px; }
+        .dev-view-header { margin-bottom: 20px; }
+        .dev-view-header h1 { margin: 0 0 8px; color: var(--text-primary); }
+        .dev-view-header p { margin: 0; color: var(--text-secondary); line-height: 1.5; }
+        .dev-view-grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 18px; }
+        .dev-card { background: var(--bg-surface); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: 18px; }
+        .warning-card { border-color: rgba(245, 158, 11, .55); background: rgba(245, 158, 11, .08); margin-bottom: 18px; }
+        .warning-card strong { color: var(--warning); }
+        .warning-card p { color: var(--text-secondary); margin: 8px 0 0; line-height: 1.5; }
+        .confirm-row { display: flex; align-items: flex-start; gap: 10px; margin: 16px 0; color: var(--text-primary); line-height: 1.4; }
+        .confirm-row input { margin-top: 3px; width: 18px; height: 18px; }
+        .button-row { display: flex; flex-wrap: wrap; gap: 10px; }
+        .dev-button { appearance: none; border: 1px solid var(--border-subtle); border-radius: 10px; background: var(--bg-elevated); color: var(--text-primary); padding: 10px 14px; font: inherit; font-weight: 600; cursor: pointer; }
+        .dev-button.primary { border-color: var(--brand-primary); background: var(--brand-primary); color: #fff; }
+        .dev-button.danger { border-color: var(--danger); color: var(--danger); }
+        .dev-button:disabled { opacity: .45; cursor: default; }
+        .frame-shell { min-height: 360px; display: flex; align-items: center; justify-content: center; background: #050608; border-radius: 12px; overflow: hidden; position: relative; }
+        #remoteFrame { display: none; width: 100%; height: auto; user-select: none; -webkit-user-drag: none; touch-action: none; cursor: crosshair; }
+        .frame-placeholder { color: #9097a5; text-align: center; padding: 40px; line-height: 1.5; }
+        .frame-status { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-top: 12px; color: var(--text-secondary); font: 12px/1.4 'JetBrains Mono', monospace; }
+        .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 6px; background: #777; }
+        .status-dot.live { background: #22c55e; box-shadow: 0 0 8px rgba(34, 197, 94, .7); }
+        .control-stack { display: flex; flex-direction: column; gap: 14px; }
+        .control-stack h2 { margin: 0 0 10px; font-size: 16px; color: var(--text-primary); }
+        .control-note { color: var(--text-secondary); font-size: 13px; line-height: 1.45; margin: 0; }
+        .text-send { display: flex; gap: 8px; }
+        .text-send input { min-width: 0; flex: 1; border: 1px solid var(--border-subtle); border-radius: 9px; background: var(--bg-primary); color: var(--text-primary); padding: 10px; }
+        .dpad { display: grid; grid-template-columns: repeat(3, 48px); grid-template-rows: repeat(3, 42px); gap: 5px; justify-content: center; }
+        .dpad .dev-button { padding: 0; }
+        .dpad-up { grid-column: 2; } .dpad-left { grid-column: 1; grid-row: 2; }
+        .dpad-center { grid-column: 2; grid-row: 2; } .dpad-right { grid-column: 3; grid-row: 2; }
+        .dpad-down { grid-column: 2; grid-row: 3; }
+        #message { min-height: 20px; margin-top: 10px; color: var(--text-secondary); font-size: 13px; }
+        #message.error { color: var(--danger); }
+        @media (max-width: 980px) {
+            .dev-view-grid { grid-template-columns: 1fr; }
+            .dev-view-page { padding: 16px; }
+            .frame-shell { min-height: 240px; }
+        }
+    </style>
+</head>
+<body>
+<div class="app-layout">
+    <div id="app-shell-mount"></div>
+    <main class="main-content">
+        <div class="dev-view-page">
+            <header class="dev-view-header">
+                <h1>Remote Overdrive Dev View</h1>
+                <p>Inspect and operate Overdrive's live Android window when BYD's ACC-off cover makes whole-display capture black.</p>
+            </header>
+
+            <section id="startCard" class="dev-card warning-card">
+                <strong>This is a real, interactive app session.</strong>
+                <p>Touches and keys act inside Overdrive exactly as local input would. They can reach vehicle-control screens. The physical head-unit display is not turned on or uncovered by this feature; frames come from Overdrive's window underneath the OEM layer.</p>
+                <label class="confirm-row">
+                    <input id="confirmStart" type="checkbox">
+                    <span>I understand that remote input operates the live Overdrive app and will use it only while the vehicle is safely parked.</span>
+                </label>
+                <div class="button-row">
+                    <button id="startButton" class="dev-button primary" disabled>Start developer view</button>
+                </div>
+                <div id="message" role="status" aria-live="polite"></div>
+            </section>
+
+            <div class="dev-view-grid">
+                <section class="dev-card">
+                    <div class="frame-shell">
+                        <div id="framePlaceholder" class="frame-placeholder">Start a confirmed session to launch Overdrive and request its first app-window frame.</div>
+                        <img id="remoteFrame" alt="Live Overdrive app window">
+                    </div>
+                    <div class="frame-status">
+                        <span><span id="liveDot" class="status-dot"></span><span id="connectionState">Stopped</span></span>
+                        <span id="frameDimensions">--</span>
+                        <span id="pixelCopyState">PixelCopy --</span>
+                        <span id="activityState">Activity --</span>
+                    </div>
+                </section>
+
+                <aside class="control-stack">
+                    <section class="dev-card">
+                        <h2>Session</h2>
+                        <div class="button-row">
+                            <button id="refreshButton" class="dev-button" disabled>Refresh</button>
+                            <button id="stopButton" class="dev-button danger" disabled>End session</button>
+                        </div>
+                    </section>
+                    <section class="dev-card">
+                        <h2>Keys</h2>
+                        <div class="button-row">
+                            <button class="dev-button key-button" data-key="back" disabled>Back</button>
+                            <button class="dev-button key-button" data-key="enter" disabled>Enter</button>
+                            <button class="dev-button key-button" data-key="tab" disabled>Tab</button>
+                            <button class="dev-button key-button" data-key="escape" disabled>Esc</button>
+                        </div>
+                        <div class="dpad" style="margin-top:12px">
+                            <button class="dev-button key-button dpad-up" data-key="dpad_up" disabled>↑</button>
+                            <button class="dev-button key-button dpad-left" data-key="dpad_left" disabled>←</button>
+                            <button class="dev-button key-button dpad-center" data-key="dpad_center" disabled>●</button>
+                            <button class="dev-button key-button dpad-right" data-key="dpad_right" disabled>→</button>
+                            <button class="dev-button key-button dpad-down" data-key="dpad_down" disabled>↓</button>
+                        </div>
+                    </section>
+                    <section class="dev-card">
+                        <h2>Text input</h2>
+                        <div class="text-send">
+                            <input id="textInput" type="text" maxlength="256" placeholder="Type into focused field" disabled>
+                            <button id="textButton" class="dev-button" disabled>Send</button>
+                        </div>
+                    </section>
+                    <section class="dev-card">
+                        <h2>Pointer</h2>
+                        <p class="control-note">Click or drag directly on the frame. Touch coordinates are normalized to the captured app window and remain inside Overdrive's process.</p>
+                    </section>
+                </aside>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script src="../shared/auth.js"></script>
+<script src="../shared/remote-dev-view.js?v=1"></script>
+</body>
+</html>

--- a/app/src/main/assets/web/shared/app-shell.js
+++ b/app/src/main/assets/web/shared/app-shell.js
@@ -73,6 +73,7 @@
         // page that exists on web; the native diagnostics fragment is native.
         { divider: true, label: 'Diagnostics', i18n: 'nav.diagnostics_group' },
         { href: 'performance.html',                       i18n: 'nav.performance',    label: 'Performance',    svg: '<path d="M22 12h-4l-3 9L9 3l-3 9H2"/>' },
+        { href: 'remote-dev-view.html',                   label: 'Remote Dev View',  svg: '<rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/><path d="m9 8 2 2-2 2M13 12h2"/>' },
 
         // ===== Settings ===== — surveillance + recording + notifications
         // are settings sub-destinations under SettingsFragment on native.

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -16,6 +16,12 @@
     var startButton = document.getElementById('startButton');
     var stopButton = document.getElementById('stopButton');
     var refreshButton = document.getElementById('refreshButton');
+    var fullscreenButton = document.getElementById('fullscreenButton');
+    var fullscreenBackButton = document.getElementById('fullscreenBackButton');
+    var fullscreenRefreshButton = document.getElementById('fullscreenRefreshButton');
+    var fullscreenStopButton = document.getElementById('fullscreenStopButton');
+    var fullscreenExitButton = document.getElementById('fullscreenExitButton');
+    var viewerCard = document.getElementById('viewerCard');
     var image = document.getElementById('remoteFrame');
     var placeholder = document.getElementById('framePlaceholder');
     var message = document.getElementById('message');
@@ -37,6 +43,10 @@
         startButton.disabled = running || !confirmStart.checked;
         stopButton.disabled = !running;
         refreshButton.disabled = !running;
+        fullscreenButton.disabled = !running;
+        fullscreenBackButton.disabled = !running;
+        fullscreenRefreshButton.disabled = !running;
+        fullscreenStopButton.disabled = !running;
         textInput.disabled = !running;
         textButton.disabled = !running;
         var keyButtons = document.querySelectorAll('.key-button');
@@ -44,10 +54,66 @@
         liveDot.className = running ? 'status-dot live' : 'status-dot';
         connectionState.textContent = running ? 'Connected' : 'Stopped';
         if (!running) {
+            exitFullscreen();
             fetchingFrame = false;
             if (pollTimer) window.clearTimeout(pollTimer);
             pollTimer = null;
         }
+    }
+
+    function nativeFullscreenElement() {
+        return document.fullscreenElement || document.webkitFullscreenElement || null;
+    }
+
+    function isFullscreen() {
+        return nativeFullscreenElement() === viewerCard ||
+            document.body.classList.contains('dev-view-focus');
+    }
+
+    function syncFullscreenState() {
+        var active = isFullscreen();
+        fullscreenButton.textContent = active ? 'Exit fullscreen' : 'Fullscreen';
+        fullscreenButton.setAttribute('aria-pressed', active ? 'true' : 'false');
+    }
+
+    function enableFullscreenFallback() {
+        document.body.classList.add('dev-view-focus');
+        syncFullscreenState();
+    }
+
+    function enterFullscreen() {
+        if (!session || isFullscreen()) return;
+        var request = viewerCard.requestFullscreen || viewerCard.webkitRequestFullscreen;
+        if (!request) {
+            enableFullscreenFallback();
+            return;
+        }
+        try {
+            var result = request.call(viewerCard);
+            if (result && typeof result.catch === 'function') {
+                result.catch(enableFullscreenFallback);
+            }
+        } catch (error) {
+            enableFullscreenFallback();
+        }
+    }
+
+    function exitFullscreen() {
+        document.body.classList.remove('dev-view-focus');
+        var active = nativeFullscreenElement();
+        var exit = document.exitFullscreen || document.webkitExitFullscreen;
+        if (active === viewerCard && exit) {
+            try {
+                var result = exit.call(document);
+                if (result && typeof result.catch === 'function') result.catch(function () {});
+            } catch (error) {}
+        }
+        syncFullscreenState();
+    }
+
+    function toggleFullscreen() {
+        if (isFullscreen()) exitFullscreen();
+        else enterFullscreen();
     }
 
     function jsonRequest(path, method, payload) {
@@ -256,7 +322,17 @@
     });
     startButton.addEventListener('click', startSession);
     stopButton.addEventListener('click', function () { endSession(false); });
+    fullscreenStopButton.addEventListener('click', function () { endSession(false); });
+    fullscreenButton.addEventListener('click', toggleFullscreen);
+    fullscreenExitButton.addEventListener('click', exitFullscreen);
+    fullscreenBackButton.addEventListener('click', function () {
+        sendInput({ type: 'key', key: 'back' });
+    });
     refreshButton.addEventListener('click', function () {
+        forceRefresh = true;
+        if (!fetchingFrame) requestFrame();
+    });
+    fullscreenRefreshButton.addEventListener('click', function () {
         forceRefresh = true;
         if (!fetchingFrame) requestFrame();
     });
@@ -280,10 +356,18 @@
     document.addEventListener('visibilitychange', function () {
         if (!document.hidden && session && !fetchingFrame) requestFrame();
     });
+    document.addEventListener('fullscreenchange', syncFullscreenState);
+    document.addEventListener('webkitfullscreenchange', syncFullscreenState);
+    document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape' && document.body.classList.contains('dev-view-focus')) {
+            exitFullscreen();
+        }
+    });
     window.addEventListener('beforeunload', function () {
         if (session) endSession(true);
     });
 
     bindPointer();
     setRunning(false);
+    syncFullscreenState();
 })();

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -1,0 +1,289 @@
+(function () {
+    'use strict';
+
+    if (!window.BYDAuth || !BYDAuth.requireAuth()) return;
+
+    var session = null;
+    var stopped = true;
+    var fetchingFrame = false;
+    var forceRefresh = false;
+    var currentObjectUrl = null;
+    var inputChain = Promise.resolve();
+    var pollTimer = null;
+    var lastMoveAt = 0;
+
+    var confirmStart = document.getElementById('confirmStart');
+    var startButton = document.getElementById('startButton');
+    var stopButton = document.getElementById('stopButton');
+    var refreshButton = document.getElementById('refreshButton');
+    var image = document.getElementById('remoteFrame');
+    var placeholder = document.getElementById('framePlaceholder');
+    var message = document.getElementById('message');
+    var liveDot = document.getElementById('liveDot');
+    var connectionState = document.getElementById('connectionState');
+    var dimensions = document.getElementById('frameDimensions');
+    var pixelCopyState = document.getElementById('pixelCopyState');
+    var activityState = document.getElementById('activityState');
+    var textInput = document.getElementById('textInput');
+    var textButton = document.getElementById('textButton');
+
+    function setMessage(text, isError) {
+        message.textContent = text || '';
+        message.className = isError ? 'error' : '';
+    }
+
+    function setRunning(running) {
+        stopped = !running;
+        startButton.disabled = running || !confirmStart.checked;
+        stopButton.disabled = !running;
+        refreshButton.disabled = !running;
+        textInput.disabled = !running;
+        textButton.disabled = !running;
+        var keyButtons = document.querySelectorAll('.key-button');
+        for (var i = 0; i < keyButtons.length; i++) keyButtons[i].disabled = !running;
+        liveDot.className = running ? 'status-dot live' : 'status-dot';
+        connectionState.textContent = running ? 'Connected' : 'Stopped';
+        if (!running) {
+            fetchingFrame = false;
+            if (pollTimer) window.clearTimeout(pollTimer);
+            pollTimer = null;
+        }
+    }
+
+    function jsonRequest(path, method, payload) {
+        return BYDAuth.fetch(path, {
+            method: method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload || {})
+        }).then(function (response) {
+            return response.json().then(function (data) {
+                if (!response.ok || data.success === false) {
+                    var error = new Error(data.error || data.detail || ('HTTP ' + response.status));
+                    error.sessionInvalid = response.status === 403;
+                    throw error;
+                }
+                return data;
+            });
+        });
+    }
+
+    function startSession() {
+        if (!confirmStart.checked || session) return;
+        startButton.disabled = true;
+        setMessage('Starting the protected app-process bridge…', false);
+        jsonRequest('/api/dev-view/session', 'POST', { confirm: 'I UNDERSTAND' })
+            .then(function (data) {
+                session = data.session;
+                setRunning(true);
+                setMessage(data.activityReady
+                    ? 'Session ready. The physical display has not been changed.'
+                    : 'Bridge ready; waiting for the Overdrive activity to render.', false);
+                requestFrame();
+            })
+            .catch(function (error) {
+                session = null;
+                setRunning(false);
+                setMessage(error.message, true);
+            });
+    }
+
+    function scheduleFrame(delay) {
+        if (stopped || !session) return;
+        if (pollTimer) window.clearTimeout(pollTimer);
+        pollTimer = window.setTimeout(requestFrame, delay);
+    }
+
+    function requestFrame() {
+        if (stopped || !session || fetchingFrame || document.hidden) return;
+        fetchingFrame = true;
+        var token = session;
+        BYDAuth.fetch('/api/dev-view/frame', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session: token, maxWidth: 1280, quality: 72 }),
+            cache: 'no-store'
+        }).then(function (response) {
+            if (!response.ok) {
+                return response.json().then(function (data) {
+                    var error = new Error(data.error || data.detail || data.pixelCopyResult || ('HTTP ' + response.status));
+                    error.sessionInvalid = response.status === 403;
+                    throw error;
+                });
+            }
+            dimensions.textContent = response.headers.get('X-Overdrive-Width') + ' × ' +
+                response.headers.get('X-Overdrive-Height');
+            pixelCopyState.textContent = 'PixelCopy ' +
+                (response.headers.get('X-Overdrive-PixelCopy-Result') || '--') + ' (' +
+                (response.headers.get('X-Overdrive-PixelCopy-Code') || '--') + ')';
+            activityState.textContent = 'Activity ' +
+                shortActivity(response.headers.get('X-Overdrive-Activity'));
+            return response.blob();
+        }).then(function (blob) {
+            if (!blob || token !== session) return;
+            var nextUrl = URL.createObjectURL(blob);
+            image.onload = function () {
+                if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+                currentObjectUrl = nextUrl;
+                image.onload = null;
+            };
+            image.src = nextUrl;
+            image.style.display = 'block';
+            placeholder.style.display = 'none';
+            setMessage('', false);
+        }).catch(function (error) {
+            if (error.sessionInvalid) {
+                session = null;
+                setRunning(false);
+            }
+            setMessage(error.message + (error.sessionInvalid ? '.' : ' — retrying.'), true);
+        }).then(function () {
+            fetchingFrame = false;
+            var delay = forceRefresh ? 0 : 300;
+            forceRefresh = false;
+            scheduleFrame(delay);
+        });
+    }
+
+    function shortActivity(name) {
+        if (!name) return '--';
+        var index = name.lastIndexOf('.');
+        return index >= 0 ? name.substring(index + 1) : name;
+    }
+
+    function sendInput(payload) {
+        if (!session) return Promise.reject(new Error('No active session'));
+        payload.session = session;
+        inputChain = inputChain.then(function () {
+            return jsonRequest('/api/dev-view/input', 'POST', payload);
+        }).then(function () {
+            forceRefresh = true;
+            if (!fetchingFrame) requestFrame();
+        }).catch(function (error) {
+            if (error.sessionInvalid) {
+                session = null;
+                setRunning(false);
+            }
+            setMessage(error.message, true);
+        });
+        return inputChain;
+    }
+
+    function pointerPayload(event, phase) {
+        var rect = image.getBoundingClientRect();
+        var clientX = event.clientX;
+        var clientY = event.clientY;
+        if (event.touches && event.touches.length) {
+            clientX = event.touches[0].clientX;
+            clientY = event.touches[0].clientY;
+        } else if (event.changedTouches && event.changedTouches.length) {
+            clientX = event.changedTouches[0].clientX;
+            clientY = event.changedTouches[0].clientY;
+        }
+        if (typeof clientX !== 'number' || typeof clientY !== 'number') {
+            clientX = rect.left + rect.width / 2;
+            clientY = rect.top + rect.height / 2;
+        }
+        return {
+            type: 'touch', phase: phase,
+            x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+            y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height))
+        };
+    }
+
+    function bindPointer() {
+        var dragging = false;
+        image.addEventListener('mousedown', function (event) {
+            dragging = true;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'down'));
+        });
+        window.addEventListener('mousemove', function (event) {
+            if (!dragging) return;
+            var now = Date.now();
+            if (now - lastMoveAt < 50) return;
+            lastMoveAt = now;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'move'));
+        });
+        window.addEventListener('mouseup', function (event) {
+            if (!dragging) return;
+            dragging = false;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'up'));
+        });
+        image.addEventListener('touchstart', function (event) {
+            dragging = true;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'down'));
+        }, { passive: false });
+        image.addEventListener('touchmove', function (event) {
+            if (!dragging) return;
+            var now = Date.now();
+            if (now - lastMoveAt < 50) return;
+            lastMoveAt = now;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'move'));
+        }, { passive: false });
+        image.addEventListener('touchend', function (event) {
+            if (!dragging) return;
+            dragging = false;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'up'));
+        }, { passive: false });
+        image.addEventListener('touchcancel', function (event) {
+            if (!dragging) return;
+            dragging = false;
+            event.preventDefault();
+            sendInput(pointerPayload(event, 'cancel'));
+        }, { passive: false });
+    }
+
+    function endSession(silent) {
+        var token = session;
+        session = null;
+        setRunning(false);
+        if (!token) return Promise.resolve();
+        return jsonRequest('/api/dev-view/session', 'DELETE', { session: token })
+            .then(function () {
+                if (!silent) setMessage('Developer-view session ended.', false);
+            }).catch(function (error) {
+                if (!silent) setMessage(error.message, true);
+            });
+    }
+
+    confirmStart.addEventListener('change', function () {
+        startButton.disabled = !confirmStart.checked || !!session;
+    });
+    startButton.addEventListener('click', startSession);
+    stopButton.addEventListener('click', function () { endSession(false); });
+    refreshButton.addEventListener('click', function () {
+        forceRefresh = true;
+        if (!fetchingFrame) requestFrame();
+    });
+    var keyButtons = document.querySelectorAll('.key-button');
+    for (var i = 0; i < keyButtons.length; i++) {
+        keyButtons[i].addEventListener('click', function () {
+            sendInput({ type: 'key', key: this.getAttribute('data-key') });
+        });
+    }
+    textButton.addEventListener('click', function () {
+        if (!textInput.value) return;
+        sendInput({ type: 'text', text: textInput.value });
+        textInput.value = '';
+    });
+    textInput.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            textButton.click();
+        }
+    });
+    document.addEventListener('visibilitychange', function () {
+        if (!document.hidden && session && !fetchingFrame) requestFrame();
+    });
+    window.addEventListener('beforeunload', function () {
+        if (session) endSession(true);
+    });
+
+    bindPointer();
+    setRunning(false);
+})();

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -20,12 +20,16 @@
     var pendingFrameBlob = null;
     var frameTimes = [];
     var screenshotInFlight = false;
+    var pendingKeyboardText = '';
+    var keyboardTextTimer = null;
+    var keyboardComposing = false;
 
     var startButton = document.getElementById('startButton');
     var stopButton = document.getElementById('stopButton');
     var refreshButton = document.getElementById('refreshButton');
     var fullscreenButton = document.getElementById('fullscreenButton');
     var fullscreenBackButton = document.getElementById('fullscreenBackButton');
+    var fullscreenKeyboardButton = document.getElementById('fullscreenKeyboardButton');
     var fullscreenScreenshotButton = document.getElementById('fullscreenScreenshotButton');
     var fullscreenRefreshButton = document.getElementById('fullscreenRefreshButton');
     var fullscreenStopButton = document.getElementById('fullscreenStopButton');
@@ -39,8 +43,8 @@
     var dimensions = document.getElementById('frameDimensions');
     var pixelCopyState = document.getElementById('pixelCopyState');
     var activityState = document.getElementById('activityState');
-    var textInput = document.getElementById('textInput');
-    var textButton = document.getElementById('textButton');
+    var keyboardButton = document.getElementById('keyboardButton');
+    var keyboardCapture = document.getElementById('keyboardCapture');
     var screenshotButton = document.getElementById('screenshotButton');
 
     function setMessage(text, isError) {
@@ -56,14 +60,13 @@
         refreshButton.disabled = !running;
         fullscreenButton.disabled = !running;
         fullscreenBackButton.disabled = !running;
+        keyboardButton.disabled = !running;
+        fullscreenKeyboardButton.disabled = !running;
+        keyboardCapture.disabled = !running;
         screenshotButton.disabled = !running || screenshotInFlight;
         fullscreenScreenshotButton.disabled = !running || screenshotInFlight;
         fullscreenRefreshButton.disabled = !running;
         fullscreenStopButton.disabled = !running;
-        textInput.disabled = !running;
-        textButton.disabled = !running;
-        var keyButtons = document.querySelectorAll('.key-button');
-        for (var i = 0; i < keyButtons.length; i++) keyButtons[i].disabled = !running;
         liveDot.className = running ? 'status-dot live' : 'status-dot';
         connectionState.textContent = running ? 'Connected' : 'Stopped';
         if (!running) {
@@ -75,6 +78,11 @@
             renderingFrame = false;
             pendingFrameBlob = null;
             frameTimes = [];
+            pendingKeyboardText = '';
+            if (keyboardTextTimer) window.clearTimeout(keyboardTextTimer);
+            keyboardTextTimer = null;
+            keyboardCapture.value = '';
+            keyboardCapture.blur();
             if (pollTimer) window.clearTimeout(pollTimer);
             pollTimer = null;
         }
@@ -167,6 +175,8 @@
                     : 'Waiting for Overdrive to render...';
                 setMessage('', false);
                 openFrameStream();
+                try { viewerCard.focus({ preventScroll: true }); }
+                catch (error) { viewerCard.focus(); }
             })
             .catch(function (error) {
                 session = null;
@@ -437,6 +447,72 @@
         return inputChain;
     }
 
+    function flushKeyboardText() {
+        if (keyboardTextTimer) window.clearTimeout(keyboardTextTimer);
+        keyboardTextTimer = null;
+        if (!pendingKeyboardText || !session) {
+            pendingKeyboardText = '';
+            return;
+        }
+        var text = pendingKeyboardText;
+        pendingKeyboardText = '';
+        sendInput({ type: 'text', text: text });
+    }
+
+    function queueKeyboardText(text) {
+        if (!text || !session) return;
+        pendingKeyboardText += text;
+        if (pendingKeyboardText.length >= 256) {
+            var overflow = pendingKeyboardText.substring(256);
+            pendingKeyboardText = pendingKeyboardText.substring(0, 256);
+            flushKeyboardText();
+            if (overflow) queueKeyboardText(overflow);
+            return;
+        }
+        if (keyboardTextTimer) window.clearTimeout(keyboardTextTimer);
+        keyboardTextTimer = window.setTimeout(flushKeyboardText, 120);
+    }
+
+    function mappedRemoteKey(key) {
+        switch (key) {
+            case 'Escape': return 'back';
+            case 'Backspace': return 'delete';
+            case 'Enter': return 'enter';
+            case 'Tab': return 'tab';
+            case 'ArrowUp': return 'dpad_up';
+            case 'ArrowDown': return 'dpad_down';
+            case 'ArrowLeft': return 'dpad_left';
+            case 'ArrowRight': return 'dpad_right';
+            default: return null;
+        }
+    }
+
+    function forwardKeyboardEvent(event, captureTextLocally) {
+        if (stopped || event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
+            return false;
+        }
+        var mapped = mappedRemoteKey(event.key);
+        if (mapped) {
+            event.preventDefault();
+            flushKeyboardText();
+            sendInput({ type: 'key', key: mapped });
+            return true;
+        }
+        if (!captureTextLocally && event.key && event.key.length === 1) {
+            event.preventDefault();
+            queueKeyboardText(event.key);
+            return true;
+        }
+        return false;
+    }
+
+    function focusRemoteKeyboard() {
+        if (!session) return;
+        keyboardCapture.value = '';
+        try { keyboardCapture.focus({ preventScroll: true }); }
+        catch (error) { keyboardCapture.focus(); }
+    }
+
     function setScreenshotBusy(busy) {
         screenshotInFlight = busy;
         screenshotButton.disabled = stopped || busy;
@@ -610,6 +686,8 @@
     fullscreenBackButton.addEventListener('click', function () {
         sendInput({ type: 'key', key: 'back' });
     });
+    keyboardButton.addEventListener('click', focusRemoteKeyboard);
+    fullscreenKeyboardButton.addEventListener('click', focusRemoteKeyboard);
     refreshButton.addEventListener('click', function () {
         if (pollingFallback) {
             forceRefresh = true;
@@ -628,22 +706,32 @@
             openFrameStream();
         }
     });
-    var keyButtons = document.querySelectorAll('.key-button');
-    for (var i = 0; i < keyButtons.length; i++) {
-        keyButtons[i].addEventListener('click', function () {
-            sendInput({ type: 'key', key: this.getAttribute('data-key') });
-        });
-    }
-    textButton.addEventListener('click', function () {
-        if (!textInput.value) return;
-        sendInput({ type: 'text', text: textInput.value });
-        textInput.value = '';
+    keyboardCapture.addEventListener('focus', function () {
+        keyboardButton.textContent = 'Keyboard active';
+        fullscreenKeyboardButton.textContent = 'Keyboard active';
     });
-    textInput.addEventListener('keydown', function (event) {
-        if (event.key === 'Enter') {
-            event.preventDefault();
-            textButton.click();
-        }
+    keyboardCapture.addEventListener('blur', function () {
+        flushKeyboardText();
+        keyboardButton.textContent = 'Keyboard';
+        fullscreenKeyboardButton.textContent = 'Keyboard';
+    });
+    keyboardCapture.addEventListener('compositionstart', function () {
+        keyboardComposing = true;
+    });
+    keyboardCapture.addEventListener('compositionend', function (event) {
+        keyboardComposing = false;
+        var text = keyboardCapture.value || event.data || '';
+        keyboardCapture.value = '';
+        queueKeyboardText(text);
+    });
+    keyboardCapture.addEventListener('input', function () {
+        if (keyboardComposing) return;
+        var text = keyboardCapture.value;
+        keyboardCapture.value = '';
+        queueKeyboardText(text);
+    });
+    keyboardCapture.addEventListener('keydown', function (event) {
+        forwardKeyboardEvent(event, true);
     });
     document.addEventListener('visibilitychange', function () {
         if (document.hidden) {
@@ -658,9 +746,15 @@
     document.addEventListener('fullscreenchange', syncFullscreenState);
     document.addEventListener('webkitfullscreenchange', syncFullscreenState);
     document.addEventListener('keydown', function (event) {
-        if (event.key === 'Escape' && document.body.classList.contains('dev-view-focus')) {
+        if (event.key === 'Escape' && isFullscreen()) {
+            event.preventDefault();
             exitFullscreen();
+            return;
         }
+        var target = event.target;
+        if (target !== keyboardCapture && target && target.closest &&
+                target.closest('button, a, input, textarea, select')) return;
+        forwardKeyboardEvent(event, target === keyboardCapture);
     });
     window.addEventListener('beforeunload', function () {
         if (session) endSession(true);

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -12,6 +12,13 @@
     var pollTimer = null;
     var lastMoveAt = 0;
     var consecutiveFrameFailures = 0;
+    var frameSocket = null;
+    var reconnectTimer = null;
+    var reconnectAttempts = 0;
+    var pollingFallback = false;
+    var renderingFrame = false;
+    var pendingFrameBlob = null;
+    var frameTimes = [];
 
     var confirmStart = document.getElementById('confirmStart');
     var startButton = document.getElementById('startButton');
@@ -56,8 +63,13 @@
         connectionState.textContent = running ? 'Connected' : 'Stopped';
         if (!running) {
             exitFullscreen();
+            closeFrameStream();
             fetchingFrame = false;
             consecutiveFrameFailures = 0;
+            pollingFallback = false;
+            renderingFrame = false;
+            pendingFrameBlob = null;
+            frameTimes = [];
             if (pollTimer) window.clearTimeout(pollTimer);
             pollTimer = null;
         }
@@ -146,7 +158,7 @@
                 setMessage(data.activityReady
                     ? 'Session ready. The physical display has not been changed.'
                     : 'Bridge ready; waiting for the Overdrive activity to render.', false);
-                requestFrame();
+                openFrameStream();
             })
             .catch(function (error) {
                 session = null;
@@ -155,14 +167,188 @@
             });
     }
 
-    function scheduleFrame(delay) {
+    function closeFrameStream() {
+        if (reconnectTimer) window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+        var socket = frameSocket;
+        frameSocket = null;
+        if (!socket) return;
+        socket.onopen = null;
+        socket.onmessage = null;
+        socket.onerror = null;
+        socket.onclose = null;
+        try { socket.close(1000, 'stream stopped'); } catch (error) {}
+    }
+
+    function streamUrl() {
+        var protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        var url = protocol + '//' + window.location.host + '/ws/dev-view';
+        var jwt = BYDAuth.getToken();
+        if (jwt) url += '?token=' + encodeURIComponent(jwt);
+        return url;
+    }
+
+    function openFrameStream() {
+        if (stopped || !session || document.hidden) return;
+        if (typeof WebSocket === 'undefined' || !BYDAuth.getToken()) {
+            startPollingFallback('Live stream is unavailable; using compatibility mode.');
+            return;
+        }
+
+        closeFrameStream();
+        pollingFallback = false;
+        if (pollTimer) window.clearTimeout(pollTimer);
+        pollTimer = null;
+        var token = session;
+        var socket;
+        try {
+            // The JWT authenticates the WebSocket upgrade. The memory-only
+            // developer capability travels as a subprotocol, never in the URL.
+            socket = new WebSocket(streamUrl(), ['overdrive-dev-view', token]);
+        } catch (error) {
+            startPollingFallback('Live stream could not start; using compatibility mode.');
+            return;
+        }
+        frameSocket = socket;
+        socket.binaryType = 'blob';
+
+        socket.onopen = function () {
+            if (socket !== frameSocket || token !== session) return;
+            reconnectAttempts = 0;
+            connectionState.textContent = 'Live stream';
+            setMessage('', false);
+        };
+
+        socket.onmessage = function (event) {
+            if (socket !== frameSocket || token !== session) return;
+            if (typeof event.data === 'string') {
+                handleStreamMetadata(event.data);
+                return;
+            }
+            var blob = event.data instanceof Blob
+                ? event.data
+                : new Blob([event.data], { type: 'image/jpeg' });
+            renderFrame(blob);
+        };
+
+        socket.onerror = function () {
+            if (socket === frameSocket) connectionState.textContent = 'Stream reconnecting';
+        };
+
+        socket.onclose = function (event) {
+            if (socket !== frameSocket) return;
+            frameSocket = null;
+            if (stopped || token !== session || document.hidden) return;
+            if (event && event.code === 1008) {
+                session = null;
+                setRunning(false);
+                setMessage('Developer-view session expired.', true);
+                return;
+            }
+            reconnectAttempts += 1;
+            if (reconnectAttempts <= 3) {
+                connectionState.textContent = 'Stream reconnecting';
+                reconnectTimer = window.setTimeout(openFrameStream,
+                    Math.min(1500, reconnectAttempts * 350));
+            } else {
+                startPollingFallback('Live stream disconnected; using compatibility mode.');
+            }
+        };
+    }
+
+    function handleStreamMetadata(text) {
+        var data;
+        try { data = JSON.parse(text); } catch (error) { return; }
+        if (data.type === 'ready') {
+            connectionState.textContent = 'Live stream';
+            return;
+        }
+        if (data.type !== 'frame') return;
+
+        if (data.width && data.height) {
+            dimensions.textContent = data.width + ' × ' + data.height;
+        }
+        pixelCopyState.textContent = 'PixelCopy ' +
+            (data.pixelCopyResult || '--') + ' (' +
+            (typeof data.pixelCopyCode === 'number' ? data.pixelCopyCode : '--') + ')';
+        activityState.textContent = 'Activity ' + shortActivity(data.activity);
+
+        if (data.success) {
+            consecutiveFrameFailures = 0;
+            setMessage('', false);
+        } else {
+            consecutiveFrameFailures += 1;
+            if (!currentObjectUrl || consecutiveFrameFailures >= 3) {
+                setMessage((data.detail || data.error || data.pixelCopyResult || 'Capture failed') +
+                    ' — retrying.', true);
+            }
+        }
+    }
+
+    function renderFrame(blob) {
+        if (!blob || !blob.size) return;
+        if (renderingFrame) {
+            // Browser decode/display can lag behind the producer. Keep only
+            // the newest waiting frame so controls never show a stale backlog.
+            pendingFrameBlob = blob;
+            return;
+        }
+        renderingFrame = true;
+        var nextUrl = URL.createObjectURL(blob);
+        image.onload = function () {
+            if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+            currentObjectUrl = nextUrl;
+            image.onload = null;
+            image.onerror = null;
+            renderingFrame = false;
+            image.style.display = 'block';
+            placeholder.style.display = 'none';
+            noteDisplayedFrame();
+            if (pendingFrameBlob) {
+                var newest = pendingFrameBlob;
+                pendingFrameBlob = null;
+                renderFrame(newest);
+            }
+        };
+        image.onerror = function () {
+            URL.revokeObjectURL(nextUrl);
+            image.onload = null;
+            image.onerror = null;
+            renderingFrame = false;
+        };
+        image.src = nextUrl;
+    }
+
+    function noteDisplayedFrame() {
+        var now = Date.now();
+        frameTimes.push(now);
+        if (frameTimes.length > 12) frameTimes.shift();
+        if (frameTimes.length >= 2) {
+            var elapsed = frameTimes[frameTimes.length - 1] - frameTimes[0];
+            if (elapsed > 0) {
+                var fps = (frameTimes.length - 1) * 1000 / elapsed;
+                connectionState.textContent = 'Live · ' + fps.toFixed(1) + ' fps';
+            }
+        }
+    }
+
+    function startPollingFallback(reason) {
         if (stopped || !session) return;
+        closeFrameStream();
+        pollingFallback = true;
+        connectionState.textContent = 'Connected · compatibility';
+        if (reason) setMessage(reason, false);
+        requestFrame();
+    }
+
+    function scheduleFrame(delay) {
+        if (stopped || !session || !pollingFallback) return;
         if (pollTimer) window.clearTimeout(pollTimer);
         pollTimer = window.setTimeout(requestFrame, delay);
     }
 
     function requestFrame() {
-        if (stopped || !session || fetchingFrame || document.hidden) return;
+        if (stopped || !session || !pollingFallback || fetchingFrame || document.hidden) return;
         fetchingFrame = true;
         var frameFailed = false;
         var token = session;
@@ -189,15 +375,7 @@
             return response.blob();
         }).then(function (blob) {
             if (!blob || token !== session) return;
-            var nextUrl = URL.createObjectURL(blob);
-            image.onload = function () {
-                if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
-                currentObjectUrl = nextUrl;
-                image.onload = null;
-            };
-            image.src = nextUrl;
-            image.style.display = 'block';
-            placeholder.style.display = 'none';
+            renderFrame(blob);
             consecutiveFrameFailures = 0;
             setMessage('', false);
         }).catch(function (error) {
@@ -232,8 +410,10 @@
         inputChain = inputChain.then(function () {
             return jsonRequest('/api/dev-view/input', 'POST', payload);
         }).then(function () {
-            forceRefresh = true;
-            if (!fetchingFrame) requestFrame();
+            if (pollingFallback) {
+                forceRefresh = true;
+                if (!fetchingFrame) requestFrame();
+            }
         }).catch(function (error) {
             if (error.sessionInvalid) {
                 session = null;
@@ -339,12 +519,22 @@
         sendInput({ type: 'key', key: 'back' });
     });
     refreshButton.addEventListener('click', function () {
-        forceRefresh = true;
-        if (!fetchingFrame) requestFrame();
+        if (pollingFallback) {
+            forceRefresh = true;
+            if (!fetchingFrame) requestFrame();
+        } else {
+            reconnectAttempts = 0;
+            openFrameStream();
+        }
     });
     fullscreenRefreshButton.addEventListener('click', function () {
-        forceRefresh = true;
-        if (!fetchingFrame) requestFrame();
+        if (pollingFallback) {
+            forceRefresh = true;
+            if (!fetchingFrame) requestFrame();
+        } else {
+            reconnectAttempts = 0;
+            openFrameStream();
+        }
     });
     var keyButtons = document.querySelectorAll('.key-button');
     for (var i = 0; i < keyButtons.length; i++) {
@@ -364,7 +554,14 @@
         }
     });
     document.addEventListener('visibilitychange', function () {
-        if (!document.hidden && session && !fetchingFrame) requestFrame();
+        if (document.hidden) {
+            closeFrameStream();
+            if (pollTimer) window.clearTimeout(pollTimer);
+            pollTimer = null;
+        } else if (session) {
+            reconnectAttempts = 0;
+            openFrameStream();
+        }
     });
     document.addEventListener('fullscreenchange', syncFullscreenState);
     document.addEventListener('webkitfullscreenchange', syncFullscreenState);

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -36,6 +36,7 @@
     var fullscreenExitButton = document.getElementById('fullscreenExitButton');
     var viewerCard = document.getElementById('viewerCard');
     var image = document.getElementById('remoteFrame');
+    var frameContext = image.getContext('2d', { alpha: false });
     var placeholder = document.getElementById('framePlaceholder');
     var message = document.getElementById('message');
     var liveDot = document.getElementById('liveDot');
@@ -295,7 +296,7 @@
         if (data.width && data.height) {
             dimensions.textContent = data.width + ' × ' + data.height;
         }
-        pixelCopyState.textContent = 'PixelCopy ' +
+        pixelCopyState.textContent = (data.captureBackend || 'PixelCopy') + ' ' +
             (data.pixelCopyResult || '--') + ' (' +
             (typeof data.pixelCopyCode === 'number' ? data.pixelCopyCode : '--') + ')';
         activityState.textContent = 'Activity ' + shortActivity(data.activity);
@@ -317,7 +318,11 @@
         loader.onload = function () {
             var previousUrl = currentObjectUrl;
             currentObjectUrl = nextUrl;
-            image.src = nextUrl;
+            if (image.width !== loader.naturalWidth || image.height !== loader.naturalHeight) {
+                image.width = loader.naturalWidth;
+                image.height = loader.naturalHeight;
+            }
+            frameContext.drawImage(loader, 0, 0, image.width, image.height);
             renderingFrame = false;
             image.style.display = 'block';
             placeholder.style.display = 'none';
@@ -386,7 +391,8 @@
             }
             dimensions.textContent = response.headers.get('X-Overdrive-Width') + ' × ' +
                 response.headers.get('X-Overdrive-Height');
-            pixelCopyState.textContent = 'PixelCopy ' +
+            pixelCopyState.textContent =
+                (response.headers.get('X-Overdrive-Capture-Backend') || 'PixelCopy') + ' ' +
                 (response.headers.get('X-Overdrive-PixelCopy-Result') || '--') + ' (' +
                 (response.headers.get('X-Overdrive-PixelCopy-Code') || '--') + ')';
             activityState.textContent = 'Activity ' +
@@ -415,7 +421,7 @@
             fetchingFrame = false;
             var delay = forceRefresh ? 0 : (frameFailed
                 ? Math.min(1000, 120 * consecutiveFrameFailures)
-                : 60);
+                : 100);
             forceRefresh = false;
             scheduleFrame(delay);
         });
@@ -571,8 +577,8 @@
 
     function frameContentRect() {
         var rect = image.getBoundingClientRect();
-        var naturalWidth = image.naturalWidth || 16;
-        var naturalHeight = image.naturalHeight || 9;
+        var naturalWidth = image.width || 16;
+        var naturalHeight = image.height || 9;
         var imageAspect = naturalWidth / naturalHeight;
         var boxAspect = rect.width / Math.max(1, rect.height);
         if (boxAspect > imageAspect) {

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -19,13 +19,14 @@
     var renderingFrame = false;
     var pendingFrameBlob = null;
     var frameTimes = [];
+    var screenshotInFlight = false;
 
-    var confirmStart = document.getElementById('confirmStart');
     var startButton = document.getElementById('startButton');
     var stopButton = document.getElementById('stopButton');
     var refreshButton = document.getElementById('refreshButton');
     var fullscreenButton = document.getElementById('fullscreenButton');
     var fullscreenBackButton = document.getElementById('fullscreenBackButton');
+    var fullscreenScreenshotButton = document.getElementById('fullscreenScreenshotButton');
     var fullscreenRefreshButton = document.getElementById('fullscreenRefreshButton');
     var fullscreenStopButton = document.getElementById('fullscreenStopButton');
     var fullscreenExitButton = document.getElementById('fullscreenExitButton');
@@ -40,6 +41,7 @@
     var activityState = document.getElementById('activityState');
     var textInput = document.getElementById('textInput');
     var textButton = document.getElementById('textButton');
+    var screenshotButton = document.getElementById('screenshotButton');
 
     function setMessage(text, isError) {
         message.textContent = text || '';
@@ -48,11 +50,14 @@
 
     function setRunning(running) {
         stopped = !running;
-        startButton.disabled = running || !confirmStart.checked;
+        startButton.disabled = running;
+        startButton.textContent = running ? 'Session active' : 'Start session';
         stopButton.disabled = !running;
         refreshButton.disabled = !running;
         fullscreenButton.disabled = !running;
         fullscreenBackButton.disabled = !running;
+        screenshotButton.disabled = !running || screenshotInFlight;
+        fullscreenScreenshotButton.disabled = !running || screenshotInFlight;
         fullscreenRefreshButton.disabled = !running;
         fullscreenStopButton.disabled = !running;
         textInput.disabled = !running;
@@ -148,16 +153,19 @@
     }
 
     function startSession() {
-        if (!confirmStart.checked || session) return;
+        if (session) return;
         startButton.disabled = true;
-        setMessage('Starting the protected app-process bridge…', false);
+        startButton.textContent = 'Starting...';
+        connectionState.textContent = 'Starting';
+        setMessage('', false);
         jsonRequest('/api/dev-view/session', 'POST', { confirm: 'I UNDERSTAND' })
             .then(function (data) {
                 session = data.session;
                 setRunning(true);
-                setMessage(data.activityReady
-                    ? 'Session ready. The physical display has not been changed.'
-                    : 'Bridge ready; waiting for the Overdrive activity to render.', false);
+                placeholder.textContent = data.activityReady
+                    ? 'Connecting live stream...'
+                    : 'Waiting for Overdrive to render...';
+                setMessage('', false);
                 openFrameStream();
             })
             .catch(function (error) {
@@ -278,10 +286,10 @@
             setMessage('', false);
         } else {
             consecutiveFrameFailures += 1;
-            if (!currentObjectUrl || consecutiveFrameFailures >= 3) {
-                setMessage((data.detail || data.error || data.pixelCopyResult || 'Capture failed') +
-                    ' — retrying.', true);
-            }
+            connectionState.textContent = currentObjectUrl
+                ? 'Live - holding last frame'
+                : 'Waiting for a stable frame';
+            if (!currentObjectUrl) placeholder.textContent = 'Waiting for a stable app frame...';
         }
     }
 
@@ -295,28 +303,29 @@
         }
         renderingFrame = true;
         var nextUrl = URL.createObjectURL(blob);
-        image.onload = function () {
-            if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+        var loader = new Image();
+        loader.onload = function () {
+            var previousUrl = currentObjectUrl;
             currentObjectUrl = nextUrl;
-            image.onload = null;
-            image.onerror = null;
+            image.src = nextUrl;
             renderingFrame = false;
             image.style.display = 'block';
             placeholder.style.display = 'none';
             noteDisplayedFrame();
+            if (previousUrl) {
+                window.setTimeout(function () { URL.revokeObjectURL(previousUrl); }, 1000);
+            }
             if (pendingFrameBlob) {
                 var newest = pendingFrameBlob;
                 pendingFrameBlob = null;
                 renderFrame(newest);
             }
         };
-        image.onerror = function () {
+        loader.onerror = function () {
             URL.revokeObjectURL(nextUrl);
-            image.onload = null;
-            image.onerror = null;
             renderingFrame = false;
         };
-        image.src = nextUrl;
+        loader.src = nextUrl;
     }
 
     function noteDisplayedFrame() {
@@ -385,8 +394,12 @@
                 session = null;
                 setRunning(false);
             }
-            if (error.sessionInvalid || !currentObjectUrl || consecutiveFrameFailures >= 3) {
-                setMessage(error.message + (error.sessionInvalid ? '.' : ' — retrying.'), true);
+            if (error.sessionInvalid) setMessage(error.message + '.', true);
+            else {
+                connectionState.textContent = currentObjectUrl
+                    ? 'Connected - holding last frame'
+                    : 'Waiting for a stable frame';
+                if (!currentObjectUrl) placeholder.textContent = 'Waiting for a stable app frame...';
             }
         }).then(function () {
             fetchingFrame = false;
@@ -424,8 +437,88 @@
         return inputChain;
     }
 
-    function pointerPayload(event, phase) {
+    function setScreenshotBusy(busy) {
+        screenshotInFlight = busy;
+        screenshotButton.disabled = stopped || busy;
+        fullscreenScreenshotButton.disabled = stopped || busy;
+        screenshotButton.textContent = busy ? 'Capturing...' : 'Screenshot';
+        fullscreenScreenshotButton.textContent = busy ? 'Capturing...' : 'Screenshot';
+    }
+
+    function captureScreenshot() {
+        if (!session || screenshotInFlight) return;
+        var token = session;
+        setScreenshotBusy(true);
+        BYDAuth.fetch('/api/dev-view/frame', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                session: token,
+                maxWidth: 1920,
+                quality: 100,
+                format: 'png'
+            }),
+            cache: 'no-store'
+        }).then(function (response) {
+            if (!response.ok) {
+                return response.json().then(function (data) {
+                    var error = new Error(data.error || data.detail ||
+                        data.pixelCopyResult || ('HTTP ' + response.status));
+                    error.sessionInvalid = response.status === 403;
+                    throw error;
+                });
+            }
+            return response.blob();
+        }).then(function (blob) {
+            if (!blob || !blob.size || token !== session) return;
+            var url = URL.createObjectURL(blob);
+            var link = document.createElement('a');
+            link.href = url;
+            link.download = 'overdrive-dev-view-' +
+                new Date().toISOString().replace(/[:.]/g, '-') + '.png';
+            link.style.display = 'none';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
+            setMessage('', false);
+        }).catch(function (error) {
+            if (error.sessionInvalid) {
+                session = null;
+                setRunning(false);
+            }
+            setMessage('Screenshot failed: ' + error.message, true);
+        }).then(function () {
+            setScreenshotBusy(false);
+        });
+    }
+
+    function frameContentRect() {
         var rect = image.getBoundingClientRect();
+        var naturalWidth = image.naturalWidth || 16;
+        var naturalHeight = image.naturalHeight || 9;
+        var imageAspect = naturalWidth / naturalHeight;
+        var boxAspect = rect.width / Math.max(1, rect.height);
+        if (boxAspect > imageAspect) {
+            var width = rect.height * imageAspect;
+            return {
+                left: rect.left + (rect.width - width) / 2,
+                top: rect.top,
+                width: width,
+                height: rect.height
+            };
+        }
+        var height = rect.width / imageAspect;
+        return {
+            left: rect.left,
+            top: rect.top + (rect.height - height) / 2,
+            width: rect.width,
+            height: height
+        };
+    }
+
+    function pointerPayload(event, phase) {
+        var rect = frameContentRect();
         var clientX = event.clientX;
         var clientY = event.clientY;
         if (event.touches && event.touches.length) {
@@ -507,13 +600,12 @@
             });
     }
 
-    confirmStart.addEventListener('change', function () {
-        startButton.disabled = !confirmStart.checked || !!session;
-    });
     startButton.addEventListener('click', startSession);
     stopButton.addEventListener('click', function () { endSession(false); });
     fullscreenStopButton.addEventListener('click', function () { endSession(false); });
     fullscreenButton.addEventListener('click', toggleFullscreen);
+    screenshotButton.addEventListener('click', captureScreenshot);
+    fullscreenScreenshotButton.addEventListener('click', captureScreenshot);
     fullscreenExitButton.addEventListener('click', exitFullscreen);
     fullscreenBackButton.addEventListener('click', function () {
         sendInput({ type: 'key', key: 'back' });

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    if (!window.BYDAuth || !BYDAuth.requireAuth()) return;
+    if (typeof BYDAuth === 'undefined' || !BYDAuth.requireAuth()) return;
 
     var session = null;
     var stopped = true;

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -11,6 +11,7 @@
     var inputChain = Promise.resolve();
     var pollTimer = null;
     var lastMoveAt = 0;
+    var consecutiveFrameFailures = 0;
 
     var confirmStart = document.getElementById('confirmStart');
     var startButton = document.getElementById('startButton');
@@ -56,6 +57,7 @@
         if (!running) {
             exitFullscreen();
             fetchingFrame = false;
+            consecutiveFrameFailures = 0;
             if (pollTimer) window.clearTimeout(pollTimer);
             pollTimer = null;
         }
@@ -162,11 +164,12 @@
     function requestFrame() {
         if (stopped || !session || fetchingFrame || document.hidden) return;
         fetchingFrame = true;
+        var frameFailed = false;
         var token = session;
         BYDAuth.fetch('/api/dev-view/frame', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ session: token, maxWidth: 1280, quality: 72 }),
+            body: JSON.stringify({ session: token, maxWidth: 960, quality: 55 }),
             cache: 'no-store'
         }).then(function (response) {
             if (!response.ok) {
@@ -195,16 +198,23 @@
             image.src = nextUrl;
             image.style.display = 'block';
             placeholder.style.display = 'none';
+            consecutiveFrameFailures = 0;
             setMessage('', false);
         }).catch(function (error) {
+            frameFailed = true;
+            consecutiveFrameFailures += 1;
             if (error.sessionInvalid) {
                 session = null;
                 setRunning(false);
             }
-            setMessage(error.message + (error.sessionInvalid ? '.' : ' — retrying.'), true);
+            if (error.sessionInvalid || !currentObjectUrl || consecutiveFrameFailures >= 3) {
+                setMessage(error.message + (error.sessionInvalid ? '.' : ' — retrying.'), true);
+            }
         }).then(function () {
             fetchingFrame = false;
-            var delay = forceRefresh ? 0 : 300;
+            var delay = forceRefresh ? 0 : (frameFailed
+                ? Math.min(1000, 120 * consecutiveFrameFailures)
+                : 60);
             forceRefresh = false;
             scheduleFrame(delay);
         });

--- a/app/src/main/assets/web/shared/remote-dev-view.js
+++ b/app/src/main/assets/web/shared/remote-dev-view.js
@@ -273,6 +273,15 @@
         }
         if (data.type !== 'frame') return;
 
+        if (!data.success) {
+            consecutiveFrameFailures += 1;
+            if (!currentObjectUrl) {
+                connectionState.textContent = 'Waiting for a stable frame';
+                placeholder.textContent = 'Waiting for a stable app frame...';
+            }
+            return;
+        }
+
         if (data.width && data.height) {
             dimensions.textContent = data.width + ' × ' + data.height;
         }
@@ -280,17 +289,8 @@
             (data.pixelCopyResult || '--') + ' (' +
             (typeof data.pixelCopyCode === 'number' ? data.pixelCopyCode : '--') + ')';
         activityState.textContent = 'Activity ' + shortActivity(data.activity);
-
-        if (data.success) {
-            consecutiveFrameFailures = 0;
-            setMessage('', false);
-        } else {
-            consecutiveFrameFailures += 1;
-            connectionState.textContent = currentObjectUrl
-                ? 'Live - holding last frame'
-                : 'Waiting for a stable frame';
-            if (!currentObjectUrl) placeholder.textContent = 'Waiting for a stable app frame...';
-        }
+        consecutiveFrameFailures = 0;
+        setMessage('', false);
     }
 
     function renderFrame(blob) {

--- a/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
+++ b/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
@@ -1,6 +1,7 @@
 package com.overdrive.app
 
 import android.app.Application
+import android.content.Intent
 import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
@@ -25,9 +26,15 @@ class OverdriveApplication : Application() {
         super.onCreate()
 
         // Track only this app's Activity/Window roots for the authenticated
-        // Remote Overdrive Dev View. The controller is dormant until the
-        // shell-daemon bridge is explicitly started for a confirmed session.
+        // Remote Overdrive Dev View. Capture and input stay dormant until an
+        // expiring HTTP session sends a command over the shell-authenticated
+        // private Unix socket.
         RemoteDevViewController.install(this)
+        try {
+            startService(Intent(this, com.overdrive.app.remote.RemoteDevViewBridgeService::class.java))
+        } catch (error: Throwable) {
+            Log.w("OverdriveApplication", "Remote dev-view bridge unavailable: ${error.message}")
+        }
 
         // Apply the user-picked locale before any Activity/Fragment is created.
         // Auto-mode (or unset) writes an empty list so AppCompat falls back to

--- a/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
+++ b/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
@@ -9,6 +9,7 @@ import com.overdrive.app.config.ConfigManager
 import com.overdrive.app.logging.LogCleaner
 import com.overdrive.app.logging.LogConfig
 import com.overdrive.app.logging.LogManager
+import com.overdrive.app.remote.RemoteDevViewController
 import com.overdrive.app.server.LocaleManager
 import com.overdrive.app.services.DaemonKeepaliveService
 // import com.overdrive.app.shell.PrivilegedShellSetup
@@ -22,6 +23,11 @@ class OverdriveApplication : Application() {
     
     override fun onCreate() {
         super.onCreate()
+
+        // Track only this app's Activity/Window roots for the authenticated
+        // Remote Overdrive Dev View. The controller is dormant until the
+        // shell-daemon bridge is explicitly started for a confirmed session.
+        RemoteDevViewController.install(this)
 
         // Apply the user-picked locale before any Activity/Fragment is created.
         // Auto-mode (or unset) writes an empty list so AppCompat falls back to

--- a/app/src/main/java/com/overdrive/app/daemon/TelegramBotDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/TelegramBotDaemon.java
@@ -68,6 +68,7 @@ public class TelegramBotDaemon {
     //   19880 — Telegram bot IPC (this daemon)
     // Was previously 19878 which collides with BydEventDaemon — whichever
     // daemon started second silently failed to bind. Moved to 19880.
+    //   19881 - Remote Overdrive Dev View app-process bridge (loopback only)
     private static final int IPC_PORT = 19880;
     
     // Singleton lock (same pattern as CameraDaemon / AccSentryDaemon)

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeAuth.java
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeAuth.java
@@ -1,0 +1,96 @@
+package com.overdrive.app.remote;
+
+import android.util.Base64;
+
+import com.overdrive.app.auth.AuthManager;
+
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/** Authenticated envelope for the app-process developer-view loopback bridge. */
+public final class RemoteDevViewBridgeAuth {
+    public static final long MAX_CLOCK_SKEW_MS = 30_000L;
+
+    private static final int NONCE_BYTES = 24;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private RemoteDevViewBridgeAuth() {}
+
+    public static String sign(JSONObject request) throws Exception {
+        long timestampMs = System.currentTimeMillis();
+        byte[] nonceBytes = new byte[NONCE_BYTES];
+        RANDOM.nextBytes(nonceBytes);
+        String nonce = base64Url(nonceBytes);
+        String requestBase64 = base64Url(request.toString().getBytes(StandardCharsets.UTF_8));
+        String signature = signature(timestampMs, nonce, requestBase64);
+        return new JSONObject()
+            .put("timestampMs", timestampMs)
+            .put("nonce", nonce)
+            .put("request", requestBase64)
+            .put("signature", signature)
+            .toString();
+    }
+
+    public static AuthenticatedRequest verify(String envelopeText) throws Exception {
+        JSONObject envelope = new JSONObject(envelopeText);
+        long timestampMs = envelope.optLong("timestampMs", 0L);
+        String nonce = envelope.optString("nonce", "");
+        String requestBase64 = envelope.optString("request", "");
+        String suppliedSignature = envelope.optString("signature", "");
+        long now = System.currentTimeMillis();
+        if (timestampMs <= 0L || Math.abs(now - timestampMs) > MAX_CLOCK_SKEW_MS) {
+            throw new SecurityException("Bridge request timestamp is outside the allowed window");
+        }
+        if (nonce.isEmpty() || requestBase64.isEmpty() || suppliedSignature.isEmpty()) {
+            throw new SecurityException("Bridge authentication is incomplete");
+        }
+        String expectedSignature = signature(timestampMs, nonce, requestBase64);
+        if (!MessageDigest.isEqual(
+                suppliedSignature.getBytes(StandardCharsets.US_ASCII),
+                expectedSignature.getBytes(StandardCharsets.US_ASCII))) {
+            throw new SecurityException("Bridge authentication failed");
+        }
+        byte[] requestBytes = Base64.decode(
+            requestBase64, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+        return new AuthenticatedRequest(
+            timestampMs,
+            nonce,
+            new JSONObject(new String(requestBytes, StandardCharsets.UTF_8)));
+    }
+
+    private static String signature(long timestampMs, String nonce, String requestBase64)
+            throws Exception {
+        AuthManager.AuthState state = AuthManager.getState();
+        if (state == null || state.deviceSecret == null || state.deviceSecret.isEmpty()) {
+            throw new SecurityException("Device authentication is not ready");
+        }
+        String content = timestampMs + "\n" + nonce + "\n" + requestBase64;
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(
+            state.deviceSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        return base64Url(mac.doFinal(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static String base64Url(byte[] bytes) {
+        return Base64.encodeToString(
+            bytes, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+    }
+
+    public static final class AuthenticatedRequest {
+        public final long timestampMs;
+        public final String nonce;
+        public final JSONObject request;
+
+        AuthenticatedRequest(long timestampMs, String nonce, JSONObject request) {
+            this.timestampMs = timestampMs;
+            this.nonce = nonce;
+            this.request = request;
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -4,7 +4,6 @@ import android.app.Service
 import android.content.Intent
 import android.os.IBinder
 import android.util.Log
-import com.overdrive.app.ui.MainActivity
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
@@ -48,6 +47,7 @@ class RemoteDevViewBridgeService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
+        RemoteDevVirtualDisplay.stop()
         try { serverSocket?.close() } catch (_: Exception) {}
         listener.shutdownNow()
         clients.shutdownNow()
@@ -88,11 +88,24 @@ class RemoteDevViewBridgeService : Service() {
                 val request = authenticated.request
                 when (request.optString("command", "")) {
                     "launch" -> {
-                        launchOverdrive()
-                        response.put("success", true)
-                        response.put("launchRequested", true)
+                        val launch = RemoteDevVirtualDisplay.start(application)
+                        response.put("success", launch.success)
+                        response.put("launchRequested", launch.success)
+                        response.put("captureBackend", RemoteDevVirtualDisplay.BACKEND_NAME)
+                        response.put("displayId", launch.displayId)
+                        if (launch.detail != null) response.put("detail", launch.detail)
                     }
-                    "status" -> putInputResult(response, RemoteDevViewController.status())
+                    "status" -> {
+                        putInputResult(response, RemoteDevViewController.status())
+                        response.put("captureBackend", RemoteDevVirtualDisplay.BACKEND_NAME)
+                        response.put("virtualDisplayRunning", RemoteDevVirtualDisplay.isRunning())
+                        response.put("displayId", RemoteDevVirtualDisplay.displayId())
+                    }
+                    "stop" -> {
+                        RemoteDevVirtualDisplay.stop()
+                        response.put("success", true)
+                        response.put("stopped", true)
+                    }
                     "capture" -> {
                         val capture = RemoteDevViewController.capture(
                             request.optInt("maxWidth", DEFAULT_MAX_WIDTH)
@@ -108,6 +121,8 @@ class RemoteDevViewBridgeService : Service() {
                         response.put("height", capture.height)
                         response.put("activity", capture.activityName ?: JSONObject.NULL)
                         response.put("mimeType", capture.mimeType)
+                        response.put("captureBackend", capture.backend)
+                        response.put("frameSequence", capture.sequence)
                         if (capture.detail != null) response.put("detail", capture.detail)
                         payload = capture.jpeg
                     }
@@ -153,20 +168,6 @@ class RemoteDevViewBridgeService : Service() {
             output.flush()
         } catch (error: Throwable) {
             Log.w(TAG, "Unable to return bridge response", error)
-        }
-    }
-
-    private fun launchOverdrive() {
-        try {
-            startActivity(
-                Intent(this, MainActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                }
-            )
-        } catch (error: Throwable) {
-            Log.w(TAG, "Unable to launch MainActivity for developer view", error)
         }
     }
 

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -196,7 +196,7 @@ class RemoteDevViewBridgeService : Service() {
     }
 
     companion object {
-        const val PORT = 19878
+        const val PORT = 19881
 
         private const val TAG = "RemoteDevViewBridge"
         private const val BACKLOG = 4

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -99,6 +99,7 @@ class RemoteDevViewBridgeService : Service() {
                                 .coerceIn(MIN_WIDTH, MAX_WIDTH),
                             request.optInt("quality", DEFAULT_QUALITY)
                                 .coerceIn(MIN_QUALITY, MAX_QUALITY),
+                            request.optString("format", "jpeg"),
                         )
                         response.put("success", capture.jpeg != null)
                         response.put("pixelCopyCode", capture.resultCode)
@@ -106,6 +107,7 @@ class RemoteDevViewBridgeService : Service() {
                         response.put("width", capture.width)
                         response.put("height", capture.height)
                         response.put("activity", capture.activityName ?: JSONObject.NULL)
+                        response.put("mimeType", capture.mimeType)
                         if (capture.detail != null) response.put("detail", capture.detail)
                         payload = capture.jpeg
                     }

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -2,35 +2,29 @@ package com.overdrive.app.remote
 
 import android.app.Service
 import android.content.Intent
+import android.net.LocalServerSocket
+import android.net.LocalSocket
 import android.os.IBinder
-import android.os.SystemClock
 import android.util.Log
 import com.overdrive.app.ui.MainActivity
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 import java.io.InputStream
-import java.net.InetAddress
-import java.net.ServerSocket
-import java.net.Socket
-import java.net.SocketTimeoutException
 import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 /**
- * DUMP-permission-protected, loopback-only bridge into Overdrive's UI process.
- * The shell camera daemon supplies a fresh in-memory secret every time it starts
- * the bridge. Nothing is persisted and no frame is written to storage.
+ * Private app service exposing an abstract Unix-domain socket to the shell
+ * camera daemon. Every accepted connection is authenticated with kernel peer
+ * credentials (uid 2000); nothing is persisted and no frame touches storage.
  */
 class RemoteDevViewBridgeService : Service() {
     private val worker: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "remote-dev-view-bridge").apply { isDaemon = true }
     }
-    @Volatile private var secret: String? = null
-    @Volatile private var serverSocket: ServerSocket? = null
-    @Volatile private var lastAuthorizedAtElapsedMs = 0L
+    @Volatile private var serverSocket: LocalServerSocket? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -38,23 +32,13 @@ class RemoteDevViewBridgeService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val supplied = intent?.getStringExtra(EXTRA_BRIDGE_SECRET)
-        if (supplied.isNullOrBlank() || supplied.length < 32) {
-            Log.w(TAG, "Rejected bridge start without a valid ephemeral secret")
-            stopSelf(startId)
-            return START_NOT_STICKY
-        }
-        secret = supplied
-        lastAuthorizedAtElapsedMs = SystemClock.elapsedRealtime()
         ensureListening()
-        if (intent.getBooleanExtra(EXTRA_LAUNCH_ACTIVITY, false)) launchOverdrive()
         return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        secret = null
         try { serverSocket?.close() } catch (_: Exception) {}
         worker.shutdownNow()
         super.onDestroy()
@@ -62,25 +46,13 @@ class RemoteDevViewBridgeService : Service() {
 
     @Synchronized
     private fun ensureListening() {
-        if (serverSocket?.isClosed == false) return
+        if (serverSocket != null) return
         worker.execute {
             try {
-                val server = ServerSocket(PORT, 4, InetAddress.getByName(HOST))
-                server.reuseAddress = true
-                server.soTimeout = ACCEPT_POLL_MS
+                val server = LocalServerSocket(SOCKET_NAME)
                 serverSocket = server
-                while (!server.isClosed) {
-                    if (SystemClock.elapsedRealtime() - lastAuthorizedAtElapsedMs > BRIDGE_IDLE_MS) {
-                        stopSelf()
-                        break
-                    }
-                    val socket = try {
-                        server.accept()
-                    } catch (_: SocketTimeoutException) {
-                        continue
-                    } catch (_: Exception) {
-                        break
-                    }
+                while (serverSocket === server) {
+                    val socket = try { server.accept() } catch (_: Exception) { break }
                     handleClient(socket)
                 }
             } catch (error: Throwable) {
@@ -91,61 +63,63 @@ class RemoteDevViewBridgeService : Service() {
         }
     }
 
-    private fun handleClient(socket: Socket) {
+    private fun handleClient(socket: LocalSocket) {
         socket.use { client ->
             client.soTimeout = SOCKET_TIMEOUT_MS
             val response = JSONObject()
             var payload: ByteArray? = null
             try {
+                val peerUid = client.peerCredentials.uid
+                if (peerUid != SHELL_UID) {
+                    response.put("success", false)
+                    response.put("error", "Unauthorized bridge peer")
+                    writeResponse(client, response, null)
+                    return
+                }
                 val line = readLineLimited(client.getInputStream(), MAX_REQUEST_BYTES)
                 val request = JSONObject(line)
-                if (!secretMatches(request.optString("secret", ""))) {
-                    response.put("success", false)
-                    response.put("error", "Unauthorized bridge request")
-                } else {
-                    lastAuthorizedAtElapsedMs = SystemClock.elapsedRealtime()
-                    when (request.optString("command", "")) {
-                        "status" -> putInputResult(response, RemoteDevViewController.status())
-                        "capture" -> {
-                            val capture = RemoteDevViewController.capture(
-                                request.optInt("maxWidth", DEFAULT_MAX_WIDTH)
-                                    .coerceIn(MIN_WIDTH, MAX_WIDTH),
-                                request.optInt("quality", DEFAULT_QUALITY)
-                                    .coerceIn(MIN_QUALITY, MAX_QUALITY),
-                            )
-                            response.put("success", capture.jpeg != null)
-                            response.put("pixelCopyCode", capture.resultCode)
-                            response.put("pixelCopyResult", capture.resultName)
-                            response.put("width", capture.width)
-                            response.put("height", capture.height)
-                            response.put("activity", capture.activityName ?: JSONObject.NULL)
-                            if (capture.detail != null) response.put("detail", capture.detail)
-                            payload = capture.jpeg
-                        }
-                        "touch" -> putInputResult(
-                            response,
-                            RemoteDevViewController.dispatchTouch(
-                                request.optString("phase", ""),
-                                request.optDouble("x", Double.NaN),
-                                request.optDouble("y", Double.NaN),
-                            ),
+                when (request.optString("command", "")) {
+                    "launch" -> {
+                        launchOverdrive()
+                        response.put("success", true)
+                        response.put("launchRequested", true)
+                    }
+                    "status" -> putInputResult(response, RemoteDevViewController.status())
+                    "capture" -> {
+                        val capture = RemoteDevViewController.capture(
+                            request.optInt("maxWidth", DEFAULT_MAX_WIDTH)
+                                .coerceIn(MIN_WIDTH, MAX_WIDTH),
+                            request.optInt("quality", DEFAULT_QUALITY)
+                                .coerceIn(MIN_QUALITY, MAX_QUALITY),
                         )
-                        "key" -> putInputResult(
-                            response,
-                            RemoteDevViewController.dispatchKey(request.optString("key", "")),
-                        )
-                        "text" -> putInputResult(
-                            response,
-                            RemoteDevViewController.dispatchText(request.optString("text", "")),
-                        )
-                        "shutdown" -> {
-                            response.put("success", true)
-                            response.put("stopping", true)
-                        }
-                        else -> {
-                            response.put("success", false)
-                            response.put("error", "Unknown bridge command")
-                        }
+                        response.put("success", capture.jpeg != null)
+                        response.put("pixelCopyCode", capture.resultCode)
+                        response.put("pixelCopyResult", capture.resultName)
+                        response.put("width", capture.width)
+                        response.put("height", capture.height)
+                        response.put("activity", capture.activityName ?: JSONObject.NULL)
+                        if (capture.detail != null) response.put("detail", capture.detail)
+                        payload = capture.jpeg
+                    }
+                    "touch" -> putInputResult(
+                        response,
+                        RemoteDevViewController.dispatchTouch(
+                            request.optString("phase", ""),
+                            request.optDouble("x", Double.NaN),
+                            request.optDouble("y", Double.NaN),
+                        ),
+                    )
+                    "key" -> putInputResult(
+                        response,
+                        RemoteDevViewController.dispatchKey(request.optString("key", "")),
+                    )
+                    "text" -> putInputResult(
+                        response,
+                        RemoteDevViewController.dispatchText(request.optString("text", "")),
+                    )
+                    else -> {
+                        response.put("success", false)
+                        response.put("error", "Unknown bridge command")
                     }
                 }
             } catch (error: Throwable) {
@@ -153,23 +127,22 @@ class RemoteDevViewBridgeService : Service() {
                 response.put("error", error.message ?: error.javaClass.simpleName)
             }
 
-            try {
-                val bytes = payload ?: ByteArray(0)
-                response.put("payloadBytes", bytes.size)
-                val metadata = response.toString().toByteArray(StandardCharsets.UTF_8)
-                val output = DataOutputStream(client.getOutputStream())
-                output.writeInt(metadata.size)
-                output.write(metadata)
-                if (bytes.isNotEmpty()) output.write(bytes)
-                output.flush()
-            } catch (error: Throwable) {
-                Log.w(TAG, "Unable to return bridge response", error)
-            }
+            writeResponse(client, response, payload)
+        }
+    }
 
-            if (response.optBoolean("stopping", false)) {
-                secret = null
-                stopSelf()
-            }
+    private fun writeResponse(client: LocalSocket, response: JSONObject, payload: ByteArray?) {
+        try {
+            val bytes = payload ?: ByteArray(0)
+            response.put("payloadBytes", bytes.size)
+            val metadata = response.toString().toByteArray(StandardCharsets.UTF_8)
+            val output = DataOutputStream(client.outputStream)
+            output.writeInt(metadata.size)
+            output.write(metadata)
+            if (bytes.isNotEmpty()) output.write(bytes)
+            output.flush()
+        } catch (error: Throwable) {
+            Log.w(TAG, "Unable to return bridge response", error)
         }
     }
 
@@ -185,14 +158,6 @@ class RemoteDevViewBridgeService : Service() {
         } catch (error: Throwable) {
             Log.w(TAG, "Unable to launch MainActivity for developer view", error)
         }
-    }
-
-    private fun secretMatches(candidate: String): Boolean {
-        val expected = secret ?: return false
-        return MessageDigest.isEqual(
-            expected.toByteArray(StandardCharsets.UTF_8),
-            candidate.toByteArray(StandardCharsets.UTF_8),
-        )
     }
 
     private fun putInputResult(target: JSONObject, result: RemoteDevViewController.InputResult) {
@@ -215,16 +180,11 @@ class RemoteDevViewBridgeService : Service() {
     }
 
     companion object {
-        const val ACTION_START = "com.overdrive.app.remote.START_DEV_VIEW_BRIDGE"
-        const val EXTRA_BRIDGE_SECRET = "bridge_secret"
-        const val EXTRA_LAUNCH_ACTIVITY = "launch_activity"
-        const val HOST = "127.0.0.1"
-        const val PORT = 19881
+        const val SOCKET_NAME = "overdrive_remote_dev_view_v1"
 
         private const val TAG = "RemoteDevViewBridge"
+        private const val SHELL_UID = 2000
         private const val SOCKET_TIMEOUT_MS = 8_000
-        private const val ACCEPT_POLL_MS = 30_000
-        private const val BRIDGE_IDLE_MS = 6 * 60 * 1000L
         private const val MAX_REQUEST_BYTES = 16 * 1024
         private const val MIN_WIDTH = 320
         private const val MAX_WIDTH = 1920

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -2,8 +2,6 @@ package com.overdrive.app.remote
 
 import android.app.Service
 import android.content.Intent
-import android.net.LocalServerSocket
-import android.net.LocalSocket
 import android.os.IBinder
 import android.util.Log
 import com.overdrive.app.ui.MainActivity
@@ -11,20 +9,28 @@ import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 import java.io.InputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.nio.charset.StandardCharsets
+import java.util.LinkedHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 /**
- * Private app service exposing an abstract Unix-domain socket to the shell
- * camera daemon. Every accepted connection is authenticated with kernel peer
- * credentials (uid 2000); nothing is persisted and no frame touches storage.
+ * Private app service exposing an authenticated loopback socket to the shell
+ * camera daemon. BYD's SELinux policy blocks shell -> app Unix-domain socket
+ * connections, so each request is instead HMAC-authenticated with the existing
+ * device secret, time-bounded, and replay-protected. Nothing is persisted and
+ * no frame touches storage.
  */
 class RemoteDevViewBridgeService : Service() {
     private val worker: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "remote-dev-view-bridge").apply { isDaemon = true }
     }
-    @Volatile private var serverSocket: LocalServerSocket? = null
+    @Volatile private var serverSocket: ServerSocket? = null
+    private val usedNonces = LinkedHashMap<String, Long>()
 
     override fun onCreate() {
         super.onCreate()
@@ -49,7 +55,10 @@ class RemoteDevViewBridgeService : Service() {
         if (serverSocket != null) return
         worker.execute {
             try {
-                val server = LocalServerSocket(SOCKET_NAME)
+                val server = ServerSocket().apply {
+                    reuseAddress = true
+                    bind(InetSocketAddress(InetAddress.getLoopbackAddress(), PORT), BACKLOG)
+                }
                 serverSocket = server
                 while (serverSocket === server) {
                     val socket = try { server.accept() } catch (_: Exception) { break }
@@ -63,21 +72,16 @@ class RemoteDevViewBridgeService : Service() {
         }
     }
 
-    private fun handleClient(socket: LocalSocket) {
+    private fun handleClient(socket: Socket) {
         socket.use { client ->
             client.soTimeout = SOCKET_TIMEOUT_MS
             val response = JSONObject()
             var payload: ByteArray? = null
             try {
-                val peerUid = client.peerCredentials.uid
-                if (peerUid != SHELL_UID) {
-                    response.put("success", false)
-                    response.put("error", "Unauthorized bridge peer")
-                    writeResponse(client, response, null)
-                    return
-                }
                 val line = readLineLimited(client.getInputStream(), MAX_REQUEST_BYTES)
-                val request = JSONObject(line)
+                val authenticated = RemoteDevViewBridgeAuth.verify(line)
+                rememberNonce(authenticated.nonce, authenticated.timestampMs)
+                val request = authenticated.request
                 when (request.optString("command", "")) {
                     "launch" -> {
                         launchOverdrive()
@@ -131,7 +135,7 @@ class RemoteDevViewBridgeService : Service() {
         }
     }
 
-    private fun writeResponse(client: LocalSocket, response: JSONObject, payload: ByteArray?) {
+    private fun writeResponse(client: Socket, response: JSONObject, payload: ByteArray?) {
         try {
             val bytes = payload ?: ByteArray(0)
             response.put("payloadBytes", bytes.size)
@@ -179,11 +183,23 @@ class RemoteDevViewBridgeService : Service() {
         return output.toString(StandardCharsets.UTF_8.name())
     }
 
+    @Synchronized
+    private fun rememberNonce(nonce: String, timestampMs: Long) {
+        val cutoff = System.currentTimeMillis() - RemoteDevViewBridgeAuth.MAX_CLOCK_SKEW_MS
+        val iterator = usedNonces.entries.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().value < cutoff) iterator.remove()
+        }
+        if (usedNonces.put(nonce, timestampMs) != null) {
+            throw SecurityException("Bridge request was already used")
+        }
+    }
+
     companion object {
-        const val SOCKET_NAME = "overdrive_remote_dev_view_v1"
+        const val PORT = 19878
 
         private const val TAG = "RemoteDevViewBridge"
-        private const val SHELL_UID = 2000
+        private const val BACKLOG = 4
         private const val SOCKET_TIMEOUT_MS = 8_000
         private const val MAX_REQUEST_BYTES = 16 * 1024
         private const val MIN_WIDTH = 320

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -1,0 +1,236 @@
+package com.overdrive.app.remote
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.os.SystemClock
+import android.util.Log
+import com.overdrive.app.ui.MainActivity
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * DUMP-permission-protected, loopback-only bridge into Overdrive's UI process.
+ * The shell camera daemon supplies a fresh in-memory secret every time it starts
+ * the bridge. Nothing is persisted and no frame is written to storage.
+ */
+class RemoteDevViewBridgeService : Service() {
+    private val worker: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "remote-dev-view-bridge").apply { isDaemon = true }
+    }
+    @Volatile private var secret: String? = null
+    @Volatile private var serverSocket: ServerSocket? = null
+    @Volatile private var lastAuthorizedAtElapsedMs = 0L
+
+    override fun onCreate() {
+        super.onCreate()
+        RemoteDevViewController.install(application)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val supplied = intent?.getStringExtra(EXTRA_BRIDGE_SECRET)
+        if (supplied.isNullOrBlank() || supplied.length < 32) {
+            Log.w(TAG, "Rejected bridge start without a valid ephemeral secret")
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+        secret = supplied
+        lastAuthorizedAtElapsedMs = SystemClock.elapsedRealtime()
+        ensureListening()
+        if (intent.getBooleanExtra(EXTRA_LAUNCH_ACTIVITY, false)) launchOverdrive()
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        secret = null
+        try { serverSocket?.close() } catch (_: Exception) {}
+        worker.shutdownNow()
+        super.onDestroy()
+    }
+
+    @Synchronized
+    private fun ensureListening() {
+        if (serverSocket?.isClosed == false) return
+        worker.execute {
+            try {
+                val server = ServerSocket(PORT, 4, InetAddress.getByName(HOST))
+                server.reuseAddress = true
+                server.soTimeout = ACCEPT_POLL_MS
+                serverSocket = server
+                while (!server.isClosed) {
+                    if (SystemClock.elapsedRealtime() - lastAuthorizedAtElapsedMs > BRIDGE_IDLE_MS) {
+                        stopSelf()
+                        break
+                    }
+                    val socket = try {
+                        server.accept()
+                    } catch (_: SocketTimeoutException) {
+                        continue
+                    } catch (_: Exception) {
+                        break
+                    }
+                    handleClient(socket)
+                }
+            } catch (error: Throwable) {
+                Log.e(TAG, "Bridge listener stopped", error)
+            } finally {
+                serverSocket = null
+            }
+        }
+    }
+
+    private fun handleClient(socket: Socket) {
+        socket.use { client ->
+            client.soTimeout = SOCKET_TIMEOUT_MS
+            val response = JSONObject()
+            var payload: ByteArray? = null
+            try {
+                val line = readLineLimited(client.getInputStream(), MAX_REQUEST_BYTES)
+                val request = JSONObject(line)
+                if (!secretMatches(request.optString("secret", ""))) {
+                    response.put("success", false)
+                    response.put("error", "Unauthorized bridge request")
+                } else {
+                    lastAuthorizedAtElapsedMs = SystemClock.elapsedRealtime()
+                    when (request.optString("command", "")) {
+                        "status" -> putInputResult(response, RemoteDevViewController.status())
+                        "capture" -> {
+                            val capture = RemoteDevViewController.capture(
+                                request.optInt("maxWidth", DEFAULT_MAX_WIDTH)
+                                    .coerceIn(MIN_WIDTH, MAX_WIDTH),
+                                request.optInt("quality", DEFAULT_QUALITY)
+                                    .coerceIn(MIN_QUALITY, MAX_QUALITY),
+                            )
+                            response.put("success", capture.jpeg != null)
+                            response.put("pixelCopyCode", capture.resultCode)
+                            response.put("pixelCopyResult", capture.resultName)
+                            response.put("width", capture.width)
+                            response.put("height", capture.height)
+                            response.put("activity", capture.activityName ?: JSONObject.NULL)
+                            if (capture.detail != null) response.put("detail", capture.detail)
+                            payload = capture.jpeg
+                        }
+                        "touch" -> putInputResult(
+                            response,
+                            RemoteDevViewController.dispatchTouch(
+                                request.optString("phase", ""),
+                                request.optDouble("x", Double.NaN),
+                                request.optDouble("y", Double.NaN),
+                            ),
+                        )
+                        "key" -> putInputResult(
+                            response,
+                            RemoteDevViewController.dispatchKey(request.optString("key", "")),
+                        )
+                        "text" -> putInputResult(
+                            response,
+                            RemoteDevViewController.dispatchText(request.optString("text", "")),
+                        )
+                        "shutdown" -> {
+                            response.put("success", true)
+                            response.put("stopping", true)
+                        }
+                        else -> {
+                            response.put("success", false)
+                            response.put("error", "Unknown bridge command")
+                        }
+                    }
+                }
+            } catch (error: Throwable) {
+                response.put("success", false)
+                response.put("error", error.message ?: error.javaClass.simpleName)
+            }
+
+            try {
+                val bytes = payload ?: ByteArray(0)
+                response.put("payloadBytes", bytes.size)
+                val metadata = response.toString().toByteArray(StandardCharsets.UTF_8)
+                val output = DataOutputStream(client.getOutputStream())
+                output.writeInt(metadata.size)
+                output.write(metadata)
+                if (bytes.isNotEmpty()) output.write(bytes)
+                output.flush()
+            } catch (error: Throwable) {
+                Log.w(TAG, "Unable to return bridge response", error)
+            }
+
+            if (response.optBoolean("stopping", false)) {
+                secret = null
+                stopSelf()
+            }
+        }
+    }
+
+    private fun launchOverdrive() {
+        try {
+            startActivity(
+                Intent(this, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
+            )
+        } catch (error: Throwable) {
+            Log.w(TAG, "Unable to launch MainActivity for developer view", error)
+        }
+    }
+
+    private fun secretMatches(candidate: String): Boolean {
+        val expected = secret ?: return false
+        return MessageDigest.isEqual(
+            expected.toByteArray(StandardCharsets.UTF_8),
+            candidate.toByteArray(StandardCharsets.UTF_8),
+        )
+    }
+
+    private fun putInputResult(target: JSONObject, result: RemoteDevViewController.InputResult) {
+        target.put("success", result.success)
+        target.put("handled", result.handled)
+        target.put("activity", result.activityName ?: JSONObject.NULL)
+        if (result.detail != null) target.put("detail", result.detail)
+    }
+
+    private fun readLineLimited(input: InputStream, maxBytes: Int): String {
+        val output = ByteArrayOutputStream()
+        while (output.size() < maxBytes) {
+            val value = input.read()
+            if (value == -1 || value == '\n'.code) break
+            if (value != '\r'.code) output.write(value)
+        }
+        if (output.size() >= maxBytes) throw IllegalArgumentException("Bridge request is too large")
+        if (output.size() == 0) throw IllegalArgumentException("Empty bridge request")
+        return output.toString(StandardCharsets.UTF_8.name())
+    }
+
+    companion object {
+        const val ACTION_START = "com.overdrive.app.remote.START_DEV_VIEW_BRIDGE"
+        const val EXTRA_BRIDGE_SECRET = "bridge_secret"
+        const val EXTRA_LAUNCH_ACTIVITY = "launch_activity"
+        const val HOST = "127.0.0.1"
+        const val PORT = 19881
+
+        private const val TAG = "RemoteDevViewBridge"
+        private const val SOCKET_TIMEOUT_MS = 8_000
+        private const val ACCEPT_POLL_MS = 30_000
+        private const val BRIDGE_IDLE_MS = 6 * 60 * 1000L
+        private const val MAX_REQUEST_BYTES = 16 * 1024
+        private const val MIN_WIDTH = 320
+        private const val MAX_WIDTH = 1920
+        private const val DEFAULT_MAX_WIDTH = 1280
+        private const val MIN_QUALITY = 35
+        private const val MAX_QUALITY = 90
+        private const val DEFAULT_QUALITY = 72
+    }
+}

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt
@@ -26,8 +26,11 @@ import java.util.concurrent.Executors
  * no frame touches storage.
  */
 class RemoteDevViewBridgeService : Service() {
-    private val worker: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "remote-dev-view-bridge").apply { isDaemon = true }
+    private val listener: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "remote-dev-view-listener").apply { isDaemon = true }
+    }
+    private val clients: ExecutorService = Executors.newFixedThreadPool(CLIENT_THREADS) { runnable ->
+        Thread(runnable, "remote-dev-view-client").apply { isDaemon = true }
     }
     @Volatile private var serverSocket: ServerSocket? = null
     private val usedNonces = LinkedHashMap<String, Long>()
@@ -46,14 +49,15 @@ class RemoteDevViewBridgeService : Service() {
 
     override fun onDestroy() {
         try { serverSocket?.close() } catch (_: Exception) {}
-        worker.shutdownNow()
+        listener.shutdownNow()
+        clients.shutdownNow()
         super.onDestroy()
     }
 
     @Synchronized
     private fun ensureListening() {
         if (serverSocket != null) return
-        worker.execute {
+        listener.execute {
             try {
                 val server = ServerSocket().apply {
                     reuseAddress = true
@@ -62,7 +66,7 @@ class RemoteDevViewBridgeService : Service() {
                 serverSocket = server
                 while (serverSocket === server) {
                     val socket = try { server.accept() } catch (_: Exception) { break }
-                    handleClient(socket)
+                    clients.execute { handleClient(socket) }
                 }
             } catch (error: Throwable) {
                 Log.e(TAG, "Bridge listener stopped", error)
@@ -199,7 +203,8 @@ class RemoteDevViewBridgeService : Service() {
         const val PORT = 19881
 
         private const val TAG = "RemoteDevViewBridge"
-        private const val BACKLOG = 4
+        private const val BACKLOG = 8
+        private const val CLIENT_THREADS = 4
         private const val SOCKET_TIMEOUT_MS = 8_000
         private const val MAX_REQUEST_BYTES = 16 * 1024
         private const val MIN_WIDTH = 320

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -21,6 +21,7 @@ import android.view.inputmethod.EditorInfo
 import com.overdrive.app.DeterrentActivity
 import java.io.ByteArrayOutputStream
 import java.lang.ref.WeakReference
+import java.lang.reflect.Method
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -42,6 +43,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private const val TAG = "RemoteDevView"
     private const val UI_TIMEOUT_SECONDS = 6L
     private const val MAX_TEXT_LENGTH = 256
+    private const val PIXEL_COPY_RETRY_COUNT = 2
+    private const val PIXEL_COPY_RETRY_DELAY_MS = 40L
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private var installed = false
@@ -49,6 +52,10 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private var currentActivity = WeakReference<Activity>(null)
     private var touchRoot = WeakReference<View>(null)
     private var touchDownTime = 0L
+    private var appRootsAccessor: AppRootsAccessor? = null
+    private var appRootsUnavailable = false
+
+    private data class AppRootsAccessor(val instance: Any, val method: Method)
 
     @Synchronized
     fun install(app: Application) {
@@ -143,28 +150,47 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
                     return@post
                 }
 
-                try {
-                    PixelCopy.request(activity.window, bitmap, { code ->
-                        if (code == PixelCopy.SUCCESS) {
-                            drawAppOwnedOverlayRoots(bitmap, activity, sourceWidth, sourceHeight)
-                            bitmapRef.set(bitmap)
-                        } else {
-                            bitmap.recycle()
-                        }
-                        resultRef.set(
-                            CaptureResult(code, pixelCopyResultName(code), outputWidth,
-                                outputHeight, activity.javaClass.name, null)
-                        )
-                        latch.countDown()
-                    }, mainHandler)
-                } catch (error: Throwable) {
-                    bitmap.recycle()
+                fun complete(code: Int, resultName: String, detail: String? = null) {
+                    if (code == PixelCopy.SUCCESS) {
+                        drawAppOwnedOverlayRoots(bitmap, activity, sourceWidth, sourceHeight)
+                        bitmapRef.set(bitmap)
+                    } else {
+                        bitmap.recycle()
+                    }
                     resultRef.set(
-                        CaptureResult(-1, "REQUEST_ERROR", outputWidth, outputHeight,
-                            activity.javaClass.name, null, error.javaClass.simpleName)
+                        CaptureResult(code, resultName, outputWidth, outputHeight,
+                            activity.javaClass.name, null, detail)
                     )
                     latch.countDown()
                 }
+
+                lateinit var requestCopy: (Int) -> Unit
+                requestCopy = { retriesRemaining ->
+                    try {
+                        PixelCopy.request(activity.window, bitmap, { code ->
+                            if (isRetryablePixelCopyResult(code) && retriesRemaining > 0) {
+                                mainHandler.postDelayed(
+                                    { requestCopy(retriesRemaining - 1) },
+                                    PIXEL_COPY_RETRY_DELAY_MS,
+                                )
+                            } else {
+                                complete(code, pixelCopyResultName(code))
+                            }
+                        }, mainHandler)
+                    } catch (error: IllegalArgumentException) {
+                        if (retriesRemaining > 0) {
+                            mainHandler.postDelayed(
+                                { requestCopy(retriesRemaining - 1) },
+                                PIXEL_COPY_RETRY_DELAY_MS,
+                            )
+                        } else {
+                            complete(-1, "REQUEST_ERROR", error.javaClass.simpleName)
+                        }
+                    } catch (error: Throwable) {
+                        complete(-1, "REQUEST_ERROR", error.javaClass.simpleName)
+                    }
+                }
+                requestCopy(PIXEL_COPY_RETRY_COUNT)
             }
         }
 
@@ -359,17 +385,49 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
      */
     private fun appOwnedRoots(): List<View> {
         val packageName = application?.packageName ?: return emptyList()
+        val accessor = resolveAppRootsAccessor() ?: return emptyList()
         return try {
-            val type = Class.forName("android.view.WindowManagerGlobal")
-            val instance = type.getDeclaredMethod("getInstance").invoke(null)
             @Suppress("UNCHECKED_CAST")
-            val roots = type.getDeclaredMethod("getRootViews").invoke(instance) as? List<View>
+            val roots = accessor.method.invoke(accessor.instance) as? List<View>
             roots.orEmpty().filter { it.context.applicationContext.packageName == packageName }
         } catch (error: Throwable) {
-            Log.d(TAG, "App-owned root enumeration unavailable: ${error.javaClass.simpleName}")
+            disableAppRootsAccessor(error)
             emptyList()
         }
     }
+
+    @Synchronized
+    private fun resolveAppRootsAccessor(): AppRootsAccessor? {
+        appRootsAccessor?.let { return it }
+        if (appRootsUnavailable) return null
+        return try {
+            val type = Class.forName("android.view.WindowManagerGlobal")
+            val instance = type.getDeclaredMethod("getInstance").invoke(null)
+                ?: throw IllegalStateException("WindowManagerGlobal instance unavailable")
+            val method = try {
+                type.getDeclaredMethod("getWindowViews")
+            } catch (_: NoSuchMethodException) {
+                type.getDeclaredMethod("getRootViews")
+            }
+            method.isAccessible = true
+            AppRootsAccessor(instance, method).also { appRootsAccessor = it }
+        } catch (error: Throwable) {
+            disableAppRootsAccessor(error)
+            null
+        }
+    }
+
+    @Synchronized
+    private fun disableAppRootsAccessor(error: Throwable) {
+        if (!appRootsUnavailable) {
+            Log.d(TAG, "App-owned root enumeration unavailable: ${error.javaClass.simpleName}")
+        }
+        appRootsAccessor = null
+        appRootsUnavailable = true
+    }
+
+    private fun isRetryablePixelCopyResult(code: Int): Boolean =
+        code == PixelCopy.ERROR_SOURCE_NO_DATA || code == PixelCopy.ERROR_SOURCE_INVALID
 
     /**
      * Keep dialogs and app-owned service overlays, but exclude roots belonging

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -113,6 +113,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     }
 
     /** Blocks the bridge worker, never the main thread. */
+    @Synchronized
     fun capture(maxWidth: Int, quality: Int): CaptureResult {
         val activity = currentActivity.get()
         if (activity == null || activity.isFinishing || activity.isDestroyed) {

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -2,6 +2,8 @@ package com.overdrive.app.remote
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.os.Bundle
@@ -16,6 +18,7 @@ import android.view.MotionEvent
 import android.view.PixelCopy
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import com.overdrive.app.DeterrentActivity
 import java.io.ByteArrayOutputStream
 import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
@@ -26,10 +29,14 @@ import kotlin.math.roundToInt
 /**
  * App-process half of Remote Overdrive Dev View.
  *
- * PixelCopy is deliberately performed against the currently resumed Overdrive
+ * PixelCopy is deliberately performed against the last interactive Overdrive
  * Activity's Window, before SurfaceFlinger combines it with BYD's opaque
- * AccAnimation layer. Input is dispatched only into app-owned view roots; this
- * class never uses global input injection and cannot address another package.
+ * AccAnimation layer. The transparent [DeterrentActivity] may temporarily take
+ * foreground to protect the physical screen; it is never selected as the
+ * developer-view target, so that safety activity can keep running while the
+ * underlying MainActivity remains stable here. Input is dispatched only into
+ * roots owned by the selected Activity; this class never uses global input
+ * injection and cannot address another package.
  */
 object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private const val TAG = "RemoteDevView"
@@ -54,7 +61,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     override fun onActivityCreated(activity: Activity, state: Bundle?) = trackIfEmpty(activity)
     override fun onActivityStarted(activity: Activity) = trackIfEmpty(activity)
     override fun onActivityResumed(activity: Activity) {
-        currentActivity = WeakReference(activity)
+        if (isRemoteTarget(activity)) currentActivity = WeakReference(activity)
     }
     override fun onActivityPaused(activity: Activity) = Unit
     override fun onActivityStopped(activity: Activity) = Unit
@@ -64,8 +71,12 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     }
 
     private fun trackIfEmpty(activity: Activity) {
-        if (currentActivity.get() == null) currentActivity = WeakReference(activity)
+        if (currentActivity.get() == null && isRemoteTarget(activity)) {
+            currentActivity = WeakReference(activity)
+        }
     }
+
+    private fun isRemoteTarget(activity: Activity): Boolean = activity !is DeterrentActivity
 
     data class CaptureResult(
         val resultCode: Int,
@@ -203,12 +214,12 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             val screenY = decorLocation[1] + normalizedY * decor.height
 
             val target = if (action == MotionEvent.ACTION_DOWN) {
-                findTopRootAt(screenX, screenY, decor).also {
+                findTopRootAt(screenX, screenY, decor, activity).also {
                     touchRoot = WeakReference(it)
                     touchDownTime = SystemClock.uptimeMillis()
                 }
             } else {
-                touchRoot.get() ?: findTopRootAt(screenX, screenY, decor)
+                touchRoot.get() ?: findTopRootAt(screenX, screenY, decor, activity)
             }
             val rootLocation = IntArray(2).also { target.getLocationOnScreen(it) }
             val eventTime = SystemClock.uptimeMillis()
@@ -254,7 +265,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
                 activity.onBackPressed()
                 return@runOnUiThread InputResult(true, true, activity.javaClass.name)
             }
-            val root = topInputRoot(activity.window.decorView)
+            val root = topInputRoot(activity.window.decorView, activity)
             val now = SystemClock.uptimeMillis()
             val down = KeyEvent(now, now, KeyEvent.ACTION_DOWN, keyCode, 0)
             val up = KeyEvent(now, SystemClock.uptimeMillis(), KeyEvent.ACTION_UP, keyCode, 0)
@@ -271,7 +282,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         return runOnUiThread {
             val activity = readyActivity()
                 ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
-            val root = topInputRoot(activity.window.decorView)
+            val root = topInputRoot(activity.window.decorView, activity)
             val focused = root.findFocus()
             var handled = false
             if (focused != null) {
@@ -311,8 +322,13 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         return result.get()
     }
 
-    private fun findTopRootAt(screenX: Double, screenY: Double, fallback: View): View {
-        val roots = appOwnedRoots()
+    private fun findTopRootAt(
+        screenX: Double,
+        screenY: Double,
+        fallback: View,
+        activity: Activity,
+    ): View {
+        val roots = activityOwnedRoots(activity)
         for (index in roots.indices.reversed()) {
             val root = roots[index]
             if (!root.isShown || root.width <= 0 || root.height <= 0) continue
@@ -328,8 +344,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         return fallback
     }
 
-    private fun topInputRoot(fallback: View): View {
-        val roots = appOwnedRoots()
+    private fun topInputRoot(fallback: View, activity: Activity): View {
+        val roots = activityOwnedRoots(activity)
         return roots.asReversed().firstOrNull { it.isShown && it.hasWindowFocus() }
             ?: roots.asReversed().firstOrNull { it.isShown }
             ?: fallback
@@ -355,6 +371,27 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         }
     }
 
+    /**
+     * Keep dialogs and app-owned service overlays, but exclude roots belonging
+     * to another Activity. In particular, DeterrentActivity's foreground,
+     * touch-swallowing root must continue protecting the physical screen
+     * without swallowing input dispatched directly to MainActivity here.
+     */
+    private fun activityOwnedRoots(activity: Activity): List<View> = appOwnedRoots().filter { root ->
+        val owner = contextActivity(root.context)
+        owner == null || owner === activity
+    }
+
+    private fun contextActivity(context: Context): Activity? {
+        var current: Context? = context
+        val seen = HashSet<Context>()
+        while (current != null && seen.add(current)) {
+            if (current is Activity) return current
+            current = if (current is ContextWrapper) current.baseContext else null
+        }
+        return null
+    }
+
     private fun drawAppOwnedOverlayRoots(
         bitmap: Bitmap,
         activity: Activity,
@@ -366,7 +403,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         val scaleX = bitmap.width.toFloat() / sourceWidth
         val scaleY = bitmap.height.toFloat() / sourceHeight
         val canvas = Canvas(bitmap)
-        appOwnedRoots().forEach { root ->
+        activityOwnedRoots(activity).forEach { root ->
             if (root === activityRoot || !root.isShown || root.width <= 0 || root.height <= 0) return@forEach
             val location = IntArray(2).also { root.getLocationOnScreen(it) }
             canvas.save()

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -249,6 +249,11 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         return runOnUiThread {
             val activity = readyActivity()
                 ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
+            if (keyCode == KeyEvent.KEYCODE_BACK) {
+                @Suppress("DEPRECATION")
+                activity.onBackPressed()
+                return@runOnUiThread InputResult(true, true, activity.javaClass.name)
+            }
             val root = topInputRoot(activity.window.decorView)
             val now = SystemClock.uptimeMillis()
             val down = KeyEvent(now, now, KeyEvent.ACTION_DOWN, keyCode, 0)

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -1,0 +1,387 @@
+package com.overdrive.app.remote
+
+import android.app.Activity
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import android.view.InputDevice
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.PixelCopy
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import java.io.ByteArrayOutputStream
+import java.lang.ref.WeakReference
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.roundToInt
+
+/**
+ * App-process half of Remote Overdrive Dev View.
+ *
+ * PixelCopy is deliberately performed against the currently resumed Overdrive
+ * Activity's Window, before SurfaceFlinger combines it with BYD's opaque
+ * AccAnimation layer. Input is dispatched only into app-owned view roots; this
+ * class never uses global input injection and cannot address another package.
+ */
+object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
+    private const val TAG = "RemoteDevView"
+    private const val UI_TIMEOUT_SECONDS = 6L
+    private const val MAX_TEXT_LENGTH = 256
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var installed = false
+    private var application: Application? = null
+    private var currentActivity = WeakReference<Activity>(null)
+    private var touchRoot = WeakReference<View>(null)
+    private var touchDownTime = 0L
+
+    @Synchronized
+    fun install(app: Application) {
+        if (installed) return
+        installed = true
+        application = app
+        app.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, state: Bundle?) = trackIfEmpty(activity)
+    override fun onActivityStarted(activity: Activity) = trackIfEmpty(activity)
+    override fun onActivityResumed(activity: Activity) {
+        currentActivity = WeakReference(activity)
+    }
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, state: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) {
+        if (currentActivity.get() === activity) currentActivity.clear()
+    }
+
+    private fun trackIfEmpty(activity: Activity) {
+        if (currentActivity.get() == null) currentActivity = WeakReference(activity)
+    }
+
+    data class CaptureResult(
+        val resultCode: Int,
+        val resultName: String,
+        val width: Int,
+        val height: Int,
+        val activityName: String?,
+        val jpeg: ByteArray?,
+        val detail: String? = null,
+    )
+
+    data class InputResult(
+        val success: Boolean,
+        val handled: Boolean,
+        val activityName: String?,
+        val detail: String? = null,
+    )
+
+    fun status(): InputResult {
+        val activity = currentActivity.get()
+        return InputResult(
+            success = activity != null && !activity.isFinishing && !activity.isDestroyed,
+            handled = false,
+            activityName = activity?.javaClass?.name,
+            detail = if (activity == null) "No Overdrive activity is ready" else null,
+        )
+    }
+
+    /** Blocks the bridge worker, never the main thread. */
+    fun capture(maxWidth: Int, quality: Int): CaptureResult {
+        val activity = currentActivity.get()
+        if (activity == null || activity.isFinishing || activity.isDestroyed) {
+            return CaptureResult(-1, "NO_ACTIVITY", 0, 0, null, null)
+        }
+
+        val resultRef = AtomicReference<CaptureResult>()
+        val bitmapRef = AtomicReference<Bitmap>()
+        val latch = CountDownLatch(1)
+        mainHandler.post {
+            val decor = activity.window.decorView
+            decor.post {
+                val sourceWidth = decor.width
+                val sourceHeight = decor.height
+                if (sourceWidth <= 0 || sourceHeight <= 0) {
+                    resultRef.set(
+                        CaptureResult(-1, "NO_WINDOW_SIZE", sourceWidth, sourceHeight,
+                            activity.javaClass.name, null)
+                    )
+                    latch.countDown()
+                    return@post
+                }
+
+                val outputWidth = maxWidth.coerceAtLeast(1).coerceAtMost(sourceWidth)
+                val outputHeight = (sourceHeight * (outputWidth.toDouble() / sourceWidth))
+                    .roundToInt().coerceAtLeast(1)
+                val bitmap = try {
+                    Bitmap.createBitmap(outputWidth, outputHeight, Bitmap.Config.ARGB_8888)
+                } catch (error: Throwable) {
+                    resultRef.set(
+                        CaptureResult(-1, "BITMAP_ERROR", outputWidth, outputHeight,
+                            activity.javaClass.name, null, error.javaClass.simpleName)
+                    )
+                    latch.countDown()
+                    return@post
+                }
+
+                try {
+                    PixelCopy.request(activity.window, bitmap, { code ->
+                        if (code == PixelCopy.SUCCESS) {
+                            drawAppOwnedOverlayRoots(bitmap, activity, sourceWidth, sourceHeight)
+                            bitmapRef.set(bitmap)
+                        } else {
+                            bitmap.recycle()
+                        }
+                        resultRef.set(
+                            CaptureResult(code, pixelCopyResultName(code), outputWidth,
+                                outputHeight, activity.javaClass.name, null)
+                        )
+                        latch.countDown()
+                    }, mainHandler)
+                } catch (error: Throwable) {
+                    bitmap.recycle()
+                    resultRef.set(
+                        CaptureResult(-1, "REQUEST_ERROR", outputWidth, outputHeight,
+                            activity.javaClass.name, null, error.javaClass.simpleName)
+                    )
+                    latch.countDown()
+                }
+            }
+        }
+
+        if (!latch.await(UI_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            return CaptureResult(-1, "TIMEOUT", 0, 0, activity.javaClass.name, null)
+        }
+        val base = resultRef.get()
+            ?: return CaptureResult(-1, "UNKNOWN", 0, 0, activity.javaClass.name, null)
+        val bitmap = bitmapRef.get() ?: return base
+        return try {
+            val bytes = ByteArrayOutputStream().use { output ->
+                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, quality.coerceIn(35, 90), output)) {
+                    throw IllegalStateException("Bitmap.compress returned false")
+                }
+                output.toByteArray()
+            }
+            base.copy(jpeg = bytes)
+        } catch (error: Throwable) {
+            base.copy(resultName = "ENCODE_ERROR", detail = error.javaClass.simpleName)
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    fun dispatchTouch(phase: String, normalizedX: Double, normalizedY: Double): InputResult {
+        if (!normalizedX.isFinite() || !normalizedY.isFinite() ||
+            normalizedX < 0.0 || normalizedX > 1.0 ||
+            normalizedY < 0.0 || normalizedY > 1.0
+        ) {
+            return InputResult(false, false, currentActivity.get()?.javaClass?.name,
+                "Coordinates must be between 0 and 1")
+        }
+        val action = when (phase) {
+            "down" -> MotionEvent.ACTION_DOWN
+            "move" -> MotionEvent.ACTION_MOVE
+            "up" -> MotionEvent.ACTION_UP
+            "cancel" -> MotionEvent.ACTION_CANCEL
+            else -> return InputResult(false, false, currentActivity.get()?.javaClass?.name,
+                "Unknown touch phase")
+        }
+        return runOnUiThread {
+            val activity = readyActivity()
+                ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
+            val decor = activity.window.decorView
+            val decorLocation = IntArray(2).also { decor.getLocationOnScreen(it) }
+            val screenX = decorLocation[0] + normalizedX * decor.width
+            val screenY = decorLocation[1] + normalizedY * decor.height
+
+            val target = if (action == MotionEvent.ACTION_DOWN) {
+                findTopRootAt(screenX, screenY, decor).also {
+                    touchRoot = WeakReference(it)
+                    touchDownTime = SystemClock.uptimeMillis()
+                }
+            } else {
+                touchRoot.get() ?: findTopRootAt(screenX, screenY, decor)
+            }
+            val rootLocation = IntArray(2).also { target.getLocationOnScreen(it) }
+            val eventTime = SystemClock.uptimeMillis()
+            if (touchDownTime == 0L) touchDownTime = eventTime
+            val event = MotionEvent.obtain(
+                touchDownTime,
+                eventTime,
+                action,
+                (screenX - rootLocation[0]).toFloat(),
+                (screenY - rootLocation[1]).toFloat(),
+                0,
+            )
+            event.source = InputDevice.SOURCE_TOUCHSCREEN
+            val handled = try { target.dispatchTouchEvent(event) } finally { event.recycle() }
+            if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+                touchRoot.clear()
+                touchDownTime = 0L
+            }
+            InputResult(true, handled, activity.javaClass.name)
+        }
+    }
+
+    fun dispatchKey(name: String): InputResult {
+        val keyCode = when (name.lowercase()) {
+            "back" -> KeyEvent.KEYCODE_BACK
+            "enter" -> KeyEvent.KEYCODE_ENTER
+            "tab" -> KeyEvent.KEYCODE_TAB
+            "escape" -> KeyEvent.KEYCODE_ESCAPE
+            "delete" -> KeyEvent.KEYCODE_DEL
+            "dpad_up" -> KeyEvent.KEYCODE_DPAD_UP
+            "dpad_down" -> KeyEvent.KEYCODE_DPAD_DOWN
+            "dpad_left" -> KeyEvent.KEYCODE_DPAD_LEFT
+            "dpad_right" -> KeyEvent.KEYCODE_DPAD_RIGHT
+            "dpad_center" -> KeyEvent.KEYCODE_DPAD_CENTER
+            else -> return InputResult(false, false, currentActivity.get()?.javaClass?.name,
+                "Key is not allowed")
+        }
+        return runOnUiThread {
+            val activity = readyActivity()
+                ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
+            val root = topInputRoot(activity.window.decorView)
+            val now = SystemClock.uptimeMillis()
+            val down = KeyEvent(now, now, KeyEvent.ACTION_DOWN, keyCode, 0)
+            val up = KeyEvent(now, SystemClock.uptimeMillis(), KeyEvent.ACTION_UP, keyCode, 0)
+            val handled = root.dispatchKeyEvent(down) or root.dispatchKeyEvent(up)
+            InputResult(true, handled, activity.javaClass.name)
+        }
+    }
+
+    fun dispatchText(text: String): InputResult {
+        if (text.isEmpty() || text.length > MAX_TEXT_LENGTH || text.any { it == '\u0000' }) {
+            return InputResult(false, false, currentActivity.get()?.javaClass?.name,
+                "Text must contain 1-$MAX_TEXT_LENGTH characters")
+        }
+        return runOnUiThread {
+            val activity = readyActivity()
+                ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
+            val root = topInputRoot(activity.window.decorView)
+            val focused = root.findFocus()
+            var handled = false
+            if (focused != null) {
+                val connection = focused.onCreateInputConnection(EditorInfo())
+                if (connection != null) {
+                    handled = connection.commitText(text, 1)
+                }
+            }
+            if (!handled) {
+                val events = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD)
+                    .getEvents(text.toCharArray())
+                if (events != null) {
+                    handled = events.fold(false) { any, event -> root.dispatchKeyEvent(event) || any }
+                }
+            }
+            InputResult(true, handled, activity.javaClass.name,
+                if (handled) null else "No focused text input accepted the text")
+        }
+    }
+
+    private fun readyActivity(): Activity? = currentActivity.get()?.takeUnless {
+        it.isFinishing || it.isDestroyed || it.window.decorView.width <= 0
+    }
+
+    private fun <T> runOnUiThread(block: () -> T): T {
+        if (Looper.myLooper() == Looper.getMainLooper()) return block()
+        val result = AtomicReference<T>()
+        val error = AtomicReference<Throwable>()
+        val latch = CountDownLatch(1)
+        mainHandler.post {
+            try { result.set(block()) } catch (t: Throwable) { error.set(t) } finally { latch.countDown() }
+        }
+        if (!latch.await(UI_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            throw IllegalStateException("UI dispatch timed out")
+        }
+        error.get()?.let { throw it }
+        return result.get()
+    }
+
+    private fun findTopRootAt(screenX: Double, screenY: Double, fallback: View): View {
+        val roots = appOwnedRoots()
+        for (index in roots.indices.reversed()) {
+            val root = roots[index]
+            if (!root.isShown || root.width <= 0 || root.height <= 0) continue
+            // Non-focusable overlays (for example Overdrive's recording status
+            // pill) are visible but are not real input targets. Directly calling
+            // dispatchTouchEvent would bypass their WindowManager flags.
+            if (root !== fallback && !root.hasWindowFocus()) continue
+            val location = IntArray(2).also { root.getLocationOnScreen(it) }
+            if (screenX >= location[0] && screenX < location[0] + root.width &&
+                screenY >= location[1] && screenY < location[1] + root.height
+            ) return root
+        }
+        return fallback
+    }
+
+    private fun topInputRoot(fallback: View): View {
+        val roots = appOwnedRoots()
+        return roots.asReversed().firstOrNull { it.isShown && it.hasWindowFocus() }
+            ?: roots.asReversed().firstOrNull { it.isShown }
+            ?: fallback
+    }
+
+    /**
+     * WindowManagerGlobal is hidden API, so this is best-effort. It lets the
+     * developer view include and interact with app-owned Dialog/Popup roots.
+     * A firmware that blocks reflection still gets the supported Activity
+     * Window PixelCopy path and its full view hierarchy.
+     */
+    private fun appOwnedRoots(): List<View> {
+        val packageName = application?.packageName ?: return emptyList()
+        return try {
+            val type = Class.forName("android.view.WindowManagerGlobal")
+            val instance = type.getDeclaredMethod("getInstance").invoke(null)
+            @Suppress("UNCHECKED_CAST")
+            val roots = type.getDeclaredMethod("getRootViews").invoke(instance) as? List<View>
+            roots.orEmpty().filter { it.context.applicationContext.packageName == packageName }
+        } catch (error: Throwable) {
+            Log.d(TAG, "App-owned root enumeration unavailable: ${error.javaClass.simpleName}")
+            emptyList()
+        }
+    }
+
+    private fun drawAppOwnedOverlayRoots(
+        bitmap: Bitmap,
+        activity: Activity,
+        sourceWidth: Int,
+        sourceHeight: Int,
+    ) {
+        val activityRoot = activity.window.decorView
+        val baseLocation = IntArray(2).also { activityRoot.getLocationOnScreen(it) }
+        val scaleX = bitmap.width.toFloat() / sourceWidth
+        val scaleY = bitmap.height.toFloat() / sourceHeight
+        val canvas = Canvas(bitmap)
+        appOwnedRoots().forEach { root ->
+            if (root === activityRoot || !root.isShown || root.width <= 0 || root.height <= 0) return@forEach
+            val location = IntArray(2).also { root.getLocationOnScreen(it) }
+            canvas.save()
+            canvas.scale(scaleX, scaleY)
+            canvas.translate(
+                (location[0] - baseLocation[0]).toFloat(),
+                (location[1] - baseLocation[1]).toFloat(),
+            )
+            root.draw(canvas)
+            canvas.restore()
+        }
+    }
+
+    private fun pixelCopyResultName(code: Int): String = when (code) {
+        PixelCopy.SUCCESS -> "SUCCESS"
+        PixelCopy.ERROR_UNKNOWN -> "ERROR_UNKNOWN"
+        PixelCopy.ERROR_TIMEOUT -> "ERROR_TIMEOUT"
+        PixelCopy.ERROR_SOURCE_NO_DATA -> "ERROR_SOURCE_NO_DATA"
+        PixelCopy.ERROR_SOURCE_INVALID -> "ERROR_SOURCE_INVALID"
+        PixelCopy.ERROR_DESTINATION_INVALID -> "ERROR_DESTINATION_INVALID"
+        else -> "ERROR_$code"
+    }
+}

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -25,6 +25,7 @@ import java.lang.reflect.Method
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.roundToInt
 
 /**
@@ -54,6 +55,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private var touchDownTime = 0L
     private var appRootsAccessor: AppRootsAccessor? = null
     private var appRootsUnavailable = false
+    private val captureLock = ReentrantLock(true)
 
     private data class AppRootsAccessor(val instance: Any, val method: Method)
 
@@ -113,8 +115,16 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     }
 
     /** Blocks the bridge worker, never the main thread. */
-    @Synchronized
     fun capture(maxWidth: Int, quality: Int): CaptureResult {
+        captureLock.lock()
+        return try {
+            captureSingleFlight(maxWidth, quality)
+        } finally {
+            captureLock.unlock()
+        }
+    }
+
+    private fun captureSingleFlight(maxWidth: Int, quality: Int): CaptureResult {
         val activity = currentActivity.get()
         if (activity == null || activity.isFinishing || activity.isDestroyed) {
             return CaptureResult(-1, "NO_ACTIVITY", 0, 0, null, null)

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -44,8 +44,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private const val TAG = "RemoteDevView"
     private const val UI_TIMEOUT_SECONDS = 6L
     private const val MAX_TEXT_LENGTH = 256
-    private const val PIXEL_COPY_RETRY_COUNT = 4
-    private const val PIXEL_COPY_RETRY_DELAY_MS = 40L
+    private const val PIXEL_COPY_RETRY_COUNT = 8
+    private const val PIXEL_COPY_RETRY_DELAY_MS = 60L
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private var installed = false

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -17,6 +17,8 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.PixelCopy
 import android.view.View
+import android.view.Display
+import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import com.overdrive.app.DeterrentActivity
 import java.io.ByteArrayOutputStream
@@ -31,14 +33,11 @@ import kotlin.math.roundToInt
 /**
  * App-process half of Remote Overdrive Dev View.
  *
- * PixelCopy is deliberately performed against the last interactive Overdrive
- * Activity's Window, before SurfaceFlinger combines it with BYD's opaque
- * AccAnimation layer. The transparent [DeterrentActivity] may temporarily take
- * foreground to protect the physical screen; it is never selected as the
- * developer-view target, so that safety activity can keep running while the
- * underlying MainActivity remains stable here. Input is dispatched only into
- * roots owned by the selected Activity; this class never uses global input
- * injection and cannot address another package.
+ * Live frames come from [RemoteDevVirtualDisplay], which contains only a
+ * dedicated Overdrive task. PixelCopy remains available for an explicit
+ * lossless Window screenshot. Input is dispatched only into roots owned by
+ * the selected Activity on that private display; this class never uses global
+ * input injection and cannot address another package or display stack 0.
  */
 object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private const val TAG = "RemoteDevView"
@@ -51,6 +50,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private var installed = false
     private var application: Application? = null
     private var currentActivity = WeakReference<Activity>(null)
+    @Volatile private var remoteDisplayId = Display.INVALID_DISPLAY
     private var touchRoot = WeakReference<View>(null)
     private var touchDownTime = 0L
     private var appRootsAccessor: AppRootsAccessor? = null
@@ -85,7 +85,34 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         }
     }
 
-    private fun isRemoteTarget(activity: Activity): Boolean = activity !is DeterrentActivity
+    private fun isRemoteTarget(activity: Activity): Boolean {
+        if (activity is DeterrentActivity) return false
+        val targetDisplay = remoteDisplayId
+        val activityDisplay = activity.display?.displayId ?: Display.DEFAULT_DISPLAY
+        return if (targetDisplay != Display.INVALID_DISPLAY) {
+            activityDisplay == targetDisplay
+        } else {
+            activityDisplay == Display.DEFAULT_DISPLAY
+        }
+    }
+
+    fun bindRemoteDisplay(displayId: Int) {
+        remoteDisplayId = displayId
+        currentActivity.clear()
+        touchRoot.clear()
+    }
+
+    fun unbindRemoteDisplay(displayId: Int) {
+        if (remoteDisplayId != displayId) return
+        remoteDisplayId = Display.INVALID_DISPLAY
+        currentActivity.clear()
+        touchRoot.clear()
+    }
+
+    fun isRemoteWindowSecure(): Boolean {
+        val activity = currentActivity.get() ?: return false
+        return activity.window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE != 0
+    }
 
     data class CaptureResult(
         val resultCode: Int,
@@ -96,6 +123,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         val jpeg: ByteArray?,
         val detail: String? = null,
         val mimeType: String = "image/jpeg",
+        val backend: String = "PixelCopy",
+        val sequence: Long = 0L,
     )
 
     data class InputResult(
@@ -117,6 +146,30 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
 
     /** Blocks the bridge worker, never the main thread. */
     fun capture(maxWidth: Int, quality: Int, format: String = "jpeg"): CaptureResult {
+        if (!format.equals("png", ignoreCase = true)) {
+            val cached = RemoteDevVirtualDisplay.latestFrame()
+            if (cached != null) {
+                return CaptureResult(
+                    resultCode = PixelCopy.SUCCESS,
+                    resultName = "LIVE",
+                    width = cached.width,
+                    height = cached.height,
+                    activityName = currentActivity.get()?.javaClass?.name,
+                    jpeg = cached.jpeg,
+                    detail = "encodeMs=${cached.encodeMs};droppedBlack=${cached.droppedBlackFrames}",
+                    mimeType = "image/jpeg",
+                    backend = RemoteDevVirtualDisplay.BACKEND_NAME,
+                    sequence = cached.sequence,
+                )
+            }
+            if (RemoteDevVirtualDisplay.isRunning()) {
+                return CaptureResult(
+                    -1, "NO_VIRTUAL_FRAME", 0, 0,
+                    currentActivity.get()?.javaClass?.name, null,
+                    backend = RemoteDevVirtualDisplay.BACKEND_NAME,
+                )
+            }
+        }
         captureLock.lock()
         return try {
             captureSingleFlight(maxWidth, quality, format)
@@ -246,7 +299,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             else -> return InputResult(false, false, currentActivity.get()?.javaClass?.name,
                 "Unknown touch phase")
         }
-        return runOnUiThread {
+        val result = runOnUiThread {
             val activity = readyActivity()
                 ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
             val decor = activity.window.decorView
@@ -281,6 +334,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             }
             InputResult(true, handled, activity.javaClass.name)
         }
+        if (result.success) RemoteDevVirtualDisplay.requestImmediateFrame()
+        return result
     }
 
     fun dispatchKey(name: String): InputResult {
@@ -298,7 +353,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             else -> return InputResult(false, false, currentActivity.get()?.javaClass?.name,
                 "Key is not allowed")
         }
-        return runOnUiThread {
+        val result = runOnUiThread {
             val activity = readyActivity()
                 ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
             if (keyCode == KeyEvent.KEYCODE_BACK) {
@@ -313,6 +368,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             val handled = root.dispatchKeyEvent(down) or root.dispatchKeyEvent(up)
             InputResult(true, handled, activity.javaClass.name)
         }
+        if (result.success) RemoteDevVirtualDisplay.requestImmediateFrame()
+        return result
     }
 
     fun dispatchText(text: String): InputResult {
@@ -320,7 +377,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             return InputResult(false, false, currentActivity.get()?.javaClass?.name,
                 "Text must contain 1-$MAX_TEXT_LENGTH characters")
         }
-        return runOnUiThread {
+        val result = runOnUiThread {
             val activity = readyActivity()
                 ?: return@runOnUiThread InputResult(false, false, null, "No Overdrive activity is ready")
             val root = topInputRoot(activity.window.decorView, activity)
@@ -342,6 +399,8 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             InputResult(true, handled, activity.javaClass.name,
                 if (handled) null else "No focused text input accepted the text")
         }
+        if (result.success) RemoteDevVirtualDisplay.requestImmediateFrame()
+        return result
     }
 
     private fun readyActivity(): Activity? = currentActivity.get()?.takeUnless {
@@ -450,9 +509,13 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
      * touch-swallowing root must continue protecting the physical screen
      * without swallowing input dispatched directly to MainActivity here.
      */
-    private fun activityOwnedRoots(activity: Activity): List<View> = appOwnedRoots().filter { root ->
-        val owner = contextActivity(root.context)
-        owner == null || owner === activity
+    private fun activityOwnedRoots(activity: Activity): List<View> {
+        val activityDisplayId = activity.display?.displayId ?: Display.DEFAULT_DISPLAY
+        return appOwnedRoots().filter { root ->
+            val rootDisplayId = root.display?.displayId ?: Display.DEFAULT_DISPLAY
+            val owner = contextActivity(root.context)
+            rootDisplayId == activityDisplayId && (owner == null || owner === activity)
+        }
     }
 
     private fun contextActivity(context: Context): Activity? {

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt
@@ -44,7 +44,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     private const val TAG = "RemoteDevView"
     private const val UI_TIMEOUT_SECONDS = 6L
     private const val MAX_TEXT_LENGTH = 256
-    private const val PIXEL_COPY_RETRY_COUNT = 2
+    private const val PIXEL_COPY_RETRY_COUNT = 4
     private const val PIXEL_COPY_RETRY_DELAY_MS = 40L
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -95,6 +95,7 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
         val activityName: String?,
         val jpeg: ByteArray?,
         val detail: String? = null,
+        val mimeType: String = "image/jpeg",
     )
 
     data class InputResult(
@@ -115,16 +116,16 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
     }
 
     /** Blocks the bridge worker, never the main thread. */
-    fun capture(maxWidth: Int, quality: Int): CaptureResult {
+    fun capture(maxWidth: Int, quality: Int, format: String = "jpeg"): CaptureResult {
         captureLock.lock()
         return try {
-            captureSingleFlight(maxWidth, quality)
+            captureSingleFlight(maxWidth, quality, format)
         } finally {
             captureLock.unlock()
         }
     }
 
-    private fun captureSingleFlight(maxWidth: Int, quality: Int): CaptureResult {
+    private fun captureSingleFlight(maxWidth: Int, quality: Int, format: String): CaptureResult {
         val activity = currentActivity.get()
         if (activity == null || activity.isFinishing || activity.isDestroyed) {
             return CaptureResult(-1, "NO_ACTIVITY", 0, 0, null, null)
@@ -212,13 +213,16 @@ object RemoteDevViewController : Application.ActivityLifecycleCallbacks {
             ?: return CaptureResult(-1, "UNKNOWN", 0, 0, activity.javaClass.name, null)
         val bitmap = bitmapRef.get() ?: return base
         return try {
+            val isPng = format.equals("png", ignoreCase = true)
+            val compressFormat = if (isPng) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
+            val compressQuality = if (isPng) 100 else quality.coerceIn(35, 90)
             val bytes = ByteArrayOutputStream().use { output ->
-                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, quality.coerceIn(35, 90), output)) {
+                if (!bitmap.compress(compressFormat, compressQuality, output)) {
                     throw IllegalStateException("Bitmap.compress returned false")
                 }
                 output.toByteArray()
             }
-            base.copy(jpeg = bytes)
+            base.copy(jpeg = bytes, mimeType = if (isPng) "image/png" else "image/jpeg")
         } catch (error: Throwable) {
             base.copy(resultName = "ENCODE_ERROR", detail = error.javaClass.simpleName)
         } finally {

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt
@@ -32,9 +32,12 @@ import java.util.concurrent.atomic.AtomicReference
  * Renders a second, real Overdrive Activity onto an app-owned private display.
  *
  * Display stack 0 and BYD's AccAnimation layer are never part of this display.
- * SurfaceFlinger scales the normal 1920x1080 / 240-dpi Activity composition
- * into a 960x540 ImageReader surface. The newest image is JPEG encoded at a
- * bounded cadence and cached, so web clients do not initiate UI screenshots.
+ * The ImageReader surface matches the normal 1920x1080 / 240-dpi Activity
+ * composition. Frames are downscaled to 960x540 only after the complete
+ * display buffer has been read; BYD's Android 10 compositor otherwise crops a
+ * full-size projection into a smaller consumer surface instead of scaling it.
+ * The newest image is JPEG encoded at a bounded cadence and cached, so web
+ * clients do not initiate UI screenshots.
  */
 object RemoteDevVirtualDisplay {
     const val BACKEND_NAME = "Virtual display"
@@ -131,8 +134,8 @@ object RemoteDevVirtualDisplay {
             Thread(runnable, "remote-dev-frame-encoder").apply { isDaemon = true }
         }
         private val reader = ImageReader.newInstance(
-            STREAM_WIDTH,
-            STREAM_HEIGHT,
+            LOGICAL_WIDTH,
+            LOGICAL_HEIGHT,
             PixelFormat.RGBA_8888,
             MAX_IMAGES,
         )
@@ -223,13 +226,13 @@ object RemoteDevVirtualDisplay {
             val plane = image.planes.firstOrNull() ?: return
             val pixelStride = plane.pixelStride
             val rowStride = plane.rowStride
-            if (pixelStride != 4 || rowStride < STREAM_WIDTH * pixelStride) {
+            if (pixelStride != 4 || rowStride < LOGICAL_WIDTH * pixelStride) {
                 throw IllegalStateException("Unsupported RGBA plane pixelStride=$pixelStride rowStride=$rowStride")
             }
             val stagingWidth = rowStride / pixelStride
             val staging = stagingBitmap?.takeIf {
-                !it.isRecycled && it.width == stagingWidth && it.height == STREAM_HEIGHT
-            } ?: Bitmap.createBitmap(stagingWidth, STREAM_HEIGHT, Bitmap.Config.ARGB_8888).also {
+                !it.isRecycled && it.width == stagingWidth && it.height == LOGICAL_HEIGHT
+            } ?: Bitmap.createBitmap(stagingWidth, LOGICAL_HEIGHT, Bitmap.Config.ARGB_8888).also {
                 stagingBitmap?.takeUnless(Bitmap::isRecycled)?.recycle()
                 stagingBitmap = it
             }
@@ -245,7 +248,7 @@ object RemoteDevVirtualDisplay {
             output.eraseColor(Color.BLACK)
             Canvas(output).drawBitmap(
                 staging,
-                Rect(0, 0, STREAM_WIDTH, STREAM_HEIGHT),
+                Rect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT),
                 Rect(0, 0, STREAM_WIDTH, STREAM_HEIGHT),
                 Paint(Paint.FILTER_BITMAP_FLAG),
             )

--- a/app/src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt
+++ b/app/src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt
@@ -1,0 +1,317 @@
+package com.overdrive.app.remote
+
+import android.app.ActivityOptions
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.Image
+import android.media.ImageReader
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.SystemClock
+import android.util.Log
+import android.view.Display
+import com.overdrive.app.ui.MainActivity
+import com.overdrive.app.ui.RemoteMainActivity
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Renders a second, real Overdrive Activity onto an app-owned private display.
+ *
+ * Display stack 0 and BYD's AccAnimation layer are never part of this display.
+ * SurfaceFlinger scales the normal 1920x1080 / 240-dpi Activity composition
+ * into a 960x540 ImageReader surface. The newest image is JPEG encoded at a
+ * bounded cadence and cached, so web clients do not initiate UI screenshots.
+ */
+object RemoteDevVirtualDisplay {
+    const val BACKEND_NAME = "Virtual display"
+
+    private const val TAG = "RemoteDevVirtualDisplay"
+    private const val DISPLAY_NAME = "Overdrive Remote Dev"
+    private const val LOGICAL_WIDTH = 1920
+    private const val LOGICAL_HEIGHT = 1080
+    private const val LOGICAL_DENSITY_DPI = 240
+    private const val STREAM_WIDTH = 960
+    private const val STREAM_HEIGHT = 540
+    private const val STREAM_JPEG_QUALITY = 60
+    private const val STREAM_FRAME_INTERVAL_MS = 100L
+    private const val MAX_IMAGES = 3
+    private const val BLACK_SAMPLE_COLUMNS = 24
+    private const val BLACK_SAMPLE_ROWS = 14
+    private const val BLACK_LUMA_THRESHOLD = 8
+    private const val BLACK_NON_DARK_SAMPLE_LIMIT = 2
+
+    data class StartResult(
+        val success: Boolean,
+        val displayId: Int = Display.INVALID_DISPLAY,
+        val detail: String? = null,
+    )
+
+    data class CachedFrame(
+        val sequence: Long,
+        val jpeg: ByteArray,
+        val width: Int,
+        val height: Int,
+        val encodedAtElapsedMs: Long,
+        val encodeMs: Long,
+        val droppedBlackFrames: Long,
+    )
+
+    private val lock = Any()
+    @Volatile private var active: Session? = null
+
+    fun start(application: Application): StartResult = synchronized(lock) {
+        active?.takeIf { it.isUsable() }?.let {
+            it.launchActivity()
+            return StartResult(true, it.displayId)
+        }
+
+        active?.close()
+        active = null
+        val session = try {
+            Session(application)
+        } catch (error: Throwable) {
+            Log.e(TAG, "Unable to create private virtual display", error)
+            return StartResult(false, detail = error.javaClass.simpleName + ": " + error.message)
+        }
+        active = session
+        RemoteDevViewController.bindRemoteDisplay(session.displayId)
+        return try {
+            session.launchActivity()
+            StartResult(true, session.displayId)
+        } catch (error: Throwable) {
+            Log.e(TAG, "Unable to launch RemoteMainActivity", error)
+            active = null
+            RemoteDevViewController.unbindRemoteDisplay(session.displayId)
+            session.close()
+            StartResult(false, detail = error.javaClass.simpleName + ": " + error.message)
+        }
+    }
+
+    fun stop() {
+        val session = synchronized(lock) {
+            active.also { active = null }
+        } ?: return
+        RemoteDevViewController.unbindRemoteDisplay(session.displayId)
+        session.close()
+    }
+
+    fun isRunning(): Boolean = active?.isUsable() == true
+
+    fun displayId(): Int = active?.displayId ?: Display.INVALID_DISPLAY
+
+    fun latestFrame(): CachedFrame? = active?.latestFrame?.get()
+
+    fun requestImmediateFrame() {
+        active?.requestImmediateFrame()
+    }
+
+    private class Session(private val application: Application) {
+        private val closed = AtomicBoolean(false)
+        private val encoding = AtomicBoolean(false)
+        private val forceNextFrame = AtomicBoolean(true)
+        private val frameSequence = AtomicLong()
+        private val droppedBlackFrames = AtomicLong()
+        private val thread = HandlerThread("remote-dev-virtual-display").apply { start() }
+        private val handler = Handler(thread.looper)
+        private val encoder = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "remote-dev-frame-encoder").apply { isDaemon = true }
+        }
+        private val reader = ImageReader.newInstance(
+            STREAM_WIDTH,
+            STREAM_HEIGHT,
+            PixelFormat.RGBA_8888,
+            MAX_IMAGES,
+        )
+        private val virtualDisplay: VirtualDisplay
+        @Volatile private var nextEncodeAtElapsedMs = 0L
+        @Volatile private var stagingBitmap: Bitmap? = null
+        @Volatile private var outputBitmap: Bitmap? = null
+        val latestFrame = AtomicReference<CachedFrame>()
+        val displayId: Int
+
+        init {
+            reader.setOnImageAvailableListener({ source -> onImageAvailable(source) }, handler)
+            val displayManager = application.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            virtualDisplay = displayManager.createVirtualDisplay(
+                DISPLAY_NAME,
+                LOGICAL_WIDTH,
+                LOGICAL_HEIGHT,
+                LOGICAL_DENSITY_DPI,
+                reader.surface,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY,
+                object : VirtualDisplay.Callback() {
+                    override fun onStopped() {
+                        Log.i(TAG, "Private virtual display stopped")
+                    }
+                },
+                handler,
+            ) ?: throw IllegalStateException("DisplayManager returned no virtual display")
+            displayId = virtualDisplay.display.displayId
+            if (displayId == Display.INVALID_DISPLAY || displayId == Display.DEFAULT_DISPLAY) {
+                virtualDisplay.release()
+                throw IllegalStateException("Invalid private display id $displayId")
+            }
+            Log.i(TAG, "Private virtual display ready: id=$displayId logical=${LOGICAL_WIDTH}x$LOGICAL_HEIGHT stream=${STREAM_WIDTH}x$STREAM_HEIGHT")
+        }
+
+        fun isUsable(): Boolean = !closed.get() && virtualDisplay.display.isValid
+
+        fun launchActivity() {
+            check(isUsable()) { "Private virtual display is not available" }
+            val options = ActivityOptions.makeBasic().apply { launchDisplayId = displayId }
+            val intent = Intent(application, RemoteMainActivity::class.java).apply {
+                putExtra(MainActivity.EXTRA_REMOTE_DEV_SESSION, true)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            }
+            application.startActivity(intent, options.toBundle())
+        }
+
+        fun requestImmediateFrame() {
+            forceNextFrame.set(true)
+            nextEncodeAtElapsedMs = 0L
+        }
+
+        private fun onImageAvailable(source: ImageReader) {
+            val image = try { source.acquireLatestImage() } catch (_: Throwable) { null } ?: return
+            val now = SystemClock.elapsedRealtime()
+            val forced = forceNextFrame.getAndSet(false)
+            if (!forced && now < nextEncodeAtElapsedMs) {
+                image.close()
+                return
+            }
+            if (!encoding.compareAndSet(false, true)) {
+                forceNextFrame.set(forced)
+                image.close()
+                return
+            }
+            nextEncodeAtElapsedMs = now + STREAM_FRAME_INTERVAL_MS
+            try {
+                encoder.execute {
+                    try { encode(image) }
+                    catch (error: Throwable) { Log.w(TAG, "Frame encode failed", error) }
+                    finally {
+                        try { image.close() } catch (_: Throwable) {}
+                        encoding.set(false)
+                    }
+                }
+            } catch (error: Throwable) {
+                try { image.close() } catch (_: Throwable) {}
+                encoding.set(false)
+            }
+        }
+
+        private fun encode(image: Image) {
+            if (closed.get()) return
+            val started = SystemClock.elapsedRealtime()
+            val plane = image.planes.firstOrNull() ?: return
+            val pixelStride = plane.pixelStride
+            val rowStride = plane.rowStride
+            if (pixelStride != 4 || rowStride < STREAM_WIDTH * pixelStride) {
+                throw IllegalStateException("Unsupported RGBA plane pixelStride=$pixelStride rowStride=$rowStride")
+            }
+            val stagingWidth = rowStride / pixelStride
+            val staging = stagingBitmap?.takeIf {
+                !it.isRecycled && it.width == stagingWidth && it.height == STREAM_HEIGHT
+            } ?: Bitmap.createBitmap(stagingWidth, STREAM_HEIGHT, Bitmap.Config.ARGB_8888).also {
+                stagingBitmap?.takeUnless(Bitmap::isRecycled)?.recycle()
+                stagingBitmap = it
+            }
+            val output = outputBitmap?.takeIf {
+                !it.isRecycled && it.width == STREAM_WIDTH && it.height == STREAM_HEIGHT
+            } ?: Bitmap.createBitmap(STREAM_WIDTH, STREAM_HEIGHT, Bitmap.Config.ARGB_8888).also {
+                outputBitmap?.takeUnless(Bitmap::isRecycled)?.recycle()
+                outputBitmap = it
+            }
+
+            plane.buffer.rewind()
+            staging.copyPixelsFromBuffer(plane.buffer)
+            output.eraseColor(Color.BLACK)
+            Canvas(output).drawBitmap(
+                staging,
+                Rect(0, 0, STREAM_WIDTH, STREAM_HEIGHT),
+                Rect(0, 0, STREAM_WIDTH, STREAM_HEIGHT),
+                Paint(Paint.FILTER_BITMAP_FLAG),
+            )
+
+            if (isNearlyBlack(output) && latestFrame.get() != null &&
+                !RemoteDevViewController.isRemoteWindowSecure()
+            ) {
+                droppedBlackFrames.incrementAndGet()
+                return
+            }
+
+            val bytes = ByteArrayOutputStream(128 * 1024).use { out ->
+                if (!output.compress(Bitmap.CompressFormat.JPEG, STREAM_JPEG_QUALITY, out)) {
+                    throw IllegalStateException("Bitmap.compress returned false")
+                }
+                out.toByteArray()
+            }
+            latestFrame.set(
+                CachedFrame(
+                    sequence = frameSequence.incrementAndGet(),
+                    jpeg = bytes,
+                    width = STREAM_WIDTH,
+                    height = STREAM_HEIGHT,
+                    encodedAtElapsedMs = SystemClock.elapsedRealtime(),
+                    encodeMs = SystemClock.elapsedRealtime() - started,
+                    droppedBlackFrames = droppedBlackFrames.get(),
+                )
+            )
+        }
+
+        fun close() {
+            if (!closed.compareAndSet(false, true)) return
+            reader.setOnImageAvailableListener(null, null)
+            try { virtualDisplay.release() } catch (_: Throwable) {}
+            try { reader.close() } catch (_: Throwable) {}
+            encoder.shutdown()
+            try { encoder.awaitTermination(750, TimeUnit.MILLISECONDS) } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            if (encoder.isTerminated) {
+                stagingBitmap?.takeUnless(Bitmap::isRecycled)?.recycle()
+                outputBitmap?.takeUnless(Bitmap::isRecycled)?.recycle()
+            }
+            thread.quitSafely()
+            latestFrame.set(null)
+            Log.i(TAG, "Private virtual display released")
+        }
+    }
+
+    internal fun isNearlyBlack(bitmap: Bitmap): Boolean {
+        var nonDark = 0
+        val xStep = (bitmap.width / BLACK_SAMPLE_COLUMNS).coerceAtLeast(1)
+        val yStep = (bitmap.height / BLACK_SAMPLE_ROWS).coerceAtLeast(1)
+        var y = yStep / 2
+        while (y < bitmap.height) {
+            var x = xStep / 2
+            while (x < bitmap.width) {
+                val color = bitmap.getPixel(x, y)
+                val luma = (Color.red(color) * 54 + Color.green(color) * 183 + Color.blue(color) * 19) shr 8
+                if (luma > BLACK_LUMA_THRESHOLD && ++nonDark > BLACK_NON_DARK_SAMPLE_LIMIT) {
+                    return false
+                }
+                x += xStep
+            }
+            y += yStep
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/HttpResponse.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpResponse.java
@@ -66,6 +66,7 @@ public class HttpResponse {
             }
             headers.append("Access-Control-Expose-Headers: X-Overdrive-Width, X-Overdrive-Height, ")
                    .append("X-Overdrive-PixelCopy-Code, X-Overdrive-PixelCopy-Result, ")
+                   .append("X-Overdrive-Capture-Backend, X-Overdrive-Frame-Sequence, ")
                    .append("X-Overdrive-Activity\r\n");
         }
         headers.append("Connection: close\r\n\r\n");

--- a/app/src/main/java/com/overdrive/app/server/HttpResponse.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpResponse.java
@@ -2,6 +2,8 @@ package com.overdrive.app.server;
 
 import org.json.JSONObject;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * HTTP Response utilities - shared by all handlers.
@@ -45,6 +47,35 @@ public class HttpResponse {
     
     public static void sendJsonSuccess(OutputStream out) throws Exception {
         sendJson(out, "{\"success\":true}");
+    }
+
+    /** Send sensitive transient bytes with mandatory no-store semantics. */
+    public static void sendBinaryNoStore(OutputStream out, String contentType, byte[] body,
+                                         Map<String, String> extraHeaders) throws Exception {
+        StringBuilder headers = new StringBuilder();
+        headers.append("HTTP/1.1 200 OK\r\n")
+               .append("Content-Type: ").append(safeHeader(contentType)).append("\r\n")
+               .append("Content-Length: ").append(body.length).append("\r\n")
+               .append("Cache-Control: no-store, no-cache, must-revalidate, private\r\n")
+               .append("Pragma: no-cache\r\n")
+               .append("X-Content-Type-Options: nosniff\r\n");
+        if (extraHeaders != null) {
+            for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
+                headers.append(safeHeader(entry.getKey())).append(": ")
+                       .append(safeHeader(entry.getValue())).append("\r\n");
+            }
+            headers.append("Access-Control-Expose-Headers: X-Overdrive-Width, X-Overdrive-Height, ")
+                   .append("X-Overdrive-PixelCopy-Code, X-Overdrive-PixelCopy-Result, ")
+                   .append("X-Overdrive-Activity\r\n");
+        }
+        headers.append("Connection: close\r\n\r\n");
+        out.write(headers.toString().getBytes(StandardCharsets.UTF_8));
+        out.write(body);
+        out.flush();
+    }
+
+    private static String safeHeader(String value) {
+        return value == null ? "" : value.replace("\r", "").replace("\n", "");
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -261,7 +261,11 @@ public class HttpServer {
             // All other requests still log.
             if (!(requestLine.contains("/api/stream/turn")
                     || requestLine.contains("/api/bs/status")
-                    || requestLine.startsWith("GET /status"))) {
+                    || requestLine.startsWith("GET /status")
+                    // WebSocket URLs carry the dashboard JWT because browser
+                    // WebSockets cannot set Authorization. Never write it to
+                    // the daemon log (applies to camera and Remote Dev View).
+                    || requestLine.startsWith("GET /ws"))) {
                 CameraDaemon.log("HTTP: " + requestLine);
             }
 
@@ -270,6 +274,7 @@ public class HttpServer {
             int contentLength = 0;
             String websocketKey = null;
             String upgradeHeader = null;
+            String websocketProtocolHeader = null;
             String rangeHeader = null;
             // Conditional GET — if the client (Chrome WebView's HTTP cache)
             // sends If-None-Match matching our ETag, we return 304 instead of
@@ -296,6 +301,8 @@ public class HttpServer {
                     websocketKey = line.substring(18).trim();
                 } else if (lower.startsWith("upgrade:")) {
                     upgradeHeader = line.substring(8).trim();
+                } else if (lower.startsWith("sec-websocket-protocol:")) {
+                    websocketProtocolHeader = line.substring(23).trim();
                 } else if (lower.startsWith("range:")) {
                     rangeHeader = line.substring(6).trim();
                 } else if (lower.startsWith("if-none-match:")) {
@@ -409,7 +416,10 @@ public class HttpServer {
             // WebSocket clients can't set arbitrary headers — cookies may be dropped
             // through tunnels' SameSite policies).
             String wsPathOnly = path.contains("?") ? path.substring(0, path.indexOf("?")) : path;
-            if (wsPathOnly.equals("/ws") && websocketKey != null && "websocket".equalsIgnoreCase(upgradeHeader)) {
+            if ((wsPathOnly.equals("/ws")
+                    || wsPathOnly.equals(RemoteDevViewWebSocketStream.PATH))
+                    && websocketKey != null
+                    && "websocket".equalsIgnoreCase(upgradeHeader)) {
                 // Promote ?token= query param into a synthetic Authorization header
                 // so AuthMiddleware's existing Bearer-token path handles it.
                 String wsAuthHeader = authHeader;
@@ -429,7 +439,20 @@ public class HttpServer {
                     client.close();
                     return;
                 }
-                handleWebSocketUpgrade(client, websocketKey);
+                if (wsPathOnly.equals(RemoteDevViewWebSocketStream.PATH)) {
+                    String devViewSession = RemoteDevViewWebSocketStream
+                        .sessionFromProtocols(websocketProtocolHeader);
+                    if (devViewSession == null
+                            || !RemoteDevViewApiHandler.validateStreamSession(devViewSession)) {
+                        HttpResponse.sendError(out, 403,
+                            "Developer-view session is invalid or expired");
+                        client.close();
+                        return;
+                    }
+                    RemoteDevViewWebSocketStream.handle(client, websocketKey, devViewSession);
+                } else {
+                    handleWebSocketUpgrade(client, websocketKey);
+                }
                 return;
             }
 

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -514,6 +514,10 @@ public class HttpServer {
                 if (!serveStaticFile(out, "local/performance.html")) {
                     HttpResponse.sendError(out, 404, "performance.html not found");
                 }
+            } else if (path.equals("/remote-dev-view.html") || path.equals("/remote-dev-view")) {
+                if (!serveStaticFile(out, "local/remote-dev-view.html")) {
+                    HttpResponse.sendError(out, 404, "remote-dev-view.html not found");
+                }
             } else if (path.equals("/abrp.html") || path.equals("/abrp")) {
                 if (!serveStaticFile(out, "local/abrp.html")) {
                     HttpResponse.sendError(out, 404, "abrp.html not found");
@@ -959,6 +963,12 @@ public class HttpServer {
         // Performance API
         if (path.startsWith("/api/performance")) {
             return PerformanceApiHandler.handle(method, path, body, out);
+        }
+
+        // Authenticated, explicitly confirmed app-window capture/control.
+        // Deliberately absent from AUTOMATION_ALLOWED_PREFIXES.
+        if (path.startsWith("/api/dev-view/")) {
+            return RemoteDevViewApiHandler.handle(method, path, body, out);
         }
         
         // External Storage API (SD card and CDR cleanup)

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
@@ -5,6 +5,10 @@ import org.json.JSONObject;
 import java.io.OutputStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Authenticated HTTP surface for Remote Overdrive Dev View.
@@ -18,6 +22,19 @@ public final class RemoteDevViewApiHandler {
         new RemoteDevViewSessionManager();
     private static final RemoteDevViewBridgeClient BRIDGE =
         new RemoteDevViewBridgeClient();
+    private static final AtomicBoolean BRIDGE_ACTIVE = new AtomicBoolean(false);
+    private static final ScheduledExecutorService SESSION_REAPER =
+        Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "remote-dev-session-reaper");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+    static {
+        SESSION_REAPER.scheduleWithFixedDelay(() -> {
+            if (BRIDGE_ACTIVE.get() && !SESSIONS.hasActiveSession()) stopBridge();
+        }, 30L, 30L, TimeUnit.SECONDS);
+    }
 
     private RemoteDevViewApiHandler() {}
 
@@ -54,10 +71,12 @@ public final class RemoteDevViewApiHandler {
             }
             RemoteDevViewBridgeClient.Response ready = BRIDGE.awaitReady();
             if (ready == null) {
+                BRIDGE.shutdown();
                 unavailable(out, "App-process bridge did not become ready");
                 return true;
             }
             RemoteDevViewSessionManager.Session session = SESSIONS.start();
+            BRIDGE_ACTIVE.set(true);
             JSONObject response = new JSONObject();
             response.put("success", true);
             response.put("session", session.token);
@@ -65,6 +84,8 @@ public final class RemoteDevViewApiHandler {
             response.put("maxLifetimeMs", RemoteDevViewSessionManager.MAX_LIFETIME_MS);
             response.put("activityReady", ready.metadata.optBoolean("success", false));
             response.put("activity", ready.metadata.opt("activity"));
+            response.put("captureBackend", ready.metadata.opt("captureBackend"));
+            response.put("displayId", ready.metadata.optInt("displayId", -1));
             response.put("physicalDisplayChanged", false);
             HttpResponse.sendJson(out, response.toString());
             return true;
@@ -76,7 +97,7 @@ public final class RemoteDevViewApiHandler {
                 invalidSession(out);
                 return true;
             }
-            BRIDGE.shutdown();
+            stopBridge();
             HttpResponse.sendJsonSuccess(out);
             return true;
         }
@@ -116,6 +137,10 @@ public final class RemoteDevViewApiHandler {
             headers.put("X-Overdrive-PixelCopy-Result",
                 metadata.optString("pixelCopyResult", "UNKNOWN"));
             headers.put("X-Overdrive-Activity", metadata.optString("activity", ""));
+            headers.put("X-Overdrive-Capture-Backend",
+                metadata.optString("captureBackend", "PixelCopy"));
+            headers.put("X-Overdrive-Frame-Sequence",
+                Long.toString(metadata.optLong("frameSequence", 0L)));
             HttpResponse.sendBinaryNoStore(out,
                 metadata.optString("mimeType", "image/jpeg"), bridgeResponse.payload, headers);
             return true;
@@ -179,6 +204,7 @@ public final class RemoteDevViewApiHandler {
     }
 
     private static void invalidSession(OutputStream out) throws Exception {
+        if (!SESSIONS.hasActiveSession()) stopBridge();
         HttpResponse.sendJson(out, 403, new JSONObject()
             .put("success", false)
             .put("error", "Developer-view session is invalid or expired")
@@ -188,5 +214,10 @@ public final class RemoteDevViewApiHandler {
     private static void unavailable(OutputStream out, String detail) throws Exception {
         HttpResponse.sendJson(out, 503, new JSONObject()
             .put("success", false).put("error", detail).toString());
+    }
+
+    private static void stopBridge() {
+        if (!BRIDGE_ACTIVE.compareAndSet(true, false)) return;
+        BRIDGE.shutdown();
     }
 }

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
@@ -1,0 +1,174 @@
+package com.overdrive.app.server;
+
+import org.json.JSONObject;
+
+import java.io.OutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Authenticated HTTP surface for Remote Overdrive Dev View.
+ *
+ * HttpServer invokes this only after AuthMiddleware. A second, short-lived
+ * in-memory session capability is required on every frame/input request so a
+ * stale browser tab cannot retain control indefinitely.
+ */
+public final class RemoteDevViewApiHandler {
+    private static final RemoteDevViewSessionManager SESSIONS =
+        new RemoteDevViewSessionManager();
+    private static final RemoteDevViewBridgeClient BRIDGE =
+        new RemoteDevViewBridgeClient();
+
+    private RemoteDevViewApiHandler() {}
+
+    public static boolean handle(String method, String path, String body, OutputStream out)
+            throws Exception {
+        if (path.equals("/api/dev-view/session") && method.equals("POST")) {
+            JSONObject request = parseBody(body);
+            if (!"I UNDERSTAND".equals(request.optString("confirm", ""))) {
+                HttpResponse.sendJson(out, 400, new JSONObject()
+                    .put("success", false)
+                    .put("error", "Explicit confirmation is required")
+                    .toString());
+                return true;
+            }
+            if (!BRIDGE.start(true)) {
+                unavailable(out, "App-process bridge could not be started");
+                return true;
+            }
+            RemoteDevViewBridgeClient.Response ready = BRIDGE.awaitReady();
+            if (ready == null) {
+                unavailable(out, "App-process bridge did not become ready");
+                return true;
+            }
+            RemoteDevViewSessionManager.Session session = SESSIONS.start();
+            JSONObject response = new JSONObject();
+            response.put("success", true);
+            response.put("session", session.token);
+            response.put("idleTimeoutMs", RemoteDevViewSessionManager.IDLE_TIMEOUT_MS);
+            response.put("maxLifetimeMs", RemoteDevViewSessionManager.MAX_LIFETIME_MS);
+            response.put("activityReady", ready.metadata.optBoolean("success", false));
+            response.put("activity", ready.metadata.opt("activity"));
+            response.put("physicalDisplayChanged", false);
+            HttpResponse.sendJson(out, response.toString());
+            return true;
+        }
+
+        if (path.equals("/api/dev-view/session") && method.equals("DELETE")) {
+            JSONObject request = parseBody(body);
+            if (!SESSIONS.end(request.optString("session", ""))) {
+                invalidSession(out);
+                return true;
+            }
+            BRIDGE.shutdown();
+            HttpResponse.sendJsonSuccess(out);
+            return true;
+        }
+
+        if (path.equals("/api/dev-view/status") && method.equals("POST")) {
+            JSONObject request = requireSession(body, out);
+            if (request == null) return true;
+            RemoteDevViewBridgeClient.Response bridgeResponse = BRIDGE.send(
+                new JSONObject().put("command", "status"));
+            sendBridgeJson(out, bridgeResponse);
+            return true;
+        }
+
+        if (path.equals("/api/dev-view/frame") && method.equals("POST")) {
+            JSONObject request = requireSession(body, out);
+            if (request == null) return true;
+            JSONObject bridgeRequest = new JSONObject();
+            bridgeRequest.put("command", "capture");
+            bridgeRequest.put("maxWidth", request.optInt("maxWidth", 1280));
+            bridgeRequest.put("quality", request.optInt("quality", 72));
+            RemoteDevViewBridgeClient.Response bridgeResponse = BRIDGE.send(bridgeRequest);
+            if (bridgeResponse == null) {
+                unavailable(out, "App-process bridge is unavailable");
+                return true;
+            }
+            JSONObject metadata = bridgeResponse.metadata;
+            if (!metadata.optBoolean("success", false) || bridgeResponse.payload.length == 0) {
+                HttpResponse.sendJson(out, 503, metadata.toString());
+                return true;
+            }
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put("X-Overdrive-Width", Integer.toString(metadata.optInt("width", 0)));
+            headers.put("X-Overdrive-Height", Integer.toString(metadata.optInt("height", 0)));
+            headers.put("X-Overdrive-PixelCopy-Code",
+                Integer.toString(metadata.optInt("pixelCopyCode", -1)));
+            headers.put("X-Overdrive-PixelCopy-Result",
+                metadata.optString("pixelCopyResult", "UNKNOWN"));
+            headers.put("X-Overdrive-Activity", metadata.optString("activity", ""));
+            HttpResponse.sendBinaryNoStore(out, "image/jpeg", bridgeResponse.payload, headers);
+            return true;
+        }
+
+        if (path.equals("/api/dev-view/input") && method.equals("POST")) {
+            JSONObject request = requireSession(body, out);
+            if (request == null) return true;
+            String type = request.optString("type", "");
+            JSONObject bridgeRequest = new JSONObject();
+            if ("touch".equals(type)) {
+                bridgeRequest.put("command", "touch");
+                bridgeRequest.put("phase", request.optString("phase", ""));
+                bridgeRequest.put("x", request.optDouble("x", Double.NaN));
+                bridgeRequest.put("y", request.optDouble("y", Double.NaN));
+            } else if ("key".equals(type)) {
+                bridgeRequest.put("command", "key");
+                bridgeRequest.put("key", request.optString("key", ""));
+            } else if ("text".equals(type)) {
+                bridgeRequest.put("command", "text");
+                bridgeRequest.put("text", request.optString("text", ""));
+            } else {
+                HttpResponse.sendJson(out, 400, new JSONObject()
+                    .put("success", false).put("error", "Unknown input type").toString());
+                return true;
+            }
+            sendBridgeJson(out, BRIDGE.send(bridgeRequest));
+            return true;
+        }
+
+        if (path.startsWith("/api/dev-view/")) {
+            HttpResponse.sendError(out, 405, "Method Not Allowed");
+            return true;
+        }
+        return false;
+    }
+
+    private static JSONObject requireSession(String body, OutputStream out) throws Exception {
+        JSONObject request = parseBody(body);
+        if (SESSIONS.validateAndTouch(request.optString("session", "")) == null) {
+            invalidSession(out);
+            return null;
+        }
+        return request;
+    }
+
+    private static JSONObject parseBody(String body) {
+        try { return new JSONObject(body == null || body.isEmpty() ? "{}" : body); }
+        catch (Exception ignored) { return new JSONObject(); }
+    }
+
+    private static void sendBridgeJson(OutputStream out,
+                                       RemoteDevViewBridgeClient.Response response) throws Exception {
+        if (response == null) {
+            unavailable(out, "App-process bridge is unavailable");
+        } else if (response.metadata.optBoolean("success", false)) {
+            HttpResponse.sendJson(out, response.metadata.toString());
+        } else {
+            HttpResponse.sendJson(out, 409, response.metadata.toString());
+        }
+    }
+
+    private static void invalidSession(OutputStream out) throws Exception {
+        HttpResponse.sendJson(out, 403, new JSONObject()
+            .put("success", false)
+            .put("error", "Developer-view session is invalid or expired")
+            .toString());
+    }
+
+    private static void unavailable(OutputStream out, String detail) throws Exception {
+        HttpResponse.sendJson(out, 503, new JSONObject()
+            .put("success", false).put("error", detail).toString());
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
@@ -21,6 +21,22 @@ public final class RemoteDevViewApiHandler {
 
     private RemoteDevViewApiHandler() {}
 
+    /** Package-private hooks used only by the authenticated WebSocket path. */
+    static boolean validateStreamSession(String session) {
+        return SESSIONS.validateAndTouch(session) != null;
+    }
+
+    static RemoteDevViewBridgeClient.Response captureStreamFrame(int maxWidth, int quality) {
+        try {
+            return BRIDGE.send(new JSONObject()
+                .put("command", "capture")
+                .put("maxWidth", maxWidth)
+                .put("quality", quality));
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     public static boolean handle(String method, String path, String body, OutputStream out)
             throws Exception {
         if (path.equals("/api/dev-view/session") && method.equals("POST")) {

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java
@@ -97,6 +97,7 @@ public final class RemoteDevViewApiHandler {
             bridgeRequest.put("command", "capture");
             bridgeRequest.put("maxWidth", request.optInt("maxWidth", 1280));
             bridgeRequest.put("quality", request.optInt("quality", 72));
+            bridgeRequest.put("format", request.optString("format", "jpeg"));
             RemoteDevViewBridgeClient.Response bridgeResponse = BRIDGE.send(bridgeRequest);
             if (bridgeResponse == null) {
                 unavailable(out, "App-process bridge is unavailable");
@@ -115,7 +116,8 @@ public final class RemoteDevViewApiHandler {
             headers.put("X-Overdrive-PixelCopy-Result",
                 metadata.optString("pixelCopyResult", "UNKNOWN"));
             headers.put("X-Overdrive-Activity", metadata.optString("activity", ""));
-            HttpResponse.sendBinaryNoStore(out, "image/jpeg", bridgeResponse.payload, headers);
+            HttpResponse.sendBinaryNoStore(out,
+                metadata.optString("mimeType", "image/jpeg"), bridgeResponse.payload, headers);
             return true;
         }
 

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -1,11 +1,8 @@
 package com.overdrive.app.server;
 
-import android.content.ComponentName;
-import android.content.Context;
-import android.content.Intent;
+import android.net.LocalSocket;
+import android.net.LocalSocketAddress;
 
-import com.overdrive.app.daemon.DaemonBootstrap;
-import com.overdrive.app.daemon.CameraDaemon;
 import com.overdrive.app.remote.RemoteDevViewBridgeService;
 
 import org.json.JSONObject;
@@ -13,20 +10,13 @@ import org.json.JSONObject;
 import java.io.DataInputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
 
 /** Shell-daemon client for the protected app-process developer-view bridge. */
 final class RemoteDevViewBridgeClient {
-    private static final int CONNECT_TIMEOUT_MS = 1_500;
     private static final int READ_TIMEOUT_MS = 9_000;
     private static final int MAX_METADATA_BYTES = 64 * 1024;
     private static final int MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
-    private static final String SERVICE_CLASS =
-        "com.overdrive.app.remote.RemoteDevViewBridgeService";
 
     static final class Response {
         final JSONObject metadata;
@@ -38,92 +28,21 @@ final class RemoteDevViewBridgeClient {
         }
     }
 
-    private final String bridgeSecret = randomHex(32);
-
     boolean start(boolean launchActivity) {
-        try {
-            Context daemonContext = DaemonBootstrap.getContext();
-            if (daemonContext == null) return false;
-            // DaemonBootstrap's package context identifies as com.overdrive.app,
-            // but this app_process is uid 2000. ActivityManager rejects that
-            // package/uid mismatch before it even checks the component's DUMP
-            // permission. Prefer a real com.android.shell package context so
-            // the Binder caller identity and attributed package agree and the
-            // ephemeral bridge secret stays inside the Binder parcel.
-            Intent intent = new Intent(RemoteDevViewBridgeService.ACTION_START);
-            intent.setComponent(new ComponentName(DaemonBootstrap.getPackageName(), SERVICE_CLASS));
-            intent.putExtra(RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret);
-            intent.putExtra(RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY, launchActivity);
-            try {
-                Context context = daemonContext.createPackageContext(
-                    "com.android.shell", Context.CONTEXT_IGNORE_SECURITY);
-                if ("com.android.shell".equals(context.getPackageName())
-                        && context.startService(intent) != null) {
-                    return true;
-                }
-            } catch (Throwable error) {
-                logStartFailure("Binder start", error);
-            }
-
-            // Some BYD builds return the Overdrive package context from
-            // createPackageContext(com.android.shell), leaving ActivityManager
-            // to reject the package/uid mismatch. Use am as a narrow fallback.
-            // ProcessBuilder passes each value as a literal argument (no shell
-            // interpolation). The only peers able to inspect this shell-uid
-            // process are shell-equivalent principals that already hold DUMP
-            // and can start/inspect the protected service directly.
-            return startWithActivityManagerCommand(launchActivity);
-        } catch (Throwable error) {
-            logStartFailure("Bridge start", error);
-            return false;
-        }
-    }
-
-    private boolean startWithActivityManagerCommand(boolean launchActivity) {
-        Process process = null;
-        try {
-            process = new ProcessBuilder(
-                "/system/bin/am",
-                "startservice",
-                "-n", DaemonBootstrap.getPackageName() + "/" + SERVICE_CLASS,
-                "-a", RemoteDevViewBridgeService.ACTION_START,
-                "--es", RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret,
-                "--ez", RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY,
-                Boolean.toString(launchActivity))
-                .redirectErrorStream(true)
-                .start();
-            if (!process.waitFor(5, TimeUnit.SECONDS)) {
-                process.destroy();
-                return false;
-            }
-            return process.exitValue() == 0;
-        } catch (Throwable error) {
-            logStartFailure("am startservice", error);
-            return false;
-        } finally {
-            if (process != null) {
-                try { process.getInputStream().close(); } catch (Exception ignored) {}
-                try { process.getOutputStream().close(); } catch (Exception ignored) {}
-                try { process.getErrorStream().close(); } catch (Exception ignored) {}
-            }
-        }
-    }
-
-    private static void logStartFailure(String stage, Throwable error) {
-        try {
-            CameraDaemon.log("RemoteDevView: " + stage + " failed: "
-                + error.getClass().getSimpleName() + ": " + error.getMessage());
-        } catch (Throwable ignored) {}
+        JSONObject request = new JSONObject();
+        try { request.put("command", launchActivity ? "launch" : "status"); }
+        catch (Exception ignored) {}
+        Response response = send(request);
+        return response != null && response.metadata.optBoolean("success", false);
     }
 
     Response send(JSONObject request) {
-        Socket socket = null;
+        LocalSocket socket = null;
         try {
-            request.put("secret", bridgeSecret);
-            socket = new Socket();
-            socket.connect(new InetSocketAddress(
-                RemoteDevViewBridgeService.HOST,
-                RemoteDevViewBridgeService.PORT), CONNECT_TIMEOUT_MS);
+            socket = new LocalSocket();
+            socket.connect(new LocalSocketAddress(
+                RemoteDevViewBridgeService.SOCKET_NAME,
+                LocalSocketAddress.Namespace.ABSTRACT));
             socket.setSoTimeout(READ_TIMEOUT_MS);
 
             PrintWriter writer = new PrintWriter(
@@ -163,21 +82,7 @@ final class RemoteDevViewBridgeClient {
     }
 
     void shutdown() {
-        JSONObject request = new JSONObject();
-        try { request.put("command", "shutdown"); } catch (Exception ignored) {}
-        send(request);
-    }
-
-    private static String randomHex(int byteCount) {
-        byte[] bytes = new byte[byteCount];
-        new SecureRandom().nextBytes(bytes);
-        char[] alphabet = "0123456789abcdef".toCharArray();
-        char[] result = new char[bytes.length * 2];
-        for (int i = 0; i < bytes.length; i++) {
-            int value = bytes[i] & 0xff;
-            result[i * 2] = alphabet[value >>> 4];
-            result[i * 2 + 1] = alphabet[value & 0x0f];
-        }
-        return new String(result);
+        // The private bridge remains dormant for later sessions; the HTTP
+        // capability is the revocation boundary.
     }
 }

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -1,9 +1,8 @@
 package com.overdrive.app.server;
 
-import android.net.LocalSocket;
-import android.net.LocalSocketAddress;
 import android.util.Log;
 
+import com.overdrive.app.remote.RemoteDevViewBridgeAuth;
 import com.overdrive.app.remote.RemoteDevViewBridgeService;
 
 import org.json.JSONObject;
@@ -11,6 +10,9 @@ import org.json.JSONObject;
 import java.io.DataInputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
 /** Shell-daemon client for the protected app-process developer-view bridge. */
@@ -39,17 +41,16 @@ final class RemoteDevViewBridgeClient {
     }
 
     Response send(JSONObject request) {
-        LocalSocket socket = null;
+        Socket socket = null;
         try {
-            socket = new LocalSocket();
-            socket.connect(new LocalSocketAddress(
-                RemoteDevViewBridgeService.SOCKET_NAME,
-                LocalSocketAddress.Namespace.ABSTRACT));
+            socket = new Socket();
+            socket.connect(new InetSocketAddress(
+                InetAddress.getLoopbackAddress(), RemoteDevViewBridgeService.PORT), 1_000);
             socket.setSoTimeout(READ_TIMEOUT_MS);
 
             PrintWriter writer = new PrintWriter(
                 new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8), true);
-            writer.println(request.toString());
+            writer.println(RemoteDevViewBridgeAuth.sign(request));
 
             DataInputStream input = new DataInputStream(socket.getInputStream());
             int metadataLength = input.readInt();

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -1,0 +1,119 @@
+package com.overdrive.app.server;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+
+import com.overdrive.app.daemon.DaemonBootstrap;
+import com.overdrive.app.remote.RemoteDevViewBridgeService;
+
+import org.json.JSONObject;
+
+import java.io.DataInputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+
+/** Shell-daemon client for the protected app-process developer-view bridge. */
+final class RemoteDevViewBridgeClient {
+    private static final int CONNECT_TIMEOUT_MS = 1_500;
+    private static final int READ_TIMEOUT_MS = 9_000;
+    private static final int MAX_METADATA_BYTES = 64 * 1024;
+    private static final int MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
+    private static final String SERVICE_CLASS =
+        "com.overdrive.app.remote.RemoteDevViewBridgeService";
+
+    static final class Response {
+        final JSONObject metadata;
+        final byte[] payload;
+
+        Response(JSONObject metadata, byte[] payload) {
+            this.metadata = metadata;
+            this.payload = payload;
+        }
+    }
+
+    private final String bridgeSecret = randomHex(32);
+
+    boolean start(boolean launchActivity) {
+        try {
+            Context context = DaemonBootstrap.getContext();
+            if (context == null) return false;
+            Intent intent = new Intent(RemoteDevViewBridgeService.ACTION_START);
+            intent.setComponent(new ComponentName(context.getPackageName(), SERVICE_CLASS));
+            intent.putExtra(RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret);
+            intent.putExtra(RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY, launchActivity);
+            return context.startService(intent) != null;
+        } catch (Throwable error) {
+            return false;
+        }
+    }
+
+    Response send(JSONObject request) {
+        Socket socket = null;
+        try {
+            request.put("secret", bridgeSecret);
+            socket = new Socket();
+            socket.connect(new InetSocketAddress(
+                RemoteDevViewBridgeService.HOST,
+                RemoteDevViewBridgeService.PORT), CONNECT_TIMEOUT_MS);
+            socket.setSoTimeout(READ_TIMEOUT_MS);
+
+            PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8), true);
+            writer.println(request.toString());
+
+            DataInputStream input = new DataInputStream(socket.getInputStream());
+            int metadataLength = input.readInt();
+            if (metadataLength <= 0 || metadataLength > MAX_METADATA_BYTES) return null;
+            byte[] metadataBytes = new byte[metadataLength];
+            input.readFully(metadataBytes);
+            JSONObject metadata = new JSONObject(new String(metadataBytes, StandardCharsets.UTF_8));
+            int payloadLength = metadata.optInt("payloadBytes", 0);
+            if (payloadLength < 0 || payloadLength > MAX_PAYLOAD_BYTES) return null;
+            byte[] payload = new byte[payloadLength];
+            if (payloadLength > 0) input.readFully(payload);
+            return new Response(metadata, payload);
+        } catch (Throwable error) {
+            return null;
+        } finally {
+            try { if (socket != null) socket.close(); } catch (Exception ignored) {}
+        }
+    }
+
+    Response awaitReady() {
+        for (int attempt = 0; attempt < 20; attempt++) {
+            JSONObject request = new JSONObject();
+            try { request.put("command", "status"); } catch (Exception ignored) {}
+            Response response = send(request);
+            if (response != null) return response;
+            try { Thread.sleep(100); } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return null;
+    }
+
+    void shutdown() {
+        JSONObject request = new JSONObject();
+        try { request.put("command", "shutdown"); } catch (Exception ignored) {}
+        send(request);
+    }
+
+    private static String randomHex(int byteCount) {
+        byte[] bytes = new byte[byteCount];
+        new SecureRandom().nextBytes(bytes);
+        char[] alphabet = "0123456789abcdef".toCharArray();
+        char[] result = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int value = bytes[i] & 0xff;
+            result[i * 2] = alphabet[value >>> 4];
+            result[i * 2 + 1] = alphabet[value & 0x0f];
+        }
+        return new String(result);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -86,7 +86,8 @@ final class RemoteDevViewBridgeClient {
     }
 
     void shutdown() {
-        // The private bridge remains dormant for later sessions; the HTTP
-        // capability is the revocation boundary.
+        try {
+            send(new JSONObject().put("command", "stop"));
+        } catch (Exception ignored) {}
     }
 }

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.overdrive.app.daemon.DaemonBootstrap;
+import com.overdrive.app.daemon.CameraDaemon;
 import com.overdrive.app.remote.RemoteDevViewBridgeService;
 
 import org.json.JSONObject;
@@ -40,14 +41,27 @@ final class RemoteDevViewBridgeClient {
 
     boolean start(boolean launchActivity) {
         try {
-            Context context = DaemonBootstrap.getContext();
-            if (context == null) return false;
+            Context daemonContext = DaemonBootstrap.getContext();
+            if (daemonContext == null) return false;
+            // DaemonBootstrap's package context identifies as com.overdrive.app,
+            // but this app_process is uid 2000. ActivityManager rejects that
+            // package/uid mismatch before it even checks the component's DUMP
+            // permission. Use a real com.android.shell package context so the
+            // Binder caller identity and attributed package agree. This also
+            // keeps the ephemeral bridge secret out of command-line arguments.
+            Context context = daemonContext.createPackageContext(
+                "com.android.shell", Context.CONTEXT_IGNORE_SECURITY);
+            if (!"com.android.shell".equals(context.getPackageName())) return false;
             Intent intent = new Intent(RemoteDevViewBridgeService.ACTION_START);
-            intent.setComponent(new ComponentName(context.getPackageName(), SERVICE_CLASS));
+            intent.setComponent(new ComponentName(DaemonBootstrap.getPackageName(), SERVICE_CLASS));
             intent.putExtra(RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret);
             intent.putExtra(RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY, launchActivity);
             return context.startService(intent) != null;
         } catch (Throwable error) {
+            try {
+                CameraDaemon.log("RemoteDevView: bridge start failed: "
+                    + error.getClass().getSimpleName() + ": " + error.getMessage());
+            } catch (Throwable ignored) {}
             return false;
         }
     }

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -17,6 +17,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 
 /** Shell-daemon client for the protected app-process developer-view bridge. */
 final class RemoteDevViewBridgeClient {
@@ -46,24 +47,73 @@ final class RemoteDevViewBridgeClient {
             // DaemonBootstrap's package context identifies as com.overdrive.app,
             // but this app_process is uid 2000. ActivityManager rejects that
             // package/uid mismatch before it even checks the component's DUMP
-            // permission. Use a real com.android.shell package context so the
-            // Binder caller identity and attributed package agree. This also
-            // keeps the ephemeral bridge secret out of command-line arguments.
-            Context context = daemonContext.createPackageContext(
-                "com.android.shell", Context.CONTEXT_IGNORE_SECURITY);
-            if (!"com.android.shell".equals(context.getPackageName())) return false;
+            // permission. Prefer a real com.android.shell package context so
+            // the Binder caller identity and attributed package agree and the
+            // ephemeral bridge secret stays inside the Binder parcel.
             Intent intent = new Intent(RemoteDevViewBridgeService.ACTION_START);
             intent.setComponent(new ComponentName(DaemonBootstrap.getPackageName(), SERVICE_CLASS));
             intent.putExtra(RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret);
             intent.putExtra(RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY, launchActivity);
-            return context.startService(intent) != null;
-        } catch (Throwable error) {
             try {
-                CameraDaemon.log("RemoteDevView: bridge start failed: "
-                    + error.getClass().getSimpleName() + ": " + error.getMessage());
-            } catch (Throwable ignored) {}
+                Context context = daemonContext.createPackageContext(
+                    "com.android.shell", Context.CONTEXT_IGNORE_SECURITY);
+                if ("com.android.shell".equals(context.getPackageName())
+                        && context.startService(intent) != null) {
+                    return true;
+                }
+            } catch (Throwable error) {
+                logStartFailure("Binder start", error);
+            }
+
+            // Some BYD builds return the Overdrive package context from
+            // createPackageContext(com.android.shell), leaving ActivityManager
+            // to reject the package/uid mismatch. Use am as a narrow fallback.
+            // ProcessBuilder passes each value as a literal argument (no shell
+            // interpolation). The only peers able to inspect this shell-uid
+            // process are shell-equivalent principals that already hold DUMP
+            // and can start/inspect the protected service directly.
+            return startWithActivityManagerCommand(launchActivity);
+        } catch (Throwable error) {
+            logStartFailure("Bridge start", error);
             return false;
         }
+    }
+
+    private boolean startWithActivityManagerCommand(boolean launchActivity) {
+        Process process = null;
+        try {
+            process = new ProcessBuilder(
+                "/system/bin/am",
+                "startservice",
+                "-n", DaemonBootstrap.getPackageName() + "/" + SERVICE_CLASS,
+                "-a", RemoteDevViewBridgeService.ACTION_START,
+                "--es", RemoteDevViewBridgeService.EXTRA_BRIDGE_SECRET, bridgeSecret,
+                "--ez", RemoteDevViewBridgeService.EXTRA_LAUNCH_ACTIVITY,
+                Boolean.toString(launchActivity))
+                .redirectErrorStream(true)
+                .start();
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroy();
+                return false;
+            }
+            return process.exitValue() == 0;
+        } catch (Throwable error) {
+            logStartFailure("am startservice", error);
+            return false;
+        } finally {
+            if (process != null) {
+                try { process.getInputStream().close(); } catch (Exception ignored) {}
+                try { process.getOutputStream().close(); } catch (Exception ignored) {}
+                try { process.getErrorStream().close(); } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    private static void logStartFailure(String stage, Throwable error) {
+        try {
+            CameraDaemon.log("RemoteDevView: " + stage + " failed: "
+                + error.getClass().getSimpleName() + ": " + error.getMessage());
+        } catch (Throwable ignored) {}
     }
 
     Response send(JSONObject request) {

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java
@@ -2,6 +2,7 @@ package com.overdrive.app.server;
 
 import android.net.LocalSocket;
 import android.net.LocalSocketAddress;
+import android.util.Log;
 
 import com.overdrive.app.remote.RemoteDevViewBridgeService;
 
@@ -14,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 
 /** Shell-daemon client for the protected app-process developer-view bridge. */
 final class RemoteDevViewBridgeClient {
+    private static final String TAG = "RemoteDevViewClient";
     private static final int READ_TIMEOUT_MS = 9_000;
     private static final int MAX_METADATA_BYTES = 64 * 1024;
     private static final int MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
@@ -61,6 +63,7 @@ final class RemoteDevViewBridgeClient {
             if (payloadLength > 0) input.readFully(payload);
             return new Response(metadata, payload);
         } catch (Throwable error) {
+            Log.w(TAG, "App-process bridge request failed", error);
             return null;
         } finally {
             try { if (socket != null) socket.close(); } catch (Exception ignored) {}

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewSessionManager.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewSessionManager.java
@@ -1,0 +1,97 @@
+package com.overdrive.app.server;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.nio.charset.StandardCharsets;
+
+/** In-memory, single-client capability for Remote Overdrive Dev View. */
+final class RemoteDevViewSessionManager {
+    static final long IDLE_TIMEOUT_MS = 5 * 60 * 1000L;
+    static final long MAX_LIFETIME_MS = 8 * 60 * 60 * 1000L;
+
+    interface Clock { long now(); }
+    interface RandomBytes { void nextBytes(byte[] target); }
+
+    static final class Session {
+        final String token;
+        final long createdAtMs;
+        long lastUsedAtMs;
+
+        Session(String token, long now) {
+            this.token = token;
+            this.createdAtMs = now;
+            this.lastUsedAtMs = now;
+        }
+    }
+
+    private final Clock clock;
+    private final RandomBytes random;
+    private Session current;
+
+    RemoteDevViewSessionManager() {
+        SecureRandom secureRandom = new SecureRandom();
+        this.clock = System::currentTimeMillis;
+        this.random = secureRandom::nextBytes;
+    }
+
+    RemoteDevViewSessionManager(Clock clock, RandomBytes random) {
+        this.clock = clock;
+        this.random = random;
+    }
+
+    synchronized Session start() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        current = new Session(toHex(bytes), clock.now());
+        return current;
+    }
+
+    synchronized Session validateAndTouch(String candidate) {
+        Session session = current;
+        long now = clock.now();
+        if (session == null || isExpired(session, now) || !constantTimeEquals(session.token, candidate)) {
+            if (session != null && isExpired(session, now)) current = null;
+            return null;
+        }
+        session.lastUsedAtMs = now;
+        return session;
+    }
+
+    synchronized boolean end(String candidate) {
+        if (current == null || !constantTimeEquals(current.token, candidate)) return false;
+        current = null;
+        return true;
+    }
+
+    synchronized boolean hasActiveSession() {
+        if (current == null) return false;
+        if (isExpired(current, clock.now())) {
+            current = null;
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isExpired(Session session, long now) {
+        return now - session.lastUsedAtMs > IDLE_TIMEOUT_MS ||
+               now - session.createdAtMs > MAX_LIFETIME_MS;
+    }
+
+    private static boolean constantTimeEquals(String expected, String actual) {
+        if (actual == null) actual = "";
+        return MessageDigest.isEqual(
+            expected.getBytes(StandardCharsets.UTF_8),
+            actual.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String toHex(byte[] bytes) {
+        char[] alphabet = "0123456789abcdef".toCharArray();
+        char[] result = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int value = bytes[i] & 0xff;
+            result[i * 2] = alphabet[value >>> 4];
+            result[i * 2 + 1] = alphabet[value & 0x0f];
+        }
+        return new String(result);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
@@ -1,0 +1,242 @@
+package com.overdrive.app.server;
+
+import android.util.Base64;
+
+import org.json.JSONObject;
+
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Authenticated latest-frame WebSocket transport for Remote Dev View.
+ *
+ * Capture runs continuously on a daemon producer thread. A capacity-one queue
+ * means a slow tunnel can never accumulate stale UI frames: the producer
+ * replaces the queued frame with the newest completed capture. HTTP input uses
+ * a different bridge connection and is therefore no longer serialized behind
+ * this stream.
+ */
+final class RemoteDevViewWebSocketStream {
+    static final String PATH = "/ws/dev-view";
+    static final String PROTOCOL = "overdrive-dev-view";
+
+    private static final String WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    private static final int STREAM_WIDTH = 960;
+    private static final int STREAM_QUALITY = 55;
+    private static final int MAX_WS_FRAGMENT_BYTES = 32 * 1024;
+    private static final long ERROR_RETRY_MS = 120L;
+
+    private RemoteDevViewWebSocketStream() {}
+
+    /**
+     * Browser WebSockets cannot set an Authorization-style capability header.
+     * Carry the memory-only session as a second requested subprotocol instead
+     * of putting it in the URL, browser history, or proxy request logs.
+     */
+    static String sessionFromProtocols(String header) {
+        if (header == null || header.isEmpty()) return null;
+        boolean protocolPresent = false;
+        String candidate = null;
+        for (String part : header.split(",")) {
+            String value = part.trim();
+            if (PROTOCOL.equals(value)) {
+                protocolPresent = true;
+            } else if (value.matches("[0-9a-f]{64}")) {
+                candidate = value;
+            }
+        }
+        return protocolPresent ? candidate : null;
+    }
+
+    static void handle(Socket client, String websocketKey, String session) {
+        AtomicBoolean running = new AtomicBoolean(true);
+        Thread producer = null;
+        try {
+            client.setSoTimeout(0);
+            client.setTcpNoDelay(true);
+            client.setSendBufferSize(128 * 1024);
+            OutputStream out = client.getOutputStream();
+            writeHandshake(out, websocketKey);
+
+            BlockingQueue<StreamFrame> latest = new ArrayBlockingQueue<>(1);
+            AtomicLong sequence = new AtomicLong();
+            producer = new Thread(
+                () -> produceFrames(client, session, running, latest, sequence),
+                "remote-dev-frame-producer");
+            producer.setDaemon(true);
+            producer.start();
+
+            sendText(out, new JSONObject()
+                .put("type", "ready")
+                .put("transport", "websocket-latest-frame")
+                .put("width", STREAM_WIDTH)
+                .put("quality", STREAM_QUALITY)
+                .toString());
+
+            while (running.get() && !client.isClosed()) {
+                if (!RemoteDevViewApiHandler.validateStreamSession(session)) {
+                    sendClose(out, 1008, "Developer-view session expired");
+                    break;
+                }
+
+                StreamFrame frame = latest.poll(5, TimeUnit.SECONDS);
+                if (frame == null) {
+                    sendPing(out);
+                    continue;
+                }
+
+                sendText(out, frame.metadata.toString());
+                if (frame.jpeg.length > 0 && frame.metadata.optBoolean("success", false)) {
+                    sendBinary(out, frame.jpeg);
+                }
+            }
+        } catch (Exception ignored) {
+            // Disconnects are expected when a tab hides, reloads, or ends its
+            // session. The producer is stopped in finally and no frame persists.
+        } finally {
+            running.set(false);
+            if (producer != null) producer.interrupt();
+            try { client.close(); } catch (Exception ignored) {}
+        }
+    }
+
+    private static void produceFrames(
+            Socket client,
+            String session,
+            AtomicBoolean running,
+            BlockingQueue<StreamFrame> latest,
+            AtomicLong sequence) {
+        while (running.get() && !client.isClosed()
+                && RemoteDevViewApiHandler.validateStreamSession(session)) {
+            long started = System.nanoTime();
+            RemoteDevViewBridgeClient.Response response =
+                RemoteDevViewApiHandler.captureStreamFrame(STREAM_WIDTH, STREAM_QUALITY);
+            long captureMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started);
+
+            JSONObject metadata = streamMetadata(
+                response, sequence.incrementAndGet(), captureMs);
+            byte[] jpeg = response == null ? new byte[0] : response.payload;
+
+            // Capacity one: replace an unsent old frame with this newer one.
+            latest.poll();
+            latest.offer(new StreamFrame(metadata, jpeg));
+
+            if (!metadata.optBoolean("success", false)) {
+                try { Thread.sleep(ERROR_RETRY_MS); }
+                catch (InterruptedException error) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        running.set(false);
+    }
+
+    private static JSONObject streamMetadata(
+            RemoteDevViewBridgeClient.Response response, long sequence, long captureMs) {
+        JSONObject metadata = new JSONObject();
+        try {
+            if (response == null) {
+                metadata.put("success", false)
+                    .put("error", "App-process bridge is unavailable");
+            } else {
+                metadata = new JSONObject(response.metadata.toString());
+            }
+            metadata.put("type", "frame")
+                .put("sequence", sequence)
+                .put("captureMs", captureMs);
+        } catch (Exception ignored) {
+            // The fields above are fixed primitive values; JSONException is not
+            // expected, but an empty metadata object safely suppresses payload
+            // delivery if a platform implementation rejects one.
+        }
+        return metadata;
+    }
+
+    private static void writeHandshake(OutputStream out, String key) throws Exception {
+        String accept = Base64.encodeToString(
+            MessageDigest.getInstance("SHA-1").digest(
+                (key + WS_MAGIC).getBytes(StandardCharsets.UTF_8)),
+            Base64.NO_WRAP);
+        String response = "HTTP/1.1 101 Switching Protocols\r\n"
+            + "Upgrade: websocket\r\n"
+            + "Connection: Upgrade\r\n"
+            + "Sec-WebSocket-Accept: " + accept + "\r\n"
+            + "Sec-WebSocket-Protocol: " + PROTOCOL + "\r\n\r\n";
+        out.write(response.getBytes(StandardCharsets.US_ASCII));
+        out.flush();
+    }
+
+    private static void sendText(OutputStream out, String text) throws Exception {
+        byte[] data = text.getBytes(StandardCharsets.UTF_8);
+        sendFrame(out, data, 0, data.length, 0x01, true);
+        out.flush();
+    }
+
+    private static void sendBinary(OutputStream out, byte[] data) throws Exception {
+        int offset = 0;
+        boolean first = true;
+        while (offset < data.length) {
+            int count = Math.min(MAX_WS_FRAGMENT_BYTES, data.length - offset);
+            boolean last = offset + count >= data.length;
+            sendFrame(out, data, offset, count, first ? 0x02 : 0x00, last);
+            first = false;
+            offset += count;
+        }
+        out.flush();
+    }
+
+    private static void sendPing(OutputStream out) throws Exception {
+        out.write(new byte[]{(byte) 0x89, 0x00});
+        out.flush();
+    }
+
+    private static void sendClose(OutputStream out, int code, String reason) {
+        try {
+            byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
+            byte[] payload = new byte[2 + reasonBytes.length];
+            payload[0] = (byte) ((code >>> 8) & 0xff);
+            payload[1] = (byte) (code & 0xff);
+            System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length);
+            sendFrame(out, payload, 0, payload.length, 0x08, true);
+            out.flush();
+        } catch (Exception ignored) {}
+    }
+
+    private static void sendFrame(
+            OutputStream out, byte[] data, int offset, int length, int opcode, boolean fin)
+            throws Exception {
+        out.write((fin ? 0x80 : 0x00) | opcode);
+        if (length <= 125) {
+            out.write(length);
+        } else if (length <= 65_535) {
+            out.write(126);
+            out.write((length >>> 8) & 0xff);
+            out.write(length & 0xff);
+        } else {
+            out.write(127);
+            long value = length;
+            for (int shift = 56; shift >= 0; shift -= 8) {
+                out.write((int) ((value >>> shift) & 0xff));
+            }
+        }
+        out.write(data, offset, length);
+    }
+
+    private static final class StreamFrame {
+        final JSONObject metadata;
+        final byte[] jpeg;
+
+        StreamFrame(JSONObject metadata, byte[] jpeg) {
+            this.metadata = metadata;
+            this.jpeg = jpeg;
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
@@ -32,6 +32,7 @@ final class RemoteDevViewWebSocketStream {
     private static final int STREAM_QUALITY = 55;
     private static final int MAX_WS_FRAGMENT_BYTES = 32 * 1024;
     private static final long ERROR_RETRY_MS = 120L;
+    private static final long STREAM_POLL_INTERVAL_MS = 80L;
 
     private RemoteDevViewWebSocketStream() {}
 
@@ -114,6 +115,7 @@ final class RemoteDevViewWebSocketStream {
             BlockingQueue<StreamFrame> latest,
             AtomicLong sequence) {
         boolean hasSuccessfulFrame = false;
+        long lastSourceSequence = -1L;
         while (running.get() && !client.isClosed()
                 && RemoteDevViewApiHandler.validateStreamSession(session)) {
             long started = System.nanoTime();
@@ -125,18 +127,28 @@ final class RemoteDevViewWebSocketStream {
                 response, sequence.incrementAndGet(), captureMs);
             byte[] jpeg = response == null ? new byte[0] : response.payload;
             boolean successful = metadata.optBoolean("success", false) && jpeg.length > 0;
+            long sourceSequence = metadata.optLong("frameSequence", 0L);
+            boolean isNewFrame = successful
+                && (sourceSequence <= 0L || sourceSequence != lastSourceSequence);
 
-            if (successful || !hasSuccessfulFrame) {
+            if (isNewFrame || (!successful && !hasSuccessfulFrame)) {
                 // Capacity one: replace an unsent old frame with this newer
                 // one. Once a good frame exists, transient PixelCopy races do
                 // not replace it or its successful metadata with an error.
                 latest.poll();
                 latest.offer(new StreamFrame(metadata, jpeg));
             }
-            if (successful) hasSuccessfulFrame = true;
+            if (isNewFrame) {
+                hasSuccessfulFrame = true;
+                lastSourceSequence = sourceSequence;
+            }
 
-            if (!successful) {
-                try { Thread.sleep(ERROR_RETRY_MS); }
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started);
+            long delayMs = successful
+                ? Math.max(1L, STREAM_POLL_INTERVAL_MS - elapsedMs)
+                : ERROR_RETRY_MS;
+            if (delayMs > 0L) {
+                try { Thread.sleep(delayMs); }
                 catch (InterruptedException error) {
                     Thread.currentThread().interrupt();
                     break;

--- a/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
+++ b/app/src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java
@@ -113,6 +113,7 @@ final class RemoteDevViewWebSocketStream {
             AtomicBoolean running,
             BlockingQueue<StreamFrame> latest,
             AtomicLong sequence) {
+        boolean hasSuccessfulFrame = false;
         while (running.get() && !client.isClosed()
                 && RemoteDevViewApiHandler.validateStreamSession(session)) {
             long started = System.nanoTime();
@@ -123,12 +124,18 @@ final class RemoteDevViewWebSocketStream {
             JSONObject metadata = streamMetadata(
                 response, sequence.incrementAndGet(), captureMs);
             byte[] jpeg = response == null ? new byte[0] : response.payload;
+            boolean successful = metadata.optBoolean("success", false) && jpeg.length > 0;
 
-            // Capacity one: replace an unsent old frame with this newer one.
-            latest.poll();
-            latest.offer(new StreamFrame(metadata, jpeg));
+            if (successful || !hasSuccessfulFrame) {
+                // Capacity one: replace an unsent old frame with this newer
+                // one. Once a good frame exists, transient PixelCopy races do
+                // not replace it or its successful metadata with an error.
+                latest.poll();
+                latest.offer(new StreamFrame(metadata, jpeg));
+            }
+            if (successful) hasSuccessfulFrame = true;
 
-            if (!metadata.optBoolean("success", false)) {
+            if (!successful) {
                 try { Thread.sleep(ERROR_RETRY_MS); }
                 catch (InterruptedException error) {
                     Thread.currentThread().interrupt();

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -52,7 +52,7 @@ import com.overdrive.app.util.BydDataCacheWhitelist
  * `invoke*Action` thin wrappers that the new SettingsFragment / Diagnostics
  * fragment call.
  */
-class MainActivity : AppCompatActivity() {
+open class MainActivity : AppCompatActivity() {
 
     private lateinit var navController: NavController
     private lateinit var appBarConfiguration: AppBarConfiguration
@@ -87,6 +87,7 @@ class MainActivity : AppCompatActivity() {
     // explicitly setIntent — without this latch the stale boot intent
     // would permanently bypass the PIN gate after a launcher tap.
     private var headlessBootSilenceGate: Boolean = false
+    private var remoteDevSession: Boolean = false
 
     // UI elements
     private lateinit var toolbar: MaterialToolbar
@@ -106,6 +107,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        remoteDevSession = this is RemoteMainActivity &&
+            intent?.getBooleanExtra(EXTRA_REMOTE_DEV_SESSION, false) == true
+
         // The main app must run on the HEAD UNIT (display 0), never the driver
         // cluster. When the OEM cluster projection opens a secondary display, AMS
         // auto-launches the LAUNCHER activity (this one) onto it. If we land on a
@@ -116,7 +120,7 @@ class MainActivity : AppCompatActivity() {
         // and bailing here this early means the startup work hasn't begun yet.)
         try {
             val did = display?.displayId ?: android.view.Display.DEFAULT_DISPLAY
-            if (did != android.view.Display.DEFAULT_DISPLAY) {
+            if (did != android.view.Display.DEFAULT_DISPLAY && !remoteDevSession) {
                 android.util.Log.w("MainActivity", "launched on display $did — relaunching on display 0")
                 val opts = android.app.ActivityOptions.makeBasic().apply {
                     launchDisplayId = android.view.Display.DEFAULT_DISPLAY
@@ -131,6 +135,11 @@ class MainActivity : AppCompatActivity() {
                 finish()
                 return
             }
+            if (did == android.view.Display.DEFAULT_DISPLAY && remoteDevSession) {
+                android.util.Log.w("MainActivity", "refusing RemoteMainActivity on display 0")
+                finish()
+                return
+            }
         } catch (_: Throwable) { /* best effort; fall through to a normal start */ }
 
         setContentView(R.layout.activity_main_new)
@@ -138,7 +147,7 @@ class MainActivity : AppCompatActivity() {
         // Storage setup is posted off the onCreate critical path so a failure
         // (e.g. ROM lacking the All-Files-Access Settings activity on BYD SL7)
         // cannot abort activity launch. See setupStorageDirectories().
-        window.decorView.post {
+        if (!remoteDevSession) window.decorView.post {
             try {
                 setupStorageDirectories()
             } catch (e: Exception) {
@@ -147,24 +156,26 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Initialize DeviceIdGenerator with ADB executor for file sync
-        val adbExecutor = com.overdrive.app.launcher.AdbShellExecutor(this)
-        com.overdrive.app.util.DeviceIdGenerator.init(adbExecutor)
+        if (!remoteDevSession) {
+            val adbExecutor = com.overdrive.app.launcher.AdbShellExecutor(this)
+            com.overdrive.app.util.DeviceIdGenerator.init(adbExecutor)
         
         // Generate device ID early - this syncs to file for daemon compatibility
         // Must happen BEFORE any daemon starts
-        val deviceId = com.overdrive.app.util.DeviceIdGenerator.generateDeviceId(this)
-        android.util.Log.i("MainActivity", "Device ID initialized: $deviceId")
+            val deviceId = com.overdrive.app.util.DeviceIdGenerator.generateDeviceId(this)
+            android.util.Log.i("MainActivity", "Device ID initialized: $deviceId")
         
         // Apply BYD whitelist (ACC + data cache) to prevent background killing
         // CRITICAL: Run on background thread to avoid blocking UI on boot
         // ActivityThread.systemMain() can block for 1+ minute waiting for system services
-        Thread {
-            try {
-                BydDataCacheWhitelist.applyAll(this)
-            } catch (e: Exception) {
-                android.util.Log.e("MainActivity", "BYD whitelist error: ${e.message}")
-            }
-        }.start()
+            Thread {
+                try {
+                    BydDataCacheWhitelist.applyAll(this)
+                } catch (e: Exception) {
+                    android.util.Log.e("MainActivity", "BYD whitelist error: ${e.message}")
+                }
+            }.start()
+        }
         
         // Register the screen-off receiver that locks the PIN session as
         // soon as the panel sleeps. Idempotent — safe to call again on
@@ -197,7 +208,7 @@ class MainActivity : AppCompatActivity() {
         setupNavigation(savedInstanceState)
         handleNavigateExtra(intent)
         setupCopyButton()
-        setupLogListener()
+        if (!remoteDevSession) setupLogListener()
         observeViewModels()
         
         // Initialize daemon startup manager
@@ -205,14 +216,14 @@ class MainActivity : AppCompatActivity() {
         daemonsViewModel.setStartupManager(daemonStartupManager)
         
         // Setup ADB auth callback to re-initialize when auth is granted
-        setupAdbAuthCallback()
+        if (!remoteDevSession) setupAdbAuthCallback()
         
         // Log app start
         logsViewModel.info("App", "OverDrive started")
 
         // Seed out-of-process revival watchdog so the process gets resurrected
         // if it ever gets force-stopped or OOM-killed without an external event.
-        try {
+        if (!remoteDevSession) try {
             com.overdrive.app.receiver.ProcessRevivalReceiver.schedule(applicationContext)
         } catch (e: Exception) {
             android.util.Log.w("MainActivity", "ProcessRevivalReceiver.schedule failed: ${e.message}")
@@ -226,23 +237,23 @@ class MainActivity : AppCompatActivity() {
         // The daemon will reload from file when getState() is called
         
         // Start Location Sidecar service (establishes ADB connection)
-        startLocationSidecarService()
+        if (!remoteDevSession) startLocationSidecarService()
         
         // Initialize daemons after a short delay to allow ADB connection.
         // If this is a post-update launch, run UpdateLifecycle.hardResetDaemons
         // FIRST so any zombie daemons / watchdogs from the previous install are
         // dead before the new daemon launcher starts. See UpdateLifecycle for
         // the sentinel handshake details.
-        runDaemonStartup(intent, fromOnCreate = true)
+        if (!remoteDevSession) runDaemonStartup(intent, fromOnCreate = true)
         
         // Handle Location start intent (from SentryDaemon restart)
-        handleLocationStartIntent(intent)
+        if (!remoteDevSession) handleLocationStartIntent(intent)
         
         // Check traffic monitor status early so drawer shows correct state
         checkTrafficMonitorStatus()
         
         // Check for app updates (delayed to not block startup)
-        android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+        if (!remoteDevSession) android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
             // Clean up any leftover update APK from previous install. Use the
             // shared daemonStartupManager.adbLauncher — allocating a fresh
             // AdbDaemonLauncher here would leak its non-daemon executor + a
@@ -294,15 +305,15 @@ class MainActivity : AppCompatActivity() {
         }, 10000) // 10 seconds after launch
         
         // Schedule periodic update checks (every 6 hours)
-        schedulePeriodicUpdateCheck()
+        if (!remoteDevSession) schedulePeriodicUpdateCheck()
         
         // Status overlay: start immediately if permission granted, show guide if not
-        startStatusOverlay()
+        if (!remoteDevSession) startStatusOverlay()
         
         // If launched from boot receiver with minimize flag, move to back immediately.
         // This keeps the process alive (important for daemon stability) without
         // showing the app UI over the BYD home screen.
-        if (headlessBootSilenceGate) {
+        if (!remoteDevSession && headlessBootSilenceGate) {
             android.util.Log.i("MainActivity", "Boot launch — minimizing to background")
             moveTaskToBack(true)
             // NB: do NOT clear headlessBootSilenceGate here. This block runs
@@ -388,7 +399,7 @@ class MainActivity : AppCompatActivity() {
         // covered without relying on onResume firing first.
         maybeShowPinLock()
         intent?.let {
-            handleLocationStartIntent(it)
+            if (!remoteDevSession) handleLocationStartIntent(it)
             handleNavigateExtra(it)
             // Critical: when MainActivity is already running and the install
             // script's `am start --ez post_update true` re-delivers the
@@ -399,7 +410,7 @@ class MainActivity : AppCompatActivity() {
             // by daemonStartupRequested + by the sentinel/intent-extra
             // checks inside isPostUpdateLaunch — once the sentinels are
             // consumed, subsequent calls become no-ops).
-            runDaemonStartup(it, fromOnCreate = false)
+            if (!remoteDevSession) runDaemonStartup(it, fromOnCreate = false)
         }
     }
 
@@ -660,12 +671,12 @@ class MainActivity : AppCompatActivity() {
         maybeShowPinLock()
 
         // Try to start overlay if permission was just granted (user returned from settings)
-        com.overdrive.app.overlay.StatusOverlayService.startIfPermitted(this)
+        if (!remoteDevSession) com.overdrive.app.overlay.StatusOverlayService.startIfPermitted(this)
 
         // Re-sync the RoadSense overlay on resume: the user may have just toggled
         // RoadSense on/off in the web UI and returned to the app, or granted the
         // overlay permission. Cheap — a no-op if the state already matches.
-        syncRoadSenseOverlay()
+        if (!remoteDevSession) syncRoadSenseOverlay()
 
         // Daemon-ready flush of any pending onboarding operating-mode choice. The
         // auth-granted callback fires BEFORE the user reaches the MODE step (and only
@@ -674,7 +685,9 @@ class MainActivity : AppCompatActivity() {
         // any non-first launch. Idempotent + no-op when nothing is pending, and it
         // reconciles against the live config so it never clobbers a later Settings
         // change (see flushPendingOperatingMode).
-        com.overdrive.app.onboarding.OnboardingHost.flushPendingOperatingMode(applicationContext)
+        if (!remoteDevSession) {
+            com.overdrive.app.onboarding.OnboardingHost.flushPendingOperatingMode(applicationContext)
+        }
 
         // Re-drive a rail tap that was deferred because it raced Activity state saving. Now
         // resumed, FragmentManager can commit. navigateToRailDestination re-checks isStateSaved
@@ -729,7 +742,7 @@ class MainActivity : AppCompatActivity() {
             headlessBootSilenceGate = false
             android.util.Log.i("MainActivity", "Boot-silence latch consumed on first onPause")
         }
-        com.overdrive.app.auth.PinSession.notePaused()
+        if (!remoteDevSession) com.overdrive.app.auth.PinSession.notePaused()
     }
 
     /**
@@ -3685,7 +3698,7 @@ class MainActivity : AppCompatActivity() {
             navigationRailScroll.onRailSwipe = null
         }
         // Remove log listener
-        LogManager.setLogListener(null)
+        if (!remoteDevSession) LogManager.setLogListener(null)
         // Tear down the onboarding overlay + its ACC receiver (mirrors the auth-callback
         // teardown below — any guard cleared only in a callback needs a destroy path).
         onboardingHost?.dismiss()
@@ -3694,7 +3707,7 @@ class MainActivity : AppCompatActivity() {
         navPollRunnable?.let { mainHandler.removeCallbacks(it) }
         navPollRunnable = null
         // Remove ADB auth callback
-        com.overdrive.app.launcher.AdbShellExecutor.setAuthCallback(null)
+        if (!remoteDevSession) com.overdrive.app.launcher.AdbShellExecutor.setAuthCallback(null)
         // Cancel the periodic update check so the Runnable doesn't leak the
         // activity reference after recreate.
         updateCheckRunnable?.let { mainHandler.removeCallbacks(it) }
@@ -3939,5 +3952,6 @@ class MainActivity : AppCompatActivity() {
     companion object {
         /** Deep-link extra consumed by [handleNavigateExtra] (launcher glance widgets). */
         const val EXTRA_NAVIGATE_TO = "navigate_to"
+        const val EXTRA_REMOTE_DEV_SESSION = "remote_dev_session"
     }
 }

--- a/app/src/main/java/com/overdrive/app/ui/RemoteMainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/RemoteMainActivity.kt
@@ -1,0 +1,11 @@
+package com.overdrive.app.ui
+
+/**
+ * A distinct component for the private Remote Dev View display.
+ *
+ * The implementation intentionally inherits the real MainActivity so the
+ * remote session exercises the same fragments, WebViews, dialogs, and input
+ * handlers. Its separate manifest task affinity lets Android keep it on the
+ * app-owned virtual display without moving or replacing the physical task.
+ */
+class RemoteMainActivity : MainActivity()

--- a/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
@@ -23,6 +23,8 @@ public class RemoteDevVirtualDisplayAssetTest {
         assertTrue(host.contains("ImageReader.newInstance("));
         assertTrue(host.contains("LOGICAL_WIDTH = 1920"));
         assertTrue(host.contains("STREAM_WIDTH = 960"));
+        assertTrue(host.contains("ImageReader.newInstance(\n            LOGICAL_WIDTH,\n            LOGICAL_HEIGHT"));
+        assertTrue(host.contains("Rect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT)"));
         assertTrue(host.contains("STREAM_FRAME_INTERVAL_MS = 100L"));
         assertTrue(host.contains("RemoteMainActivity::class.java"));
         assertFalse(host.contains("MediaProjection"));

--- a/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
@@ -1,0 +1,78 @@
+package com.overdrive.app.remote;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RemoteDevVirtualDisplayAssetTest {
+
+    @Test
+    public void liveStreamUsesAPrivatePacedVirtualDisplayInsteadOfPixelCopy() throws Exception {
+        String host = read("src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt");
+        String controller = read("src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt");
+        String stream = read("src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java");
+
+        assertTrue(host.contains("createVirtualDisplay("));
+        assertTrue(host.contains("VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY"));
+        assertTrue(host.contains("ImageReader.newInstance("));
+        assertTrue(host.contains("LOGICAL_WIDTH = 1920"));
+        assertTrue(host.contains("STREAM_WIDTH = 960"));
+        assertTrue(host.contains("STREAM_FRAME_INTERVAL_MS = 100L"));
+        assertTrue(host.contains("RemoteMainActivity::class.java"));
+        assertFalse(host.contains("MediaProjection"));
+        assertFalse(host.contains("captureLayers"));
+        assertTrue(controller.contains("RemoteDevVirtualDisplay.latestFrame()"));
+        assertTrue(controller.contains("if (!format.equals(\"png\""));
+        assertTrue(stream.contains("STREAM_POLL_INTERVAL_MS = 80L"));
+        assertTrue(stream.contains("sourceSequence != lastSourceSequence"));
+    }
+
+    @Test
+    public void remoteActivityIsIsolatedFromPhysicalStartupAndExplicitlyTornDown() throws Exception {
+        String manifest = read("src/main/AndroidManifest.xml");
+        String main = read("src/main/java/com/overdrive/app/ui/MainActivity.kt");
+        String bridge = read("src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt");
+        String client = read("src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java");
+        String api = read("src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java");
+
+        assertTrue(manifest.contains("com.overdrive.app.ui.RemoteMainActivity"));
+        assertTrue(manifest.contains("android:exported=\"false\""));
+        assertTrue(manifest.contains("android:taskAffinity=\"com.overdrive.app.remote_dev\""));
+        assertTrue(main.contains("this is RemoteMainActivity"));
+        assertTrue(main.contains("if (!remoteDevSession) runDaemonStartup"));
+        assertTrue(main.contains("if (!remoteDevSession) startStatusOverlay"));
+        assertTrue(bridge.contains("\"stop\" ->"));
+        assertTrue(bridge.contains("RemoteDevVirtualDisplay.stop()"));
+        assertTrue(client.contains("new JSONObject().put(\"command\", \"stop\")"));
+        assertTrue(api.contains("remote-dev-session-reaper"));
+        assertTrue(api.contains("!SESSIONS.hasActiveSession()"));
+    }
+
+    @Test
+    public void transientBlackFramesAreHeldUnlessTheRemoteWindowIsSecure() throws Exception {
+        String host = read("src/main/java/com/overdrive/app/remote/RemoteDevVirtualDisplay.kt");
+        String controller = read("src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt");
+
+        assertTrue(host.contains("isNearlyBlack(output)"));
+        assertTrue(host.contains("latestFrame.get() != null"));
+        assertTrue(host.contains("!RemoteDevViewController.isRemoteWindowSecure()"));
+        assertTrue(controller.contains("WindowManager.LayoutParams.FLAG_SECURE"));
+        assertTrue(controller.contains("rootDisplayId == activityDisplayId"));
+    }
+
+    private static String read(String moduleRelativePath) throws Exception {
+        Path current = Paths.get("").toAbsolutePath();
+        Path fromModule = current.resolve(moduleRelativePath);
+        if (Files.exists(fromModule)) {
+            return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+        }
+        Path fromRepository = current.resolve("app").resolve(moduleRelativePath);
+        return new String(Files.readAllBytes(fromRepository), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/remote/RemoteDevVirtualDisplayAssetTest.java
@@ -72,9 +72,13 @@ public class RemoteDevVirtualDisplayAssetTest {
         Path current = Paths.get("").toAbsolutePath();
         Path fromModule = current.resolve(moduleRelativePath);
         if (Files.exists(fromModule)) {
-            return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            return normalizeNewlines(Files.readAllBytes(fromModule));
         }
         Path fromRepository = current.resolve("app").resolve(moduleRelativePath);
-        return new String(Files.readAllBytes(fromRepository), StandardCharsets.UTF_8);
+        return normalizeNewlines(Files.readAllBytes(fromRepository));
+    }
+
+    private static String normalizeNewlines(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8).replace("\r\n", "\n");
     }
 }

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -37,7 +37,10 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("body: JSON.stringify({ session: token"));
         assertFalse(script.contains("/api/dev-view/frame?"));
         assertFalse(script.contains("localStorage.setItem"));
-        assertTrue(html.contains("remote-dev-view.js?v=3"));
+        assertTrue(script.contains("maxWidth: 960, quality: 55"));
+        assertTrue(script.contains("consecutiveFrameFailures >= 3"));
+        assertTrue(script.contains(": 60"));
+        assertTrue(html.contains("remote-dev-view.js?v=4"));
     }
 
     @Test
@@ -63,6 +66,9 @@ public class RemoteDevViewAssetTest {
         assertTrue(controller.contains("if (isRemoteTarget(activity))"));
         assertTrue(controller.contains("activityOwnedRoots(activity)"));
         assertTrue(controller.contains("owner == null || owner === activity"));
+        assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 2"));
+        assertTrue(controller.contains("catch (error: IllegalArgumentException)"));
+        assertTrue(controller.contains("getDeclaredMethod(\"getWindowViews\")"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -36,20 +36,25 @@ public class RemoteDevViewAssetTest {
     }
 
     @Test
-    public void bridgeIsPrivateAndAuthenticatesKernelPeerUid() throws Exception {
+    public void bridgeIsPrivateLoopbackAuthenticatedAndReplayBounded() throws Exception {
         String manifest = read("src/main/AndroidManifest.xml");
         String service = read(
             "src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt");
+        String auth = read(
+            "src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeAuth.java");
 
         assertTrue(manifest.contains("com.overdrive.app.remote.RemoteDevViewBridgeService"));
-        assertTrue(service.contains("LocalServerSocket(SOCKET_NAME)"));
-        assertTrue(service.contains("client.peerCredentials.uid"));
-        assertTrue(service.contains("peerUid != SHELL_UID"));
+        assertTrue(manifest.contains("android:exported=\"false\""));
+        assertTrue(service.contains("InetAddress.getLoopbackAddress()"));
+        assertTrue(service.contains("rememberNonce(authenticated.nonce"));
+        assertTrue(auth.contains("HmacSHA256"));
+        assertTrue(auth.contains("MessageDigest.isEqual"));
+        assertTrue(auth.contains("MAX_CLOCK_SKEW_MS"));
 
         String client = read(
             "src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java");
-        assertTrue(client.contains("new LocalSocket()"));
-        assertTrue(client.contains("LocalSocketAddress.Namespace.ABSTRACT"));
+        assertTrue(client.contains("InetAddress.getLoopbackAddress()"));
+        assertTrue(client.contains("RemoteDevViewBridgeAuth.sign(request)"));
         assertFalse(client.contains("Runtime.getRuntime().exec"));
         assertFalse(client.contains("new ProcessBuilder("));
     }

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -45,6 +45,12 @@ public class RemoteDevViewAssetTest {
         assertTrue(manifest.contains("android:permission=\"android.permission.DUMP\""));
         assertTrue(service.contains("const val HOST = \"127.0.0.1\""));
         assertTrue(service.contains("MessageDigest.isEqual"));
+
+        String client = read(
+            "src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java");
+        assertTrue(client.contains("createPackageContext("));
+        assertTrue(client.contains("\"com.android.shell\""));
+        assertFalse(client.contains("Runtime.getRuntime().exec"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -46,6 +46,7 @@ public class RemoteDevViewAssetTest {
         assertTrue(manifest.contains("com.overdrive.app.remote.RemoteDevViewBridgeService"));
         assertTrue(manifest.contains("android:exported=\"false\""));
         assertTrue(service.contains("InetAddress.getLoopbackAddress()"));
+        assertTrue(service.contains("const val PORT = 19881"));
         assertTrue(service.contains("rememberNonce(authenticated.nonce"));
         assertTrue(auth.contains("HmacSHA256"));
         assertTrue(auth.contains("MessageDigest.isEqual"));

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -13,13 +13,14 @@ import java.nio.file.Paths;
 public class RemoteDevViewAssetTest {
 
     @Test
-    public void pageRequiresExplicitConfirmationAndWarnsAboutRealInput() throws Exception {
+    public void pageRequiresCompactExplicitConfirmationForRealInput() throws Exception {
         String html = read("src/main/assets/web/local/remote-dev-view.html");
 
         assertTrue(html.contains("id=\"confirmStart\""));
-        assertTrue(html.contains("remote input operates the live Overdrive app"));
-        assertTrue(html.contains("physical head-unit display is not turned on or uncovered"));
+        assertTrue(html.contains("Remote input operates the real Overdrive app"));
+        assertTrue(html.contains("Use only while parked"));
         assertTrue(html.contains("id=\"startButton\" class=\"dev-button primary\" disabled"));
+        assertFalse(html.contains("warning-card"));
     }
 
     @Test
@@ -36,7 +37,32 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("body: JSON.stringify({ session: token"));
         assertFalse(script.contains("/api/dev-view/frame?"));
         assertFalse(script.contains("localStorage.setItem"));
-        assertTrue(html.contains("remote-dev-view.js?v=2"));
+        assertTrue(html.contains("remote-dev-view.js?v=3"));
+    }
+
+    @Test
+    public void viewerOffersFullscreenWithAnInFrameEscapePath() throws Exception {
+        String html = read("src/main/assets/web/local/remote-dev-view.html");
+        String script = read("src/main/assets/web/shared/remote-dev-view.js");
+
+        assertTrue(html.contains("id=\"viewerCard\""));
+        assertTrue(html.contains("id=\"fullscreenButton\""));
+        assertTrue(html.contains("id=\"fullscreenExitButton\""));
+        assertTrue(script.contains("viewerCard.requestFullscreen"));
+        assertTrue(script.contains("webkitRequestFullscreen"));
+        assertTrue(script.contains("dev-view-focus"));
+        assertTrue(script.contains("fullscreenStopButton"));
+    }
+
+    @Test
+    public void deterrentActivityCannotReplaceOrConsumeTheRemoteTarget() throws Exception {
+        String controller = read(
+            "src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt");
+
+        assertTrue(controller.contains("activity !is DeterrentActivity"));
+        assertTrue(controller.contains("if (isRemoteTarget(activity))"));
+        assertTrue(controller.contains("activityOwnedRoots(activity)"));
+        assertTrue(controller.contains("owner == null || owner === activity"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -46,7 +46,7 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("maxWidth: 960, quality: 55"));
         assertTrue(script.contains("Waiting for a stable app frame"));
         assertTrue(script.contains(": 60"));
-        assertTrue(html.contains("remote-dev-view.js?v=7"));
+        assertTrue(html.contains("remote-dev-view.js?v=8"));
     }
 
     @Test
@@ -95,6 +95,25 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("fullscreenStopButton"));
         assertTrue(html.contains("object-fit: contain"));
         assertTrue(script.contains("frameContentRect()"));
+    }
+
+    @Test
+    public void viewerUsesBrowserKeyboardWithoutTheInputToolsSidebar() throws Exception {
+        String html = read("src/main/assets/web/local/remote-dev-view.html");
+        String script = read("src/main/assets/web/shared/remote-dev-view.js");
+
+        assertFalse(html.contains("<h2>Input tools</h2>"));
+        assertFalse(html.contains("class=\"dev-button key-button"));
+        assertFalse(html.contains("id=\"textInput\""));
+        assertTrue(html.contains("id=\"keyboardButton\""));
+        assertTrue(html.contains("id=\"fullscreenKeyboardButton\""));
+        assertTrue(html.contains("id=\"keyboardCapture\""));
+        assertTrue(script.contains("case 'Escape': return 'back'"));
+        assertTrue(script.contains("case 'Backspace': return 'delete'"));
+        assertTrue(script.contains("case 'ArrowUp': return 'dpad_up'"));
+        assertTrue(script.contains("queueKeyboardText(event.key)"));
+        assertTrue(script.contains("keyboardCapture.addEventListener('compositionend'"));
+        assertTrue(script.contains("viewerCard.focus({ preventScroll: true })"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -99,6 +99,8 @@ public class RemoteDevViewAssetTest {
         assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 2"));
         assertTrue(controller.contains("catch (error: IllegalArgumentException)"));
         assertTrue(controller.contains("getDeclaredMethod(\"getWindowViews\")"));
+        assertTrue(controller.contains("captureLock = ReentrantLock(true)"));
+        assertFalse(controller.contains("@Synchronized\n    fun capture"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -45,8 +45,8 @@ public class RemoteDevViewAssetTest {
         assertFalse(script.contains("localStorage.setItem"));
         assertTrue(script.contains("maxWidth: 960, quality: 55"));
         assertTrue(script.contains("Waiting for a stable app frame"));
-        assertTrue(script.contains(": 60"));
-        assertTrue(html.contains("remote-dev-view.js?v=8"));
+        assertTrue(script.contains(": 100"));
+        assertTrue(html.contains("remote-dev-view.js?v=9"));
     }
 
     @Test
@@ -67,7 +67,8 @@ public class RemoteDevViewAssetTest {
         assertFalse(script.contains("data.pixelCopyResult || 'Capture failed'"));
         assertTrue(stream.contains("new ArrayBlockingQueue<>(1)"));
         assertTrue(stream.contains("latest.poll()"));
-        assertTrue(stream.contains("successful || !hasSuccessfulFrame"));
+        assertTrue(stream.contains("isNewFrame || (!successful && !hasSuccessfulFrame)"));
+        assertTrue(stream.contains("sourceSequence != lastSourceSequence"));
         assertTrue(server.contains("RemoteDevViewWebSocketStream"));
         assertTrue(server.contains(".sessionFromProtocols(websocketProtocolHeader)"));
         assertTrue(server.contains("requestLine.startsWith(\"GET /ws\")"));
@@ -100,6 +101,9 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("dev-view-focus"));
         assertTrue(script.contains("fullscreenStopButton"));
         assertTrue(html.contains("object-fit: contain"));
+        assertTrue(html.contains("<canvas id=\"remoteFrame\" width=\"960\" height=\"540\""));
+        assertTrue(script.contains("frameContext.drawImage"));
+        assertFalse(script.contains("image.src = nextUrl"));
         assertTrue(script.contains("frameContentRect()"));
     }
 
@@ -145,7 +149,8 @@ public class RemoteDevViewAssetTest {
         String controller = read(
             "src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt");
 
-        assertTrue(controller.contains("activity !is DeterrentActivity"));
+        assertTrue(controller.contains("activity is DeterrentActivity"));
+        assertTrue(controller.contains("rootDisplayId == activityDisplayId"));
         assertTrue(controller.contains("if (isRemoteTarget(activity))"));
         assertTrue(controller.contains("activityOwnedRoots(activity)"));
         assertTrue(controller.contains("owner == null || owner === activity"));

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -15,14 +15,18 @@ import java.nio.file.Paths;
 public class RemoteDevViewAssetTest {
 
     @Test
-    public void pageRequiresCompactExplicitConfirmationForRealInput() throws Exception {
+    public void pageUsesOneClickStartWithACompactParkedUseNotice() throws Exception {
         String html = read("src/main/assets/web/local/remote-dev-view.html");
 
-        assertTrue(html.contains("id=\"confirmStart\""));
-        assertTrue(html.contains("Remote input operates the real Overdrive app"));
+        assertFalse(html.contains("id=\"confirmStart\""));
+        assertTrue(html.contains("Controls the real Overdrive app"));
         assertTrue(html.contains("Use only while parked"));
-        assertTrue(html.contains("id=\"startButton\" class=\"dev-button primary\" disabled"));
+        assertTrue(html.contains("id=\"startButton\" class=\"dev-button primary\""));
+        assertFalse(html.contains("id=\"startButton\" class=\"dev-button primary\" disabled"));
         assertFalse(html.contains("warning-card"));
+        assertTrue(html.contains(".dev-view-page { width: 100%"));
+        assertTrue(html.contains("#message { position: absolute"));
+        assertTrue(html.contains("#message:empty { visibility: hidden"));
     }
 
     @Test
@@ -40,9 +44,9 @@ public class RemoteDevViewAssetTest {
         assertFalse(script.contains("/api/dev-view/frame?"));
         assertFalse(script.contains("localStorage.setItem"));
         assertTrue(script.contains("maxWidth: 960, quality: 55"));
-        assertTrue(script.contains("consecutiveFrameFailures >= 3"));
+        assertTrue(script.contains("Waiting for a stable app frame"));
         assertTrue(script.contains(": 60"));
-        assertTrue(html.contains("remote-dev-view.js?v=5"));
+        assertTrue(html.contains("remote-dev-view.js?v=6"));
     }
 
     @Test
@@ -58,6 +62,8 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("['overdrive-dev-view', token]"));
         assertFalse(script.contains("session=' + encodeURIComponent"));
         assertTrue(script.contains("pendingFrameBlob = blob"));
+        assertTrue(script.contains("holding last frame"));
+        assertFalse(script.contains("data.pixelCopyResult || 'Capture failed'"));
         assertTrue(stream.contains("new ArrayBlockingQueue<>(1)"));
         assertTrue(stream.contains("latest.poll()"));
         assertTrue(server.contains("RemoteDevViewWebSocketStream"));
@@ -85,6 +91,26 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("webkitRequestFullscreen"));
         assertTrue(script.contains("dev-view-focus"));
         assertTrue(script.contains("fullscreenStopButton"));
+        assertTrue(html.contains("object-fit: contain"));
+        assertTrue(script.contains("frameContentRect()"));
+    }
+
+    @Test
+    public void screenshotUsesAFullResolutionLosslessNoStoreCapture() throws Exception {
+        String html = read("src/main/assets/web/local/remote-dev-view.html");
+        String script = read("src/main/assets/web/shared/remote-dev-view.js");
+        String api = read("src/main/java/com/overdrive/app/server/RemoteDevViewApiHandler.java");
+        String controller = read(
+            "src/main/java/com/overdrive/app/remote/RemoteDevViewController.kt");
+
+        assertTrue(html.contains("id=\"screenshotButton\""));
+        assertTrue(html.contains("id=\"fullscreenScreenshotButton\""));
+        assertTrue(script.contains("maxWidth: 1920"));
+        assertTrue(script.contains("format: 'png'"));
+        assertTrue(script.contains("cache: 'no-store'"));
+        assertTrue(script.contains(".png'"));
+        assertTrue(api.contains("request.optString(\"format\", \"jpeg\")"));
+        assertTrue(controller.contains("Bitmap.CompressFormat.PNG"));
     }
 
     @Test
@@ -96,7 +122,7 @@ public class RemoteDevViewAssetTest {
         assertTrue(controller.contains("if (isRemoteTarget(activity))"));
         assertTrue(controller.contains("activityOwnedRoots(activity)"));
         assertTrue(controller.contains("owner == null || owner === activity"));
-        assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 2"));
+        assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 4"));
         assertTrue(controller.contains("catch (error: IllegalArgumentException)"));
         assertTrue(controller.contains("getDeclaredMethod(\"getWindowViews\")"));
         assertTrue(controller.contains("captureLock = ReentrantLock(true)"));

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -87,6 +87,12 @@ public class RemoteDevViewAssetTest {
         String script = read("src/main/assets/web/shared/remote-dev-view.js");
 
         assertTrue(html.contains("id=\"viewerCard\""));
+        assertTrue(html.contains("class=\"head-unit-bezel\""));
+        assertTrue(html.contains(".head-unit-bezel::before"));
+        assertTrue(html.contains(".head-unit-bezel::after"));
+        assertTrue(html.contains("#viewerCard:fullscreen .head-unit-bezel"));
+        assertTrue(html.contains("body.dev-view-focus #viewerCard .head-unit-bezel"));
+        assertTrue(html.contains(".head-unit-bezel::after { display: none; }"));
         assertTrue(html.contains("id=\"fullscreenButton\""));
         assertTrue(html.contains("id=\"fullscreenExitButton\""));
         assertTrue(script.contains("viewerCard.requestFullscreen"));

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -36,23 +36,22 @@ public class RemoteDevViewAssetTest {
     }
 
     @Test
-    public void bridgeIsShellProtectedAndLoopbackOnly() throws Exception {
+    public void bridgeIsPrivateAndAuthenticatesKernelPeerUid() throws Exception {
         String manifest = read("src/main/AndroidManifest.xml");
         String service = read(
             "src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt");
 
         assertTrue(manifest.contains("com.overdrive.app.remote.RemoteDevViewBridgeService"));
-        assertTrue(manifest.contains("android:permission=\"android.permission.DUMP\""));
-        assertTrue(service.contains("const val HOST = \"127.0.0.1\""));
-        assertTrue(service.contains("MessageDigest.isEqual"));
+        assertTrue(service.contains("LocalServerSocket(SOCKET_NAME)"));
+        assertTrue(service.contains("client.peerCredentials.uid"));
+        assertTrue(service.contains("peerUid != SHELL_UID"));
 
         String client = read(
             "src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java");
-        assertTrue(client.contains("createPackageContext("));
-        assertTrue(client.contains("\"com.android.shell\""));
-        assertTrue(client.contains("new ProcessBuilder("));
-        assertTrue(client.contains("\"/system/bin/am\""));
+        assertTrue(client.contains("new LocalSocket()"));
+        assertTrue(client.contains("LocalSocketAddress.Namespace.ABSTRACT"));
         assertFalse(client.contains("Runtime.getRuntime().exec"));
+        assertFalse(client.contains("new ProcessBuilder("));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -62,10 +62,12 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("['overdrive-dev-view', token]"));
         assertFalse(script.contains("session=' + encodeURIComponent"));
         assertTrue(script.contains("pendingFrameBlob = blob"));
-        assertTrue(script.contains("holding last frame"));
+        assertTrue(script.contains("if (!data.success)"));
+        assertTrue(script.contains("if (!currentObjectUrl)"));
         assertFalse(script.contains("data.pixelCopyResult || 'Capture failed'"));
         assertTrue(stream.contains("new ArrayBlockingQueue<>(1)"));
         assertTrue(stream.contains("latest.poll()"));
+        assertTrue(stream.contains("successful || !hasSuccessfulFrame"));
         assertTrue(server.contains("RemoteDevViewWebSocketStream"));
         assertTrue(server.contains(".sessionFromProtocols(websocketProtocolHeader)"));
         assertTrue(server.contains("requestLine.startsWith(\"GET /ws\")"));
@@ -122,7 +124,8 @@ public class RemoteDevViewAssetTest {
         assertTrue(controller.contains("if (isRemoteTarget(activity))"));
         assertTrue(controller.contains("activityOwnedRoots(activity)"));
         assertTrue(controller.contains("owner == null || owner === activity"));
-        assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 4"));
+        assertTrue(controller.contains("PIXEL_COPY_RETRY_COUNT = 8"));
+        assertTrue(controller.contains("PIXEL_COPY_RETRY_DELAY_MS = 60L"));
         assertTrue(controller.contains("catch (error: IllegalArgumentException)"));
         assertTrue(controller.contains("getDeclaredMethod(\"getWindowViews\")"));
         assertTrue(controller.contains("captureLock = ReentrantLock(true)"));

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -46,7 +46,7 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("maxWidth: 960, quality: 55"));
         assertTrue(script.contains("Waiting for a stable app frame"));
         assertTrue(script.contains(": 60"));
-        assertTrue(html.contains("remote-dev-view.js?v=6"));
+        assertTrue(html.contains("remote-dev-view.js?v=7"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -1,0 +1,73 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class RemoteDevViewAssetTest {
+
+    @Test
+    public void pageRequiresExplicitConfirmationAndWarnsAboutRealInput() throws Exception {
+        String html = read("src/main/assets/web/local/remote-dev-view.html");
+
+        assertTrue(html.contains("id=\"confirmStart\""));
+        assertTrue(html.contains("remote input operates the live Overdrive app"));
+        assertTrue(html.contains("physical head-unit display is not turned on or uncovered"));
+        assertTrue(html.contains("id=\"startButton\" class=\"dev-button primary\" disabled"));
+    }
+
+    @Test
+    public void framesUseAuthenticatedPostAndNoStoreWithoutPuttingSessionInUrl() throws Exception {
+        String script = read("src/main/assets/web/shared/remote-dev-view.js");
+
+        assertTrue(script.contains("BYDAuth.requireAuth()"));
+        assertTrue(script.contains("BYDAuth.fetch('/api/dev-view/frame'"));
+        assertTrue(script.contains("method: 'POST'"));
+        assertTrue(script.contains("cache: 'no-store'"));
+        assertTrue(script.contains("body: JSON.stringify({ session: token"));
+        assertFalse(script.contains("/api/dev-view/frame?"));
+        assertFalse(script.contains("localStorage.setItem"));
+    }
+
+    @Test
+    public void bridgeIsShellProtectedAndLoopbackOnly() throws Exception {
+        String manifest = read("src/main/AndroidManifest.xml");
+        String service = read(
+            "src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt");
+
+        assertTrue(manifest.contains("com.overdrive.app.remote.RemoteDevViewBridgeService"));
+        assertTrue(manifest.contains("android:permission=\"android.permission.DUMP\""));
+        assertTrue(service.contains("const val HOST = \"127.0.0.1\""));
+        assertTrue(service.contains("MessageDigest.isEqual"));
+    }
+
+    @Test
+    public void developerViewIsNotOnAutomationAuthBypassAllowlist() throws Exception {
+        String server = read("src/main/java/com/overdrive/app/server/HttpServer.java");
+        int allowlistStart = server.indexOf("AUTOMATION_ALLOWED_PREFIXES");
+        int allowlistEnd = server.indexOf("};", allowlistStart);
+        String allowlist = server.substring(allowlistStart, allowlistEnd);
+
+        assertFalse(allowlist.contains("dev-view"));
+        assertTrue(server.contains("path.startsWith(\"/api/dev-view/\")"));
+    }
+
+    private static String read(String moduleRelativePath) throws Exception {
+        Path current = Paths.get("").toAbsolutePath();
+        Path fromModule = current.resolve(moduleRelativePath);
+        if (Files.exists(fromModule)) {
+            return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+        }
+        Path fromRepository = current.resolve("app").resolve(moduleRelativePath);
+        if (Files.exists(fromRepository)) {
+            return new String(Files.readAllBytes(fromRepository), StandardCharsets.UTF_8);
+        }
+        throw new AssertionError("Could not locate file: " + moduleRelativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -25,7 +25,10 @@ public class RemoteDevViewAssetTest {
     @Test
     public void framesUseAuthenticatedPostAndNoStoreWithoutPuttingSessionInUrl() throws Exception {
         String script = read("src/main/assets/web/shared/remote-dev-view.js");
+        String html = read("src/main/assets/web/local/remote-dev-view.html");
 
+        assertTrue(script.contains("typeof BYDAuth === 'undefined'"));
+        assertFalse(script.contains("window.BYDAuth"));
         assertTrue(script.contains("BYDAuth.requireAuth()"));
         assertTrue(script.contains("BYDAuth.fetch('/api/dev-view/frame'"));
         assertTrue(script.contains("method: 'POST'"));
@@ -33,6 +36,7 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("body: JSON.stringify({ session: token"));
         assertFalse(script.contains("/api/dev-view/frame?"));
         assertFalse(script.contains("localStorage.setItem"));
+        assertTrue(html.contains("remote-dev-view.js?v=2"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -50,6 +50,8 @@ public class RemoteDevViewAssetTest {
             "src/main/java/com/overdrive/app/server/RemoteDevViewBridgeClient.java");
         assertTrue(client.contains("createPackageContext("));
         assertTrue(client.contains("\"com.android.shell\""));
+        assertTrue(client.contains("new ProcessBuilder("));
+        assertTrue(client.contains("\"/system/bin/am\""));
         assertFalse(client.contains("Runtime.getRuntime().exec"));
     }
 

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewAssetTest.java
@@ -1,6 +1,8 @@
 package com.overdrive.app.server;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -24,7 +26,7 @@ public class RemoteDevViewAssetTest {
     }
 
     @Test
-    public void framesUseAuthenticatedPostAndNoStoreWithoutPuttingSessionInUrl() throws Exception {
+    public void frameFallbackUsesAuthenticatedPostAndNoStoreWithoutPuttingSessionInUrl() throws Exception {
         String script = read("src/main/assets/web/shared/remote-dev-view.js");
         String html = read("src/main/assets/web/local/remote-dev-view.html");
 
@@ -40,7 +42,35 @@ public class RemoteDevViewAssetTest {
         assertTrue(script.contains("maxWidth: 960, quality: 55"));
         assertTrue(script.contains("consecutiveFrameFailures >= 3"));
         assertTrue(script.contains(": 60"));
-        assertTrue(html.contains("remote-dev-view.js?v=4"));
+        assertTrue(html.contains("remote-dev-view.js?v=5"));
+    }
+
+    @Test
+    public void liveFramesUseLatestOnlyWebSocketWithCapabilityOutsideUrl() throws Exception {
+        String script = read("src/main/assets/web/shared/remote-dev-view.js");
+        String stream = read(
+            "src/main/java/com/overdrive/app/server/RemoteDevViewWebSocketStream.java");
+        String server = read("src/main/java/com/overdrive/app/server/HttpServer.java");
+        String bridge = read(
+            "src/main/java/com/overdrive/app/remote/RemoteDevViewBridgeService.kt");
+
+        assertTrue(script.contains("/ws/dev-view"));
+        assertTrue(script.contains("['overdrive-dev-view', token]"));
+        assertFalse(script.contains("session=' + encodeURIComponent"));
+        assertTrue(script.contains("pendingFrameBlob = blob"));
+        assertTrue(stream.contains("new ArrayBlockingQueue<>(1)"));
+        assertTrue(stream.contains("latest.poll()"));
+        assertTrue(server.contains("RemoteDevViewWebSocketStream"));
+        assertTrue(server.contains(".sessionFromProtocols(websocketProtocolHeader)"));
+        assertTrue(server.contains("requestLine.startsWith(\"GET /ws\")"));
+        assertTrue(bridge.contains("Executors.newFixedThreadPool(CLIENT_THREADS)"));
+
+        String capability = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assertEquals(capability, RemoteDevViewWebSocketStream.sessionFromProtocols(
+            "overdrive-dev-view, " + capability));
+        assertNull(RemoteDevViewWebSocketStream.sessionFromProtocols(capability));
+        assertNull(RemoteDevViewWebSocketStream.sessionFromProtocols(
+            "overdrive-dev-view, not-a-capability"));
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/server/RemoteDevViewSessionManagerTest.java
+++ b/app/src/test/java/com/overdrive/app/server/RemoteDevViewSessionManagerTest.java
@@ -1,0 +1,81 @@
+package com.overdrive.app.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class RemoteDevViewSessionManagerTest {
+
+    @Test
+    public void startingNewSessionInvalidatesPreviousCapability() {
+        MutableClock clock = new MutableClock();
+        CountingRandom random = new CountingRandom();
+        RemoteDevViewSessionManager manager = new RemoteDevViewSessionManager(clock, random);
+
+        RemoteDevViewSessionManager.Session first = manager.start();
+        RemoteDevViewSessionManager.Session second = manager.start();
+
+        assertNotEquals(first.token, second.token);
+        assertNull(manager.validateAndTouch(first.token));
+        assertNotNull(manager.validateAndTouch(second.token));
+    }
+
+    @Test
+    public void inactivityExpiresSessionAndClearsActiveState() {
+        MutableClock clock = new MutableClock();
+        RemoteDevViewSessionManager manager =
+            new RemoteDevViewSessionManager(clock, new CountingRandom());
+        String token = manager.start().token;
+
+        clock.now = RemoteDevViewSessionManager.IDLE_TIMEOUT_MS + 1;
+
+        assertNull(manager.validateAndTouch(token));
+        assertFalse(manager.hasActiveSession());
+    }
+
+    @Test
+    public void activityExtendsIdleButNeverMaximumLifetime() {
+        MutableClock clock = new MutableClock();
+        RemoteDevViewSessionManager manager =
+            new RemoteDevViewSessionManager(clock, new CountingRandom());
+        String token = manager.start().token;
+
+        while (clock.now < RemoteDevViewSessionManager.MAX_LIFETIME_MS) {
+            clock.now += RemoteDevViewSessionManager.IDLE_TIMEOUT_MS - 1;
+            if (clock.now > RemoteDevViewSessionManager.MAX_LIFETIME_MS) break;
+            assertNotNull(manager.validateAndTouch(token));
+        }
+        clock.now = RemoteDevViewSessionManager.MAX_LIFETIME_MS + 1;
+
+        assertNull(manager.validateAndTouch(token));
+    }
+
+    @Test
+    public void endingRequiresExactCapability() {
+        RemoteDevViewSessionManager manager = new RemoteDevViewSessionManager();
+        String token = manager.start().token;
+
+        assertFalse(manager.end(token + "0"));
+        assertTrue(manager.hasActiveSession());
+        assertTrue(manager.end(token));
+        assertFalse(manager.hasActiveSession());
+    }
+
+    private static final class MutableClock implements RemoteDevViewSessionManager.Clock {
+        long now;
+        @Override public long now() { return now; }
+    }
+
+    private static final class CountingRandom implements RemoteDevViewSessionManager.RandomBytes {
+        private byte value = 1;
+        @Override public void nextBytes(byte[] target) {
+            Arrays.fill(target, value++);
+        }
+    }
+}

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -10,7 +10,9 @@ launches Overdrive normally. It does not bypass the PIN screen and does not
 turn on, uncover, or otherwise alter the physical head-unit display. The
 viewer can be expanded and scaled to browser fullscreen; Back, Keyboard,
 Screenshot, Refresh, End, and Exit remain available in a small overlay while
-direct touch control continues on the scaled frame.
+direct touch control continues on the scaled frame. Normal view presents the
+window inside a responsive in-dash tablet bezel. The decorative bezel is
+removed in fullscreen so the live window remains edge-to-edge.
 
 ## Security boundary
 

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -20,10 +20,10 @@ uncover, or otherwise alter the physical head-unit display.
 - Frames use authenticated `POST` requests so the capability is never placed in
   a URL. Responses are marked `no-store`; frames are held in memory and are not
   written to app, shared, or daemon storage.
-- The shell daemon reaches the Android app process through an exported service
-  protected by the signature-level `android.permission.DUMP` permission. The
-  service also requires a daemon-generated in-memory secret and listens only on
-  `127.0.0.1:19881`.
+- The bridge service is private (`exported=false`) and started by Overdrive
+  itself. The shell daemon reaches it over an abstract Unix-domain socket; the
+  bridge checks Linux peer credentials and rejects every UID except shell
+  (2000). There is no network-listening IPC port or shared on-disk secret.
 - Input is dispatched only to Overdrive-owned view roots in the app process.
   There is no `adb input`, accessibility injection, system-window capture, or
   interaction with `AccAnimation`, SurfaceFlinger, or BYD power services.

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -41,6 +41,12 @@ then drawn over that frame on a best-effort basis. Pointer coordinates are
 normalized to the captured window, and the page also exposes a small allowlist
 of navigation keys plus focused-field text input.
 
+The browser requests a 960-pixel-wide, quality-55 JPEG profile and starts the
+next request 60 ms after a successful frame. Capture remains single-flight so
+the car cannot accumulate stale work. The app retries short-lived PixelCopy
+source/window races internally, while the browser keeps the last good frame
+and only surfaces an error after repeated failures.
+
 `DeterrentActivity` is intentionally not selected as the remote target. It can
 continue running in the foreground to block physical input while its warning is
 active, while Remote Dev View keeps capturing and dispatching directly to the

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -19,9 +19,12 @@ in a small overlay while direct touch control continues on the frame.
   random, single-client capability kept only in browser memory.
 - Capabilities expire after five minutes without activity and after eight hours
   regardless of activity. Starting another session invalidates the first.
-- Frames use authenticated `POST` requests so the capability is never placed in
-  a URL. Responses are marked `no-store`; frames are held in memory and are not
-  written to app, shared, or daemon storage.
+- Live frames use an authenticated WebSocket. The normal dashboard JWT
+  authenticates the upgrade; the developer capability is carried as a
+  WebSocket subprotocol so it is never placed in a URL, browser history, or
+  proxy request log. The authenticated `POST` frame endpoint remains as a
+  `no-store` compatibility fallback. Frames stay in memory and are not written
+  to app, shared, or daemon storage.
 - The bridge service is private (`exported=false`) and started by Overdrive
   itself. The BYD firmware blocks shell-to-app Unix sockets with SELinux, so the
   daemon reaches it on a loopback-only TCP port. Every request is signed with
@@ -41,11 +44,14 @@ then drawn over that frame on a best-effort basis. Pointer coordinates are
 normalized to the captured window, and the page also exposes a small allowlist
 of navigation keys plus focused-field text input.
 
-The browser requests a 960-pixel-wide, quality-55 JPEG profile and starts the
-next request 60 ms after a successful frame. Capture remains single-flight so
-the car cannot accumulate stale work. The app retries short-lived PixelCopy
-source/window races internally, while the browser keeps the last good frame
-and only surfaces an error after repeated failures.
+The app continuously produces a 960-pixel-wide, quality-55 JPEG stream while a
+visible WebSocket client is attached. A capacity-one queue on both sides keeps
+only the latest completed frame, so a slow tunnel or browser cannot accumulate
+stale work. Capture remains single-flight, but input is handled by independent
+bridge workers instead of waiting behind PixelCopy. The app retries short-lived
+PixelCopy source/window races internally, while the browser keeps the last good
+frame and only surfaces an error after repeated failures. If WebSocket setup
+fails, the browser falls back to sequential authenticated POST requests.
 
 `DeterrentActivity` is intentionally not selected as the remote target. It can
 continue running in the foreground to block physical input while its warning is
@@ -59,7 +65,7 @@ Only use it while the vehicle is safely parked. It cannot capture or control
 unrelated Android apps, OEM dialogs, system overlays, or the black ACC-off
 cover itself.
 
-The current JPEG polling transport is intentionally simple and bounded to one
-in-flight frame (about three frames per second at up to 1280 pixels wide). A
-future transport can replace it with WebSocket/WebRTC without changing the
-app-process capture and input boundary.
+The transport intentionally streams JPEG rather than the composed Android
+display: PixelCopy is still performed against Overdrive's Window before BYD's
+opaque ACC-off layer is applied. WebSocket transport changes latency and frame
+delivery only; it does not broaden the capture or input boundary.

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -47,10 +47,12 @@ removed in fullscreen so the live window remains edge-to-edge.
 
 ## Capture and input behavior
 
-The virtual display has the same 1920 x 1080 logical size and 240 dpi as the
-head unit, while SurfaceFlinger scales its output directly into a 960 x 540
-ImageReader surface. A bounded app-process encoder keeps the newest JPEG at a
-10 fps target. Web clients read that cached frame; they do not initiate a
+The virtual display and its ImageReader surface both use the same 1920 x 1080
+size and 240 dpi as the head unit. This match is required on BYD's Android 10
+compositor: a smaller consumer surface receives a top-left crop rather than a
+scaled display. The app reads the complete buffer and then downsamples it to a
+960 x 540 stream frame. A bounded app-process encoder keeps the newest JPEG at
+a 10 fps target. Web clients read that cached frame; they do not initiate a
 window screenshot or wait behind the UI thread. A successful input requests
 the next available virtual-display frame immediately.
 

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -21,9 +21,12 @@ uncover, or otherwise alter the physical head-unit display.
   a URL. Responses are marked `no-store`; frames are held in memory and are not
   written to app, shared, or daemon storage.
 - The bridge service is private (`exported=false`) and started by Overdrive
-  itself. The shell daemon reaches it over an abstract Unix-domain socket; the
-  bridge checks Linux peer credentials and rejects every UID except shell
-  (2000). There is no network-listening IPC port or shared on-disk secret.
+  itself. The BYD firmware blocks shell-to-app Unix sockets with SELinux, so the
+  daemon reaches it on a loopback-only TCP port. Every request is signed with
+  HMAC-SHA256 using Overdrive's existing device authentication secret and is
+  rejected when its timestamp is stale or its random nonce has already been
+  used. The bridge is not reachable from another device or network interface,
+  and it creates no additional on-disk secret.
 - Input is dispatched only to Overdrive-owned view roots in the app process.
   There is no `adb input`, accessibility injection, system-window capture, or
   interaction with `AccAnimation`, SurfaceFlinger, or BYD power services.

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -52,6 +52,8 @@ stale work. Capture remains single-flight, but input is handled by independent
 bridge workers instead of waiting behind PixelCopy. The app retries short-lived
 PixelCopy source/window races internally, while the browser keeps the last good
 frame through transient failures instead of blanking it or moving the page. If
+the stream has produced a good frame, later transient failure metadata is also
+discarded so the successful dimensions and PixelCopy state stay visible. If
 WebSocket setup fails, the browser falls back to sequential authenticated POST
 requests. The Screenshot button performs a separate native-size, lossless PNG
 capture and downloads it locally; it does not reduce the streaming frame rate

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -1,13 +1,15 @@
 # Remote Overdrive Dev View
 
-Remote Overdrive Dev View captures and controls Overdrive's own Android window.
-Its primary use is development while a BYD is ACC-off and the OEM's opaque
-`AccAnimation` layer makes whole-display capture tools return black.
+Remote Overdrive Dev View renders and controls a second Overdrive Android
+activity on an app-owned private virtual display. Its primary use is
+development while a BYD is ACC-off and the OEM's opaque `AccAnimation` layer
+makes whole-display capture tools return black.
 
 Open the authenticated web dashboard, choose **Remote Dev View**, and press
 **Start session** beside the compact parked-use notice. Starting a session
-launches Overdrive normally. It does not bypass the PIN screen and does not
-turn on, uncover, or otherwise alter the physical head-unit display. The
+launches a dedicated `RemoteMainActivity` instance with the real MainActivity
+implementation and shared app data. It does not bypass the PIN screen and does
+not turn on, uncover, or otherwise alter the physical head-unit display. The
 viewer can be expanded and scaled to browser fullscreen; Back, Keyboard,
 Screenshot, Refresh, End, and Exit remain available in a small overlay while
 direct touch control continues on the scaled frame. Normal view presents the
@@ -28,6 +30,9 @@ removed in fullscreen so the live window remains edge-to-edge.
   proxy request log. The authenticated `POST` frame endpoint remains as a
   `no-store` compatibility fallback. Frames stay in memory and are not written
   to app, shared, or daemon storage.
+- The remote Activity is placed on a private, own-content-only virtual display.
+  Android restricts that display to Overdrive's UID; it is not public,
+  auto-mirroring, secure-content capable, or visible to unrelated apps.
 - The bridge service is private (`exported=false`) and started by Overdrive
   itself. The BYD firmware blocks shell-to-app Unix sockets with SELinux, so the
   daemon reaches it on a loopback-only TCP port. Every request is signed with
@@ -35,39 +40,44 @@ removed in fullscreen so the live window remains edge-to-edge.
   rejected when its timestamp is stale or its random nonce has already been
   used. The bridge is not reachable from another device or network interface,
   and it creates no additional on-disk secret.
-- Input is dispatched only to Overdrive-owned view roots in the app process.
-  There is no `adb input`, accessibility injection, system-window capture, or
-  interaction with `AccAnimation`, SurfaceFlinger, or BYD power services.
+- Input is dispatched only to Overdrive-owned view roots on the private display.
+  There is no `adb input`, accessibility injection, display-stack capture, or
+  interaction with `AccAnimation`, SurfaceFlinger services, or BYD power
+  services.
 
 ## Capture and input behavior
 
-The last interactive Overdrive Activity window is captured with
-`PixelCopy.request(activity.window, ...)`. App-owned dialog and popup roots are
-then drawn over that frame on a best-effort basis. Pointer coordinates are
-normalized to the captured window. The page forwards Escape as Android Back,
-Backspace as Delete, Enter, Tab, arrow-key navigation, and printable keyboard
-text. A compact Keyboard button focuses a hidden input so a phone or tablet can
-open its soft keyboard without keeping a separate input-tools sidebar.
+The virtual display has the same 1920 x 1080 logical size and 240 dpi as the
+head unit, while SurfaceFlinger scales its output directly into a 960 x 540
+ImageReader surface. A bounded app-process encoder keeps the newest JPEG at a
+10 fps target. Web clients read that cached frame; they do not initiate a
+window screenshot or wait behind the UI thread. A successful input requests
+the next available virtual-display frame immediately.
 
-The app continuously produces a 960-pixel-wide, quality-55 JPEG stream while a
-visible WebSocket client is attached. A capacity-one queue on both sides keeps
-only the latest completed frame, so a slow tunnel or browser cannot accumulate
-stale work. Capture remains single-flight, but input is handled by independent
-bridge workers instead of waiting behind PixelCopy. The app retries short-lived
-PixelCopy source/window races internally, while the browser keeps the last good
-frame through transient failures instead of blanking it or moving the page. If
-the stream has produced a good frame, later transient failure metadata is also
-discarded so the successful dimensions and PixelCopy state stay visible. If
-WebSocket setup fails, the browser falls back to sequential authenticated POST
-requests. The Screenshot button performs a separate native-size, lossless PNG
-capture and downloads it locally; it does not reduce the streaming frame rate
-or persist a copy on the vehicle.
+Pointer coordinates are normalized to the virtual Activity window. The page
+forwards Escape as Android Back, Backspace as Delete, Enter, Tab, arrow-key
+navigation, and printable keyboard text. A compact Keyboard button focuses a
+hidden input so a phone or tablet can open its soft keyboard without keeping a
+separate input-tools sidebar.
 
-`DeterrentActivity` is intentionally not selected as the remote target. It can
-continue running in the foreground to block physical input while its warning is
-active, while Remote Dev View keeps capturing and dispatching directly to the
-underlying interactive Overdrive Activity. The deterrent, its daemon-owned
-surface, its deadline, and its power behavior are not disabled or modified.
+The capacity-one WebSocket queue keeps only the latest newly encoded frame, so
+a slow tunnel or browser cannot accumulate stale work. The daemon polls the
+app's cached frame at a bounded cadence and ignores duplicate sequence numbers.
+The browser draws decoded JPEGs into a persistent canvas, leaving the last
+frame intact throughout decoding and reconnects. A near-uniform black frame is
+discarded after a visible frame unless the active remote Window is deliberately
+`FLAG_SECURE`; secure state therefore never exposes an older unlocked image.
+If WebSocket setup fails, the browser falls back to sequential authenticated
+POST requests.
+
+The Screenshot button is the only path that still uses `PixelCopy`: it performs
+a separate native-size, lossless PNG capture of the virtual Activity Window and
+downloads it locally without persisting a copy on the vehicle.
+
+`DeterrentActivity` and `AccAnimation` remain on physical display stack 0. They
+are not selected as remote targets and are not present on the private display.
+Their surfaces, deadlines, input blocking, and power behavior are not disabled
+or modified.
 
 This gives the remote session the same practical reach as a person interacting
 with Overdrive locally, including screens that can issue vehicle commands.
@@ -75,7 +85,7 @@ Only use it while the vehicle is safely parked. It cannot capture or control
 unrelated Android apps, OEM dialogs, system overlays, or the black ACC-off
 cover itself.
 
-The transport intentionally streams JPEG rather than the composed Android
-display: PixelCopy is still performed against Overdrive's Window before BYD's
-opaque ACC-off layer is applied. WebSocket transport changes latency and frame
-delivery only; it does not broaden the capture or input boundary.
+Ending or expiring a developer-view session sends an authenticated stop command
+to the private app bridge, releases the ImageReader and virtual display, and
+causes Android to remove its remote task. The physical MainActivity task and all
+Overdrive configuration and app data remain untouched.

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -4,12 +4,13 @@ Remote Overdrive Dev View captures and controls Overdrive's own Android window.
 Its primary use is development while a BYD is ACC-off and the OEM's opaque
 `AccAnimation` layer makes whole-display capture tools return black.
 
-Open the authenticated web dashboard, choose **Remote Dev View**, acknowledge
-the compact parked-use notice, and start a session. Starting a session launches
-Overdrive normally. It does not bypass the PIN screen and does not turn on,
-uncover, or otherwise alter the physical head-unit display. The viewer can be
-expanded to browser fullscreen; Back, Refresh, End, and Exit remain available
-in a small overlay while direct touch control continues on the frame.
+Open the authenticated web dashboard, choose **Remote Dev View**, and press
+**Start session** beside the compact parked-use notice. Starting a session
+launches Overdrive normally. It does not bypass the PIN screen and does not
+turn on, uncover, or otherwise alter the physical head-unit display. The
+viewer can be expanded and scaled to browser fullscreen; Back, Screenshot,
+Refresh, End, and Exit remain available in a small overlay while direct touch
+control continues on the scaled frame.
 
 ## Security boundary
 
@@ -50,8 +51,11 @@ only the latest completed frame, so a slow tunnel or browser cannot accumulate
 stale work. Capture remains single-flight, but input is handled by independent
 bridge workers instead of waiting behind PixelCopy. The app retries short-lived
 PixelCopy source/window races internally, while the browser keeps the last good
-frame and only surfaces an error after repeated failures. If WebSocket setup
-fails, the browser falls back to sequential authenticated POST requests.
+frame through transient failures instead of blanking it or moving the page. If
+WebSocket setup fails, the browser falls back to sequential authenticated POST
+requests. The Screenshot button performs a separate native-size, lossless PNG
+capture and downloads it locally; it does not reduce the streaming frame rate
+or persist a copy on the vehicle.
 
 `DeterrentActivity` is intentionally not selected as the remote target. It can
 continue running in the foreground to block physical input while its warning is

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -1,0 +1,48 @@
+# Remote Overdrive Dev View
+
+Remote Overdrive Dev View captures and controls Overdrive's own Android window.
+Its primary use is development while a BYD is ACC-off and the OEM's opaque
+`AccAnimation` layer makes whole-display capture tools return black.
+
+Open the authenticated web dashboard, choose **Diagnostics → Remote Dev View**,
+read the warning, and explicitly start a session. Starting a session launches
+Overdrive normally. It does not bypass the PIN screen and does not turn on,
+uncover, or otherwise alter the physical head-unit display.
+
+## Security boundary
+
+- The page and every `/api/dev-view/*` request pass the normal dashboard JWT
+  middleware.
+- Session creation additionally requires explicit confirmation and returns a
+  random, single-client capability kept only in browser memory.
+- Capabilities expire after five minutes without activity and after eight hours
+  regardless of activity. Starting another session invalidates the first.
+- Frames use authenticated `POST` requests so the capability is never placed in
+  a URL. Responses are marked `no-store`; frames are held in memory and are not
+  written to app, shared, or daemon storage.
+- The shell daemon reaches the Android app process through an exported service
+  protected by the signature-level `android.permission.DUMP` permission. The
+  service also requires a daemon-generated in-memory secret and listens only on
+  `127.0.0.1:19881`.
+- Input is dispatched only to Overdrive-owned view roots in the app process.
+  There is no `adb input`, accessibility injection, system-window capture, or
+  interaction with `AccAnimation`, SurfaceFlinger, or BYD power services.
+
+## Capture and input behavior
+
+The active Overdrive Activity window is captured with
+`PixelCopy.request(activity.window, ...)`. App-owned dialog and popup roots are
+then drawn over that frame on a best-effort basis. Pointer coordinates are
+normalized to the captured window, and the page also exposes a small allowlist
+of navigation keys plus focused-field text input.
+
+This gives the remote session the same practical reach as a person interacting
+with Overdrive locally, including screens that can issue vehicle commands.
+Only use it while the vehicle is safely parked. It cannot capture or control
+unrelated Android apps, OEM dialogs, system overlays, or the black ACC-off
+cover itself.
+
+The current JPEG polling transport is intentionally simple and bounded to one
+in-flight frame (about three frames per second at up to 1280 pixels wide). A
+future transport can replace it with WebSocket/WebRTC without changing the
+app-process capture and input boundary.

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -8,9 +8,9 @@ Open the authenticated web dashboard, choose **Remote Dev View**, and press
 **Start session** beside the compact parked-use notice. Starting a session
 launches Overdrive normally. It does not bypass the PIN screen and does not
 turn on, uncover, or otherwise alter the physical head-unit display. The
-viewer can be expanded and scaled to browser fullscreen; Back, Screenshot,
-Refresh, End, and Exit remain available in a small overlay while direct touch
-control continues on the scaled frame.
+viewer can be expanded and scaled to browser fullscreen; Back, Keyboard,
+Screenshot, Refresh, End, and Exit remain available in a small overlay while
+direct touch control continues on the scaled frame.
 
 ## Security boundary
 
@@ -42,8 +42,10 @@ control continues on the scaled frame.
 The last interactive Overdrive Activity window is captured with
 `PixelCopy.request(activity.window, ...)`. App-owned dialog and popup roots are
 then drawn over that frame on a best-effort basis. Pointer coordinates are
-normalized to the captured window, and the page also exposes a small allowlist
-of navigation keys plus focused-field text input.
+normalized to the captured window. The page forwards Escape as Android Back,
+Backspace as Delete, Enter, Tab, arrow-key navigation, and printable keyboard
+text. A compact Keyboard button focuses a hidden input so a phone or tablet can
+open its soft keyboard without keeping a separate input-tools sidebar.
 
 The app continuously produces a 960-pixel-wide, quality-55 JPEG stream while a
 visible WebSocket client is attached. A capacity-one queue on both sides keeps

--- a/docs/REMOTE_DEV_VIEW.md
+++ b/docs/REMOTE_DEV_VIEW.md
@@ -4,10 +4,12 @@ Remote Overdrive Dev View captures and controls Overdrive's own Android window.
 Its primary use is development while a BYD is ACC-off and the OEM's opaque
 `AccAnimation` layer makes whole-display capture tools return black.
 
-Open the authenticated web dashboard, choose **Diagnostics → Remote Dev View**,
-read the warning, and explicitly start a session. Starting a session launches
+Open the authenticated web dashboard, choose **Remote Dev View**, acknowledge
+the compact parked-use notice, and start a session. Starting a session launches
 Overdrive normally. It does not bypass the PIN screen and does not turn on,
-uncover, or otherwise alter the physical head-unit display.
+uncover, or otherwise alter the physical head-unit display. The viewer can be
+expanded to browser fullscreen; Back, Refresh, End, and Exit remain available
+in a small overlay while direct touch control continues on the frame.
 
 ## Security boundary
 
@@ -33,11 +35,17 @@ uncover, or otherwise alter the physical head-unit display.
 
 ## Capture and input behavior
 
-The active Overdrive Activity window is captured with
+The last interactive Overdrive Activity window is captured with
 `PixelCopy.request(activity.window, ...)`. App-owned dialog and popup roots are
 then drawn over that frame on a best-effort basis. Pointer coordinates are
 normalized to the captured window, and the page also exposes a small allowlist
 of navigation keys plus focused-field text input.
+
+`DeterrentActivity` is intentionally not selected as the remote target. It can
+continue running in the foreground to block physical input while its warning is
+active, while Remote Dev View keeps capturing and dispatching directly to the
+underlying interactive Overdrive Activity. The deterrent, its daemon-owned
+surface, its deadline, and its power behavior are not disabled or modified.
 
 This gives the remote session the same practical reach as a person interacting
 with Overdrive locally, including screens that can issue vehicle commands.


### PR DESCRIPTION
## Summary

- add Remote Dev View to `main`'s authenticated web dashboard
- start a dedicated OverDrive activity on an app-owned 1920 x 1080 virtual
  display, leaving the physical BYD display and ACC-off cover untouched
- stream a latest-frame view over an authenticated WebSocket with a bounded
  POST fallback and no stale-frame backlog
- map pointer, Back, navigation keys, and keyboard input only to the OverDrive
  root on that virtual display
- provide an explicit full-resolution PNG Screenshot action
- require dashboard authentication, parked-use confirmation, and a random
  single-client capability with idle and absolute expiry
- keep the non-exported bridge loopback-only and authenticate requests with
  HMAC, fresh timestamps, and nonce replay protection

## Why

When the BYD is ACC-off, its OEM cover can make whole-display capture return a
black frame although OverDrive is still running. `main` has no supported way
to inspect and operate the app window in that state.

## Impact

Developers can inspect and control an isolated OverDrive activity without
capturing or controlling other apps, OEM dialogs, system overlays, or the
ACC-off cover. Sessions release their display, reader, task, and capability
state when ended or expired.

## Validation

- focused virtual-display, web asset, authentication, stream, and session
  lifecycle tests
- `test`, `testDebugUnitTest`, and `assembleDebug` passed in exact
  aggregate `743354e5687da24d0b273646a3d8fb4db8addbeb`
- aggregate ARM64 APK SHA-256:
  `49355A2DC0D19A05CC17B88262FC1984A33A49C68C4500B0C871435AF04F77D8`
- a live vehicle session produced a complete frame, accepted scoped input, and
  downloaded a full-resolution still before ending cleanly

## Visual evidence

There is no corresponding destination on `main`, so no fabricated before image
is shown.

![Remote Dev View complete browser viewport](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/12105b1b9aaff9411a66314060fe5f5df6d94f3a/docs/pr-evidence/2026-08-12/remote-dev/remote-dev-view.png)
