### PR TITLE
feat(settings): add a Wi-Fi auto-enable control

### DIFF
--- a/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
+++ b/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
@@ -1795,7 +1795,8 @@ object UnifiedConfigManager {
     fun setAutomationShellAllowed(allow: Boolean): Boolean =
         updateValues("automation", mapOf("allowShell" to allow))
 
-    /** Whether the user has explicitly turned WiFi OFF via an automation / key-mapping
+    /** Whether the user has explicitly disabled OverDrive's WiFi keep-alive via the
+     *  Background services setting or turned WiFi OFF via an automation / key-mapping
      *  radio action. The WiFi keep-alive watchdog (AccSentryDaemon.ensureWifiEnabled,
      *  SentryDaemon.enableWifi, ServiceLauncher.ensureWifiEnabled) checks this BEFORE
      *  running `svc wifi enable`, so a deliberate "WiFi off" rule is not immediately
@@ -1808,8 +1809,9 @@ object UnifiedConfigManager {
         try { (loadConfig().optJSONObject("radio")?.optBoolean("wifiUserOff", false)) ?: false }
         catch (t: Throwable) { false }
 
-    /** Persist the WiFi-off suppression flag. Set true when a radio action turns WiFi
-     *  off (so keep-alive stands down), cleared to false when WiFi is turned back on.
+    /** Persist the WiFi keep-alive suppression flag. Set true by the Background services
+     *  setting or when a radio action turns WiFi off (so keep-alive stands down), and
+     *  cleared to false when the setting is enabled or WiFi is turned back on.
      *  Single-key merge on the "radio" section, off the main looper (updateValues
      *  routes an app-process write to the daemon). */
     @JvmStatic

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
@@ -23,6 +23,7 @@ import com.overdrive.app.ui.viewmodel.DaemonsViewModel
 import com.overdrive.app.ui.model.DaemonType
 import com.overdrive.app.ui.model.localizedName
 import com.overdrive.app.R
+import com.overdrive.app.config.UnifiedConfigManager
 import com.overdrive.app.ui.model.DaemonStatus
 import com.overdrive.app.ui.util.QrCodeGenerator
 
@@ -36,7 +37,9 @@ class DaemonsFragment : Fragment() {
     private val daemonsViewModel: DaemonsViewModel by activityViewModels()
     private lateinit var recyclerDaemons: RecyclerView
     private lateinit var tvDaemonsCount: TextView
+    private lateinit var swWifiAutoEnable: SwitchMaterial
     private lateinit var daemonAdapter: DaemonAdapter
+    private var applyingWifiAutoEnable = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -60,6 +63,42 @@ class DaemonsFragment : Fragment() {
     private fun initViews(view: View) {
         recyclerDaemons = view.findViewById(R.id.recyclerDaemons)
         tvDaemonsCount = view.findViewById(R.id.tvDaemonsCount)
+        swWifiAutoEnable = view.findViewById(R.id.swWifiAutoEnable)
+
+        refreshWifiAutoEnable()
+        view.findViewById<View>(R.id.rowWifiAutoEnable).setOnClickListener {
+            swWifiAutoEnable.isChecked = !swWifiAutoEnable.isChecked
+        }
+        swWifiAutoEnable.setOnCheckedChangeListener { _, checked ->
+            if (applyingWifiAutoEnable) return@setOnCheckedChangeListener
+
+            // The stored value is deliberately phrased as suppression because every
+            // keep-alive site can fail open to the historical/default behaviour when
+            // the config is unreadable. The UI presents the friendlier positive form.
+            if (!UnifiedConfigManager.setWifiKeepAliveSuppressed(!checked)) {
+                applyingWifiAutoEnable = true
+                swWifiAutoEnable.isChecked = !checked
+                applyingWifiAutoEnable = false
+                Toast.makeText(
+                    context,
+                    R.string.daemons_wifi_auto_enable_save_failed,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Automation and key-mapping radio actions share this preference. Reflect any
+        // change made through those entry points when the user returns to this page.
+        if (::swWifiAutoEnable.isInitialized) refreshWifiAutoEnable()
+    }
+
+    private fun refreshWifiAutoEnable() {
+        applyingWifiAutoEnable = true
+        swWifiAutoEnable.isChecked = !UnifiedConfigManager.isWifiKeepAliveSuppressed()
+        applyingWifiAutoEnable = false
     }
     
     private fun setupRecyclerView() {

--- a/app/src/main/res/layout/fragment_daemons.xml
+++ b/app/src/main/res/layout/fragment_daemons.xml
@@ -2,15 +2,16 @@
 <!--
   SOTA Daemons page — portrait (1080×1920 / ~540dp × 960dp).
 
-  Hero header (title + live "X of Y running" subtitle) above a flat
-  RecyclerView of daemon cards. Card surface alternation comes from
+  Hero header (title + live "X of Y running" subtitle), an OverDrive Wi-Fi
+  keep-alive preference, then a flat RecyclerView of daemon cards. Card surface alternation comes from
   M3 surface tier (?attr/colorSurfaceContainer); side padding is owned
   by the recycler so individual cards can use marginHorizontal=0.
 
-  IDs preserved (DaemonsFragment.kt findViewById targets):
-    recyclerDaemons, tvDaemonsCount
+  IDs read by DaemonsFragment.kt:
+    recyclerDaemons, tvDaemonsCount, rowWifiAutoEnable, swWifiAutoEnable
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -47,10 +48,69 @@
             tools:text="3 of 8 running" />
     </LinearLayout>
 
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/page_padding_horizontal"
+        android:layout_marginBottom="@dimen/card_gap_vertical"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
+        app:cardCornerRadius="@dimen/card_radius_standard"
+        app:cardElevation="0dp">
+
+        <LinearLayout
+            android:id="@+id/rowWifiAutoEnable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="@dimen/card_padding_standard">
+
+            <ImageView
+                android:layout_width="@dimen/card_icon_standard"
+                android:layout_height="@dimen/card_icon_standard"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_signal_disconnected"
+                app:tint="?attr/colorPrimary" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/daemons_wifi_auto_enable_title"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                    android:textColor="?attr/colorOnSurface" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/daemons_wifi_auto_enable_subtitle"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+            </LinearLayout>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/swWifiAutoEnable"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/daemons_wifi_auto_enable_title" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerDaemons"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:clipToPadding="false"
         android:paddingHorizontal="@dimen/page_padding_horizontal"
         android:paddingBottom="@dimen/page_padding_bottom" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,9 @@
     <string name="daemons_count_pending">Loading services…</string>
     <!-- Subtitle on the Daemons hero header. %1$d running, %2$d total. -->
     <string name="daemons_count_fmt">%1$d of %2$d running</string>
+    <string name="daemons_wifi_auto_enable_title">Automatically enable Wi&#8209;Fi</string>
+    <string name="daemons_wifi_auto_enable_subtitle">OverDrive restores Wi&#8209;Fi while parked and when background services start. Turn this off to leave the current Wi&#8209;Fi state under vehicle control.</string>
+    <string name="daemons_wifi_auto_enable_save_failed">Could not save the Wi&#8209;Fi auto-enable setting.</string>
 
     <!-- dialog_time_window -->
 

--- a/app/src/test/java/com/overdrive/app/ui/daemon/WifiAutoEnableSettingWiringTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/daemon/WifiAutoEnableSettingWiringTest.java
@@ -1,0 +1,60 @@
+package com.overdrive.app.ui.daemon;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Guards the user-facing switch that prevents OverDrive from restoring Wi-Fi. */
+public class WifiAutoEnableSettingWiringTest {
+
+    @Test
+    public void daemonsPageExposesAndPersistsThePositiveAutoEnableSetting() throws Exception {
+        String layout = readRepositoryFile("app/src/main/res/layout/fragment_daemons.xml");
+        String fragment = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt");
+
+        assertTrue(layout.contains("@+id/rowWifiAutoEnable"));
+        assertTrue(layout.contains("@+id/swWifiAutoEnable"));
+        assertTrue(layout.contains("@string/daemons_wifi_auto_enable_title"));
+        assertTrue(fragment.contains(
+                "swWifiAutoEnable.isChecked = !UnifiedConfigManager.isWifiKeepAliveSuppressed()"));
+        assertTrue(fragment.contains(
+                "UnifiedConfigManager.setWifiKeepAliveSuppressed(!checked)"));
+    }
+
+    @Test
+    public void everyOverdriveWifiEnablePathHonoursTheSharedSuppressionFlag() throws Exception {
+        String accSentry = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/daemon/AccSentryDaemon.java");
+        String sentry = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/daemon/SentryDaemon.java");
+        String launcher = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/launcher/ServiceLauncher.kt");
+
+        assertTrue(accSentry.contains("UnifiedConfigManager.isWifiKeepAliveSuppressed()"));
+        assertTrue(sentry.contains("UnifiedConfigManager.isWifiKeepAliveSuppressed()"));
+        assertTrue(launcher.contains("UnifiedConfigManager.isWifiKeepAliveSuppressed()"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- add **Automatically enable Wi-Fi** to **Settings → Background services**
- expose `main`'s existing persisted Wi-Fi keep-alive suppression flag as a
  clear positive setting instead of requiring an Automation or Key Mapping
  action
- default to enabled so existing behaviour is preserved
- when disabled, prevent the parked watchdog, sentry daemon, and service
  launcher from restoring Wi-Fi without disconnecting the current network or
  changing cellular/operator settings
- refresh the switch on resume and revert it with an error if persistence fails

## Why

`main` already has one suppression flag respected by every OverDrive Wi-Fi
enable path, but no direct Settings control. A deliberate Wi-Fi-off choice can
therefore be reversed during parked or background-service startup unless the
user knows about the indirect radio actions.

## Impact

The existing policy becomes discoverable and reversible. No second watchdog or
network-routing behaviour is introduced, and Automation/Key Mapping changes
remain synchronised with the setting.

## Validation

- focused wiring tests cover persistence and all three existing Wi-Fi enable
  paths
- `test`, `testDebugUnitTest`, and `assembleDebug` passed in exact
  aggregate `743354e5687da24d0b273646a3d8fb4db8addbeb`
- aggregate ARM64 APK SHA-256:
  `49355A2DC0D19A05CC17B88262FC1984A33A49C68C4500B0C871435AF04F77D8`
- the setting was exercised on the complete 1920 x 1080 Background services
  screen in the installed, hash-matched aggregate

## Visual evidence

| Before — current `main` | After — tested aggregate |
| --- | --- |
| ![Background services before](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/12105b1b9aaff9411a66314060fe5f5df6d94f3a/docs/pr-evidence/2026-08-12/wifi/before-wifi-auto-enable.png) | ![Background services after](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/12105b1b9aaff9411a66314060fe5f5df6d94f3a/docs/pr-evidence/2026-08-12/wifi/after-wifi-auto-enable.png) |
