### PR TITLE
feat(settings): add screenshot privacy mode

### DIFF
--- a/app/src/main/assets/web/local/about.html
+++ b/app/src/main/assets/web/local/about.html
@@ -427,7 +427,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/backup-flow.js"></script>
     <script src="../shared/send-logs.js"></script>

--- a/app/src/main/assets/web/local/abrp.html
+++ b/app/src/main/assets/web/local/abrp.html
@@ -296,7 +296,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/abrp.js"></script>
     <script>

--- a/app/src/main/assets/web/local/automations.html
+++ b/app/src/main/assets/web/local/automations.html
@@ -297,7 +297,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/automations.js?v=av62"></script>
     <script src="../shared/audio-library.js?v=2"></script>

--- a/app/src/main/assets/web/local/byd-cloud.html
+++ b/app/src/main/assets/web/local/byd-cloud.html
@@ -283,7 +283,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <!-- BydCloud module + SurvSettings stubs live in surveillance.js. -->
     <script src="../shared/surveillance.js?v=survtoggle1"></script>

--- a/app/src/main/assets/web/local/charging.html
+++ b/app/src/main/assets/web/local/charging.html
@@ -905,7 +905,7 @@
     <div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()"></div>
     <div id="toastContainer" class="toast-container"></div>
 
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/charging.js?v=31"></script>
     <script>

--- a/app/src/main/assets/web/local/communicate.html
+++ b/app/src/main/assets/web/local/communicate.html
@@ -195,7 +195,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/communicate.js?v=3"></script>
     <script>
         function toggleSidebar() {

--- a/app/src/main/assets/web/local/events.html
+++ b/app/src/main/assets/web/local/events.html
@@ -2299,7 +2299,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/events.js?v=storagefilter1"></script>
     <script>

--- a/app/src/main/assets/web/local/index.html
+++ b/app/src/main/assets/web/local/index.html
@@ -1345,7 +1345,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=19"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/map.js?v=1"></script>
     <script>

--- a/app/src/main/assets/web/local/key-mapping.html
+++ b/app/src/main/assets/web/local/key-mapping.html
@@ -519,7 +519,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/key-mapping.js?v=32"></script>
     <script src="../shared/cluster-projection.js?v=1"></script>
     <script>

--- a/app/src/main/assets/web/local/live-view.html
+++ b/app/src/main/assets/web/local/live-view.html
@@ -1191,7 +1191,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/stream.js?v=index3"></script>
     <script src="../shared/map.js?v=1"></script>

--- a/app/src/main/assets/web/local/login.html
+++ b/app/src/main/assets/web/local/login.html
@@ -277,7 +277,7 @@
     <!-- Load i18n runtime so BYD.i18n.init() resolves. The login page has no
          sidebar/status polling so we don't need the rest of core.js, but
          loading it here keeps the dependency graph consistent. -->
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
 </head>
 <body>
     <div class="login-container">

--- a/app/src/main/assets/web/local/mqtt.html
+++ b/app/src/main/assets/web/local/mqtt.html
@@ -394,7 +394,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/mqtt.js?v=3"></script>
     <script>

--- a/app/src/main/assets/web/local/network.html
+++ b/app/src/main/assets/web/local/network.html
@@ -294,7 +294,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/network.js?v=1"></script>
     <script>

--- a/app/src/main/assets/web/local/notifications.html
+++ b/app/src/main/assets/web/local/notifications.html
@@ -1167,7 +1167,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <!-- surveillance.js owns the SurvSettings module that backs the Telegram
          tier toggles. We load it here so the v2TelegramSendStartPing /

--- a/app/src/main/assets/web/local/performance.html
+++ b/app/src/main/assets/web/local/performance.html
@@ -1412,7 +1412,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/performance.js?v=11"></script>
     <script>

--- a/app/src/main/assets/web/local/recording.html
+++ b/app/src/main/assets/web/local/recording.html
@@ -892,7 +892,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/storage-budget.js?v=8"></script>
     <script src="../shared/recording.js?v=budget8"></script>

--- a/app/src/main/assets/web/local/road-sense.html
+++ b/app/src/main/assets/web/local/road-sense.html
@@ -933,7 +933,7 @@
     <div id="toastContainer" class="toast-container"></div>
 
     <script src="../shared/auth.js"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/road-sense.js?v=chimevolume6"></script>
     <script>

--- a/app/src/main/assets/web/local/seat-positions.html
+++ b/app/src/main/assets/web/local/seat-positions.html
@@ -125,7 +125,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=15"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/seat-positions.js"></script>
     <script>
         function toggleSidebar() {

--- a/app/src/main/assets/web/local/surveillance.html
+++ b/app/src/main/assets/web/local/surveillance.html
@@ -1509,7 +1509,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/storage-budget.js?v=8"></script>
     <script src="../shared/surveillance.js?v=survtoggle1"></script>

--- a/app/src/main/assets/web/local/telegram.html
+++ b/app/src/main/assets/web/local/telegram.html
@@ -262,7 +262,7 @@
 
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script>
         function toggleSidebar() {

--- a/app/src/main/assets/web/local/trips.html
+++ b/app/src/main/assets/web/local/trips.html
@@ -2081,7 +2081,7 @@
     <script src="../shared/leaflet.js"></script>
     <script src="../shared/auth.js"></script>
     <script src="../shared/pwa-init.js?v=index1"></script>
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <script src="../shared/storage-budget.js?v=8"></script>
     <script src="../shared/trips.js?v=budget9"></script>

--- a/app/src/main/assets/web/local/vehicle-control.html
+++ b/app/src/main/assets/web/local/vehicle-control.html
@@ -618,7 +618,7 @@
     <!-- core.js polls /status every 5s and populates the sidebar status card
          (12V, ACC, SOC, range, SOH, fuel, network). Without it those values
          all stay at "--" since vehicle-control.js only manages the 3D scene. -->
-    <script src="../shared/core.js?v=18"></script>
+    <script src="../shared/core.js?v=20"></script>
     <script src="../shared/update-flow.js"></script>
     <!-- Mode-gated loader. In immersive mode this injects the heavy stack
          (SotaPlayer + three.js + Draco/GLTF/Orbit + gsap ≈ 820 KB of script,

--- a/app/src/main/assets/web/shared/core.js
+++ b/app/src/main/assets/web/shared/core.js
@@ -649,6 +649,172 @@ BYD.units = {
     }
 };
 
+/**
+ * Screenshot privacy mode.
+ *
+ * The native Settings switch is persisted in unified config and echoed by
+ * /status. This shared client applies the same policy to every daemon-served
+ * page without copying masking rules into individual screens. The class is a
+ * visual-only aid: values remain untouched for controls, links, and APIs.
+ */
+BYD.screenshotPrivacy = (function () {
+    var MASK_CLASS = 'screenshot-privacy-mask';
+    var AUTO_ATTR = 'data-screenshot-privacy-auto';
+    var STYLE_ID = 'screenshotPrivacyStyle';
+    var enabled = false;
+    var observer = null;
+    var scanQueued = false;
+    var ipv4 = /(^|[^\d])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?::\d{1,5})?(?!\d)/;
+    var coordinates = /(^|[^\d.])[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}\s*[,;\/]\s*[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}(?![\d.])/;
+    var labelledCoordinate = /\b(?:lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*[+-]?\d{1,3}\.\d{3,}/i;
+    var url = /\b(?:https?|wss?):\/\/\S+/i;
+    var email = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
+    var identityTokens = [
+        'qrcode', 'deviceid', 'currenturl', 'tunnelurl', 'remoteurl',
+        'ipaddress', 'latitude', 'longitude', 'coordinates', 'location',
+        'address', 'mapcontainer', 'dashlocation', 'detailloc', 'locrow',
+        'placefilter', 'placesearch', 'thumbnail', 'videoplayer',
+        'camerapreview', 'cameraimage', 'snapshot', 'platenumber',
+        'licenseplate'
+    ];
+
+    function ensureStyle() {
+        if (document.getElementById(STYLE_ID)) return;
+        var style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent =
+            'html.screenshot-privacy-mode .' + MASK_CLASS + ' {' +
+            'filter: blur(14px) brightness(.42) contrast(.45) saturate(.25) !important;' +
+            '-webkit-filter: blur(14px) brightness(.42) contrast(.45) saturate(.25) !important;' +
+            'user-select: none !important;' +
+            '-webkit-user-select: none !important;' +
+            '}' +
+            'html.screenshot-privacy-mode img.' + MASK_CLASS + ',' +
+            'html.screenshot-privacy-mode video.' + MASK_CLASS + ',' +
+            'html.screenshot-privacy-mode canvas.' + MASK_CLASS + ',' +
+            'html.screenshot-privacy-mode .recording-thumbnail.' + MASK_CLASS + ',' +
+            'html.screenshot-privacy-mode .video-player.' + MASK_CLASS + ' {' +
+            'filter: blur(22px) brightness(.32) contrast(.35) saturate(.15) !important;' +
+            '-webkit-filter: blur(22px) brightness(.32) contrast(.35) saturate(.15) !important;' +
+            '}';
+        (document.head || document.documentElement).appendChild(style);
+    }
+
+    function normalize(value) {
+        return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    function hasSensitiveIdentity(el) {
+        if (!el || !el.getAttribute) return false;
+        if (el.hasAttribute('data-screenshot-private')) return true;
+        var identity = normalize(
+            (el.id || '') + ' ' +
+            (typeof el.className === 'string' ? el.className : '') + ' ' +
+            (el.getAttribute('name') || '') + ' ' +
+            (el.getAttribute('aria-label') || '') + ' ' +
+            (el.getAttribute('data-card-id') || '') + ' ' +
+            (el.getAttribute('data-filter-row') || '')
+        );
+        if (identity.indexOf('qr') >= 0) return true;
+        for (var i = 0; i < identityTokens.length; i++) {
+            if (identity.indexOf(identityTokens[i]) >= 0) return true;
+        }
+        return false;
+    }
+
+    function directText(el) {
+        if (!el) return '';
+        var tag = String(el.tagName || '').toLowerCase();
+        if (tag === 'input' || tag === 'textarea') return el.value || '';
+        var result = '';
+        for (var i = 0; i < el.childNodes.length; i++) {
+            var node = el.childNodes[i];
+            if (node.nodeType === 3) result += ' ' + node.nodeValue;
+        }
+        return result;
+    }
+
+    function hasSensitiveText(text) {
+        var value = String(text || '').trim();
+        return value && (ipv4.test(value) || coordinates.test(value) ||
+            labelledCoordinate.test(value) || url.test(value) || email.test(value));
+    }
+
+    function mark(el) {
+        if (!el || !el.classList || el === document.body || el === document.documentElement) return;
+        var ancestor = el.parentElement && el.parentElement.closest
+            ? el.parentElement.closest('.' + MASK_CLASS)
+            : null;
+        if (ancestor) return;
+        el.classList.add(MASK_CLASS);
+        el.setAttribute(AUTO_ATTR, 'true');
+    }
+
+    function scan(root) {
+        if (!enabled || !document.documentElement) return;
+        ensureStyle();
+        var scope = root && root.nodeType === 1 ? root : document;
+        var elements = [];
+        if (scope.nodeType === 1) elements.push(scope);
+        var descendants = scope.querySelectorAll ? scope.querySelectorAll('*') : [];
+        for (var i = 0; i < descendants.length; i++) elements.push(descendants[i]);
+
+        for (var j = 0; j < elements.length; j++) {
+            var el = elements[j];
+            var tag = String(el.tagName || '').toLowerCase();
+            if (tag === 'script' || tag === 'style' || tag === 'link' || tag === 'meta') continue;
+            if (hasSensitiveIdentity(el) || hasSensitiveText(directText(el))) mark(el);
+        }
+    }
+
+    function queueScan() {
+        if (scanQueued || !enabled) return;
+        scanQueued = true;
+        setTimeout(function () {
+            scanQueued = false;
+            scan(document);
+        }, 0);
+    }
+
+    function setEnabled(next) {
+        next = !!next;
+        if (enabled === next) {
+            if (enabled) queueScan();
+            return;
+        }
+        enabled = next;
+        if (!document.documentElement) return;
+        document.documentElement.classList.toggle('screenshot-privacy-mode', enabled);
+        if (enabled) {
+            ensureStyle();
+            scan(document);
+            if (!observer && typeof MutationObserver !== 'undefined') {
+                observer = new MutationObserver(queueScan);
+                observer.observe(document.documentElement, {
+                    childList: true,
+                    subtree: true,
+                    characterData: true
+                });
+            }
+        } else {
+            if (observer) observer.disconnect();
+            observer = null;
+            scanQueued = false;
+            var marked = document.querySelectorAll('[' + AUTO_ATTR + ']');
+            for (var i = 0; i < marked.length; i++) {
+                marked[i].classList.remove(MASK_CLASS);
+                marked[i].removeAttribute(AUTO_ATTR);
+            }
+        }
+    }
+
+    return {
+        setEnabled: setEnabled,
+        isEnabled: function () { return enabled; },
+        scan: scan
+    };
+})();
+
 BYD.core = {
     deviceId: null,
     pollInterval: null,
@@ -790,6 +956,13 @@ BYD.core = {
             // behaviour on cards downstream.
             const hadData = !!(status.soc || status.range || status.charging);
             if (hadData) this.hasEverHadVehicleData = true;
+
+            // One persisted developer switch controls native and web captures.
+            // Apply before updating fields so newly-written sensitive values
+            // are masked during the same render turn.
+            if (BYD.screenshotPrivacy) {
+                BYD.screenshotPrivacy.setEnabled(!!status.screenshotPrivacyMode);
+            }
 
             // Distance unit preference (from user setting / auto-detect).
             // Announce a real CHANGE: this poll runs at ~1 Hz and silently

--- a/app/src/main/assets/web/shared/core.js
+++ b/app/src/main/assets/web/shared/core.js
@@ -665,7 +665,10 @@ BYD.screenshotPrivacy = (function () {
     var observer = null;
     var scanQueued = false;
     var ipv4 = /(^|[^\d])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?::\d{1,5})?(?!\d)/;
-    var coordinates = /(^|[^\d.])[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}\s*[,;\/]\s*[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}(?![\d.])/;
+    // Charging history renders stored coordinates to three decimal places,
+    // while other screens retain the full precision. Treat both as location
+    // data so a presentation-oriented rounding step cannot bypass the mask.
+    var coordinates = /(^|[^\d.])[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{3,}\s*[,;\/]\s*[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{3,}(?![\d.])/;
     var labelledCoordinate = /\b(?:lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*[+-]?\d{1,3}\.\d{3,}/i;
     var url = /\b(?:https?|wss?):\/\/\S+/i;
     var email = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;

--- a/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
+++ b/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
@@ -3358,7 +3358,10 @@ object UnifiedConfigManager {
      * is the WebView-only locale) so a tunnel-side picker doesn't change
      * the in-car native shell's language and vice versa.
      *
-     * Schema: { "locale": "<bcp47>" | "auto" }
+     * Schema: {
+     *   "locale": "<bcp47>" | "auto",
+     *   "screenshotPrivacyMode": boolean
+     * }
      *
      * The legacy file at /data/local/tmp/.overdrive/locale was unreliable
      * because the app UID can't `mkdir` under /data/local/tmp/, so writes
@@ -3373,6 +3376,21 @@ object UnifiedConfigManager {
     @JvmStatic
     fun setNativeShell(nativeShell: JSONObject): Boolean {
         return updateSection("nativeShell", nativeShell)
+    }
+
+    /**
+     * Whether screenshot privacy masking is active in both the native shell
+     * and daemon-served web UI. This lives in the unified native-shell section
+     * so the app and shell daemon see one persisted value across processes.
+     */
+    @JvmStatic
+    fun isScreenshotPrivacyModeEnabled(): Boolean {
+        return getNativeShell().optBoolean("screenshotPrivacyMode", false)
+    }
+
+    @JvmStatic
+    fun setScreenshotPrivacyModeEnabled(enabled: Boolean): Boolean {
+        return setNativeShell(JSONObject().put("screenshotPrivacyMode", enabled))
     }
 
 

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -1101,6 +1101,16 @@ public class HttpServer {
         JSONObject status = new JSONObject();
         status.put("status", "ok");
         status.put("deviceId", CameraDaemon.getDeviceId());
+        try {
+            status.put(
+                "screenshotPrivacyMode",
+                com.overdrive.app.config.UnifiedConfigManager.isScreenshotPrivacyModeEnabled()
+            );
+        } catch (Exception ignored) {
+            // A status response must remain available even if unified config
+            // is temporarily unreadable during a cross-process replacement.
+            status.put("screenshotPrivacyMode", false);
+        }
 
         // Vehicle-data readiness, surfaced explicitly so the web UI can render
         // a "waiting for vehicle…" state instead of silently leaving every

--- a/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/overdrive/app/ui/MainActivity.kt
@@ -34,6 +34,7 @@ import com.overdrive.app.ui.model.DaemonType
 import com.overdrive.app.ui.model.NavigationRailSwipePolicy
 import com.overdrive.app.ui.model.TunnelDisplayPolicy
 import com.overdrive.app.ui.navigation.NavigationRailCatalog
+import com.overdrive.app.ui.privacy.ScreenshotPrivacyController
 import com.overdrive.app.ui.util.PreferencesManager
 import com.overdrive.app.ui.widget.SwipeExpandableRailScrollView
 import com.overdrive.app.ui.viewmodel.DaemonsViewModel
@@ -119,6 +120,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var statusIndicator: View
     private lateinit var urlStatusDot: View
     private lateinit var btnCopyUrl: ImageButton
+    private var screenshotPrivacyController: ScreenshotPrivacyController? = null
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -211,6 +213,7 @@ class MainActivity : AppCompatActivity() {
         maybeShowPinLock()
 
         initViews()
+        screenshotPrivacyController = ScreenshotPrivacyController(this).also { it.start() }
         setupNavigation(savedInstanceState)
         handleNavigateExtra(intent)
         setupCopyButton()
@@ -1375,6 +1378,11 @@ class MainActivity : AppCompatActivity() {
         
         // Brand version + device id used to live in the drawer header; in the
         // rail-based shell they're surfaced on the Dashboard card instead.
+    }
+
+    /** Apply a persisted screenshot-privacy change without recreating the activity. */
+    fun applyScreenshotPrivacyMode(enabled: Boolean) {
+        screenshotPrivacyController?.setEnabled(enabled)
     }
     
     private fun setupNavigation(savedInstanceState: Bundle?) {
@@ -4165,6 +4173,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        screenshotPrivacyController?.stop()
+        screenshotPrivacyController = null
         navigationRailAnimator?.cancel()
         navigationRailAnimator = null
         if (::navigationRailScroll.isInitialized) {

--- a/app/src/main/java/com/overdrive/app/ui/fragment/settings/SettingsPrivacyFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/settings/SettingsPrivacyFragment.kt
@@ -11,8 +11,10 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
+import com.google.android.material.materialswitch.MaterialSwitch
 import com.overdrive.app.R
 import com.overdrive.app.config.ConfigManager
+import com.overdrive.app.config.UnifiedConfigManager
 import com.overdrive.app.logging.LogLevel
 import com.overdrive.app.logging.LogManager
 import com.overdrive.app.ui.MainActivity
@@ -62,6 +64,7 @@ class SettingsPrivacyFragment : Fragment() {
             (activity as? MainActivity)?.invokeResetDataDialog()
         }
         setupLogLevel(view)
+        setupScreenshotPrivacyMode(view)
         populateStorage(view)
     }
 
@@ -153,6 +156,32 @@ class SettingsPrivacyFragment : Fragment() {
         R.id.btnLogLevelWarn -> LogLevel.WARN
         R.id.btnLogLevelError -> LogLevel.ERROR
         else -> null
+    }
+
+    private fun setupScreenshotPrivacyMode(root: View) {
+        val toggle = root.findViewById<MaterialSwitch>(R.id.switchScreenshotPrivacy) ?: return
+        toggle.isChecked = UnifiedConfigManager.isScreenshotPrivacyModeEnabled()
+
+        var reverting = false
+        toggle.setOnCheckedChangeListener { _, enabled ->
+            if (reverting) return@setOnCheckedChangeListener
+            if (UnifiedConfigManager.setScreenshotPrivacyModeEnabled(enabled)) {
+                (activity as? MainActivity)?.applyScreenshotPrivacyMode(enabled)
+                LogManager.getInstance().info(
+                    TAG,
+                    "Screenshot privacy mode ${if (enabled) "enabled" else "disabled"}"
+                )
+            } else {
+                reverting = true
+                toggle.isChecked = !enabled
+                reverting = false
+                android.widget.Toast.makeText(
+                    requireContext(),
+                    R.string.settings_screenshot_privacy_save_failed,
+                    android.widget.Toast.LENGTH_LONG
+                ).show()
+            }
+        }
     }
 
     private fun populateStorage(root: View) {

--- a/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyController.kt
+++ b/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyController.kt
@@ -5,6 +5,7 @@ import android.graphics.BlurMaskFilter
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.Rect
 import android.graphics.RectF
 import android.view.View
@@ -119,11 +120,17 @@ class ScreenshotPrivacyController(private val activity: Activity) {
             for (rect in maskRects) {
                 canvas.drawRoundRect(rect, radius, radius, edgePaint)
                 canvas.drawRoundRect(rect, radius, radius, fillPaint)
+                val checkpoint = canvas.save()
+                val clipPath = Path().apply {
+                    addRoundRect(rect, radius, radius, Path.Direction.CW)
+                }
+                canvas.clipPath(clipPath)
                 var x = rect.left - rect.height()
                 while (x < rect.right) {
                     canvas.drawLine(x, rect.bottom, x + rect.height(), rect.top, texturePaint)
                     x += stripeStep
                 }
+                canvas.restoreToCount(checkpoint)
             }
         }
 

--- a/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyController.kt
+++ b/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyController.kt
@@ -1,0 +1,212 @@
+package com.overdrive.app.ui.privacy
+
+import android.app.Activity
+import android.graphics.BlurMaskFilter
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.overdrive.app.config.UnifiedConfigManager
+import kotlin.math.max
+
+/**
+ * Draws a non-interactive, fuzzy privacy layer above sensitive native views.
+ *
+ * The source views keep their real values and remain interactive. Only the
+ * pixels presented on screen (and therefore in screenshots) are obscured.
+ * Matching is deliberately centralised so newly-added URL, location, QR,
+ * recording-thumbnail, or camera-preview views inherit the same behaviour.
+ */
+class ScreenshotPrivacyController(private val activity: Activity) {
+    private val contentRoot: ViewGroup by lazy {
+        activity.findViewById(android.R.id.content)
+    }
+    private val overlay = PrivacyOverlayView(activity)
+    private var started = false
+
+    fun start() {
+        if (started) return
+        started = true
+        contentRoot.addView(
+            overlay,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+        setEnabled(UnifiedConfigManager.isScreenshotPrivacyModeEnabled())
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        overlay.setPrivacyEnabled(enabled)
+    }
+
+    fun stop() {
+        if (!started) return
+        overlay.setPrivacyEnabled(false)
+        if (overlay.parent === contentRoot) contentRoot.removeView(overlay)
+        started = false
+    }
+
+    private inner class PrivacyOverlayView(activity: Activity) : View(activity) {
+        private val density = resources.displayMetrics.density
+        private val scanIntervalMs = 350L
+        private val maskRects = ArrayList<RectF>()
+        private var privacyEnabled = false
+
+        private val edgePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.argb(235, 24, 30, 36)
+            style = Paint.Style.FILL
+            maskFilter = BlurMaskFilter(10f * density, BlurMaskFilter.Blur.NORMAL)
+        }
+        private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.rgb(30, 36, 43)
+            style = Paint.Style.FILL
+        }
+        private val texturePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.argb(62, 153, 166, 178)
+            strokeWidth = max(1f, density)
+            style = Paint.Style.STROKE
+        }
+
+        private val scan = object : Runnable {
+            override fun run() {
+                if (!privacyEnabled || !isAttachedToWindow) return
+                refreshRects()
+                postDelayed(this, scanIntervalMs)
+            }
+        }
+
+        init {
+            isClickable = false
+            isFocusable = false
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
+            setLayerType(LAYER_TYPE_SOFTWARE, null)
+        }
+
+        fun setPrivacyEnabled(enabled: Boolean) {
+            if (privacyEnabled == enabled) {
+                if (enabled) refreshRects()
+                return
+            }
+            privacyEnabled = enabled
+            removeCallbacks(scan)
+            visibility = if (enabled) VISIBLE else GONE
+            if (enabled) {
+                bringToFront()
+                refreshRects()
+                postDelayed(scan, scanIntervalMs)
+            } else {
+                maskRects.clear()
+                invalidate()
+            }
+        }
+
+        override fun onDetachedFromWindow() {
+            removeCallbacks(scan)
+            super.onDetachedFromWindow()
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            if (!privacyEnabled) return
+            val radius = 9f * density
+            val stripeStep = 9f * density
+            for (rect in maskRects) {
+                canvas.drawRoundRect(rect, radius, radius, edgePaint)
+                canvas.drawRoundRect(rect, radius, radius, fillPaint)
+                var x = rect.left - rect.height()
+                while (x < rect.right) {
+                    canvas.drawLine(x, rect.bottom, x + rect.height(), rect.top, texturePaint)
+                    x += stripeStep
+                }
+            }
+        }
+
+        private fun refreshRects() {
+            if (width <= 0 || height <= 0) return
+            val rootOnScreen = IntArray(2)
+            getLocationOnScreen(rootOnScreen)
+            val found = ArrayList<RectF>()
+            collectSensitiveViews(contentRoot, rootOnScreen, found)
+
+            found.sortByDescending { it.width() * it.height() }
+            val deduped = ArrayList<RectF>()
+            for (candidate in found) {
+                if (deduped.none { contains(it, candidate) }) deduped.add(candidate)
+            }
+            if (sameRects(maskRects, deduped)) return
+            maskRects.clear()
+            maskRects.addAll(deduped)
+            invalidate()
+        }
+
+        private fun collectSensitiveViews(
+            view: View,
+            rootOnScreen: IntArray,
+            result: MutableList<RectF>
+        ) {
+            if (view === this || view.visibility != VISIBLE || !view.isShown || view.alpha <= 0.02f) {
+                return
+            }
+
+            val resourceName = resourceEntryName(view)
+            val namedSensitive = ScreenshotPrivacyPolicy.isSensitiveResourceName(resourceName)
+            val textSensitive = view is TextView &&
+                ScreenshotPrivacyPolicy.isSensitiveText(view.text)
+            val descriptionSensitive = ScreenshotPrivacyPolicy.isSensitiveText(view.contentDescription) ||
+                ScreenshotPrivacyPolicy.isSensitiveResourceName(view.contentDescription?.toString())
+
+            if (namedSensitive || textSensitive || descriptionSensitive) {
+                visibleRect(view, rootOnScreen)?.let(result::add)
+                // A sensitive container is already covered; avoid stacking a
+                // second blur over each of its children.
+                if (view is ViewGroup) return
+            }
+
+            if (view is ViewGroup) {
+                for (index in 0 until view.childCount) {
+                    collectSensitiveViews(view.getChildAt(index), rootOnScreen, result)
+                }
+            }
+        }
+
+        private fun resourceEntryName(view: View): String? {
+            if (view.id == NO_ID) return null
+            return try {
+                view.resources.getResourceEntryName(view.id)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun visibleRect(view: View, rootOnScreen: IntArray): RectF? {
+            val global = Rect()
+            if (!view.getGlobalVisibleRect(global) || global.isEmpty) return null
+            val pad = 4f * density
+            val left = (global.left - rootOnScreen[0]).toFloat() - pad
+            val top = (global.top - rootOnScreen[1]).toFloat() - pad
+            val right = (global.right - rootOnScreen[0]).toFloat() + pad
+            val bottom = (global.bottom - rootOnScreen[1]).toFloat() + pad
+            return RectF(
+                left.coerceAtLeast(0f),
+                top.coerceAtLeast(0f),
+                right.coerceAtMost(width.toFloat()),
+                bottom.coerceAtMost(height.toFloat())
+            ).takeUnless { it.isEmpty }
+        }
+
+        private fun contains(outer: RectF, inner: RectF): Boolean =
+            outer.left <= inner.left && outer.top <= inner.top &&
+                outer.right >= inner.right && outer.bottom >= inner.bottom
+
+        private fun sameRects(a: List<RectF>, b: List<RectF>): Boolean {
+            if (a.size != b.size) return false
+            return a.indices.all { a[it] == b[it] }
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyPolicy.kt
+++ b/app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyPolicy.kt
@@ -1,0 +1,56 @@
+package com.overdrive.app.ui.privacy
+
+/** Pure matching policy shared by the native privacy overlay and unit tests. */
+object ScreenshotPrivacyPolicy {
+    private val ipv4 = Regex(
+        """(?<!\d)(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?::\d{1,5})?(?!\d)"""
+    )
+    private val coordinates = Regex(
+        """(?<![\d.])[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}\s*[,;/]\s*[+-]?(?:\d{1,2}|1[0-7]\d|180)\.\d{4,}(?![\d.])"""
+    )
+    private val labelledCoordinate = Regex(
+        """(?i)\b(?:lat(?:itude)?|lon(?:gitude)?|lng)\s*[:=]\s*[+-]?\d{1,3}\.\d{3,}"""
+    )
+    private val url = Regex("""(?i)\b(?:https?|wss?)://\S+""")
+    private val email = Regex("""(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b""")
+
+    private val sensitiveResourceTokens = listOf(
+        "qrcode",
+        "currenturl",
+        "tunnelurl",
+        "remoteurl",
+        "deviceid",
+        "ipaddress",
+        "latitude",
+        "longitude",
+        "coordinates",
+        "location",
+        "address",
+        "thumbnail",
+        "videoplayer",
+        "camerapreview",
+        "cameraimage",
+        "snapshot",
+        "platenumber",
+        "licenseplate"
+    )
+
+    fun isSensitiveText(value: CharSequence?): Boolean {
+        val text = value?.toString()?.trim().orEmpty()
+        if (text.isEmpty()) return false
+        return ipv4.containsMatchIn(text) ||
+            coordinates.containsMatchIn(text) ||
+            labelledCoordinate.containsMatchIn(text) ||
+            url.containsMatchIn(text) ||
+            email.containsMatchIn(text)
+    }
+
+    fun isSensitiveResourceName(resourceName: String?): Boolean {
+        val normalized = resourceName
+            ?.lowercase()
+            ?.filter { it.isLetterOrDigit() }
+            .orEmpty()
+        if (normalized.isEmpty()) return false
+        return normalized.contains("qr") || sensitiveResourceTokens.any(normalized::contains)
+    }
+}

--- a/app/src/main/res/layout/fragment_settings_privacy.xml
+++ b/app/src/main/res/layout/fragment_settings_privacy.xml
@@ -315,6 +315,71 @@
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- ============== DEVELOPER TOOLS ============== -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/section_overline_bottom"
+            android:letterSpacing="0.06"
+            android:text="@string/settings_privacy_overline_developer_tools"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="@dimen/card_padding_standard">
+
+                <ImageView
+                    android:layout_width="@dimen/card_icon_standard"
+                    android:layout_height="@dimen/card_icon_standard"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_security_lock"
+                    app:tint="?attr/colorPrimary" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="14dp"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/settings_screenshot_privacy_title"
+                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                        android:textColor="?attr/colorOnSurface" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@string/settings_screenshot_privacy_body"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+                </LinearLayout>
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/switchScreenshotPrivacy"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:contentDescription="@string/settings_screenshot_privacy_title" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
         <!-- ============== RESET ============== -->
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1288,6 +1288,10 @@
          ability to diagnose anything later. -->
     <string name="settings_privacy_log_level_note_verbose">Verbose logging is on — older log history is discarded sooner.</string>
     <string name="settings_privacy_log_level_note_quiet">Most logging is suppressed — a later fault will be harder to diagnose.</string>
+    <string name="settings_privacy_overline_developer_tools">DEVELOPER TOOLS</string>
+    <string name="settings_screenshot_privacy_title">Screenshot privacy mode</string>
+    <string name="settings_screenshot_privacy_body">Adds a fuzzy cover over IP addresses, URLs, coordinates, locations, QR codes, recording thumbnails, and camera previews in the native and web interfaces. This is a visual aid; always review screenshots before sharing.</string>
+    <string name="settings_screenshot_privacy_save_failed">Could not save screenshot privacy mode.</string>
 
     <!-- Settings → Security pane copy + PIN unlock screen.
          The lock guards the OverDrive UI only. Cam daemon, AccSentry,

--- a/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
@@ -42,6 +42,13 @@ public class ScreenshotPrivacyModeAssetTest {
     }
 
     @Test
+    public void roundedChargingCoordinatesAreStillSensitive() throws IOException {
+        String core = readRepositoryFile("app/src/main/assets/web/shared/core.js");
+
+        assertTrue(core.contains("\\.\\d{3,}\\s*[,;\\/]\\s*"));
+    }
+
+    @Test
     public void changedPrPagesAllLoadTheSharedCore() throws IOException {
         assertTrue(readRepositoryFile("app/src/main/assets/web/local/index.html")
                 .contains("../shared/core.js"));

--- a/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
@@ -49,13 +49,21 @@ public class ScreenshotPrivacyModeAssetTest {
     }
 
     @Test
-    public void changedPrPagesAllLoadTheSharedCore() throws IOException {
-        assertTrue(readRepositoryFile("app/src/main/assets/web/local/index.html")
-                .contains("../shared/core.js"));
-        assertTrue(readRepositoryFile("app/src/main/assets/web/local/events.html")
-                .contains("../shared/core.js"));
-        assertTrue(readRepositoryFile("app/src/main/assets/web/local/charging.html")
-                .contains("../shared/core.js"));
+    public void allCoreConsumersLoadThePrivacyBundleVersion() throws IOException {
+        String[] pages = {
+                "about.html", "abrp.html", "automations.html", "byd-cloud.html",
+                "charging.html", "communicate.html", "events.html", "index.html",
+                "key-mapping.html", "live-view.html", "login.html", "mqtt.html",
+                "network.html", "notifications.html", "performance.html",
+                "recording.html", "road-sense.html", "seat-positions.html",
+                "surveillance.html", "telegram.html", "trips.html",
+                "vehicle-control.html"
+        };
+        for (String page : pages) {
+            assertTrue(page, readRepositoryFile(
+                    "app/src/main/assets/web/local/" + page)
+                    .contains("../shared/core.js?v=20"));
+        }
     }
 
     @Test

--- a/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
@@ -51,6 +51,17 @@ public class ScreenshotPrivacyModeAssetTest {
                 .contains("../shared/core.js"));
     }
 
+    @Test
+    public void nativeTextureIsClippedToEachSensitiveView() throws IOException {
+        String controller = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyController.kt");
+
+        int clip = controller.indexOf("canvas.clipPath(clipPath)");
+        int stripe = controller.indexOf("canvas.drawLine(");
+        int restore = controller.indexOf("canvas.restoreToCount(checkpoint)");
+        assertTrue(clip >= 0 && stripe > clip && restore > stripe);
+    }
+
     private static String readRepositoryFile(String relativePath) throws IOException {
         Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
         while (current != null) {

--- a/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
@@ -33,7 +33,8 @@ public class ScreenshotPrivacyModeAssetTest {
                 "app/src/main/java/com/overdrive/app/server/HttpServer.java");
         String core = readRepositoryFile("app/src/main/assets/web/shared/core.js");
 
-        assertTrue(server.contains("status.put(\n                \"screenshotPrivacyMode\""));
+        assertTrue(server.contains("\"screenshotPrivacyMode\""));
+        assertTrue(server.contains("isScreenshotPrivacyModeEnabled()"));
         assertTrue(core.contains("BYD.screenshotPrivacy = (function ()"));
         assertTrue(core.contains("setEnabled(!!status.screenshotPrivacyMode)"));
         assertTrue(core.contains("new MutationObserver(queueScan)"));

--- a/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
+++ b/app/src/test/java/com/overdrive/app/ui/ScreenshotPrivacyModeAssetTest.java
@@ -1,0 +1,68 @@
+package com.overdrive.app.ui;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/** Guards the cross-process and cross-surface screenshot privacy wiring. */
+public class ScreenshotPrivacyModeAssetTest {
+
+    @Test
+    public void settingPersistsInUnifiedNativeShellConfig() throws IOException {
+        String config = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt");
+        String fragment = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/ui/fragment/settings/SettingsPrivacyFragment.kt");
+        String layout = readRepositoryFile(
+                "app/src/main/res/layout/fragment_settings_privacy.xml");
+
+        assertTrue(config.contains("setScreenshotPrivacyModeEnabled"));
+        assertTrue(config.contains("\"screenshotPrivacyMode\""));
+        assertTrue(fragment.contains("applyScreenshotPrivacyMode(enabled)"));
+        assertTrue(layout.contains("@+id/switchScreenshotPrivacy"));
+    }
+
+    @Test
+    public void daemonStatusDrivesOneSharedWebMasker() throws IOException {
+        String server = readRepositoryFile(
+                "app/src/main/java/com/overdrive/app/server/HttpServer.java");
+        String core = readRepositoryFile("app/src/main/assets/web/shared/core.js");
+
+        assertTrue(server.contains("status.put(\n                \"screenshotPrivacyMode\""));
+        assertTrue(core.contains("BYD.screenshotPrivacy = (function ()"));
+        assertTrue(core.contains("setEnabled(!!status.screenshotPrivacyMode)"));
+        assertTrue(core.contains("new MutationObserver(queueScan)"));
+        assertTrue(core.contains("data-screenshot-private"));
+    }
+
+    @Test
+    public void changedPrPagesAllLoadTheSharedCore() throws IOException {
+        assertTrue(readRepositoryFile("app/src/main/assets/web/local/index.html")
+                .contains("../shared/core.js"));
+        assertTrue(readRepositoryFile("app/src/main/assets/web/local/events.html")
+                .contains("../shared/core.js"));
+        assertTrue(readRepositoryFile("app/src/main/assets/web/local/charging.html")
+                .contains("../shared/core.js"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path current = Paths.get(System.getProperty("user.dir")).toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+            }
+            Path fromModule = current.resolve(relativePath.replaceFirst("^app/", ""));
+            if (Files.isRegularFile(fromModule)) {
+                return new String(Files.readAllBytes(fromModule), StandardCharsets.UTF_8);
+            }
+            current = current.getParent();
+        }
+        throw new AssertionError("Could not locate repository file: " + relativePath);
+    }
+}

--- a/app/src/test/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyPolicyTest.kt
+++ b/app/src/test/java/com/overdrive/app/ui/privacy/ScreenshotPrivacyPolicyTest.kt
@@ -1,0 +1,33 @@
+package com.overdrive.app.ui.privacy
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScreenshotPrivacyPolicyTest {
+    @Test
+    fun masksNetworkAddressesUrlsAndCoordinates() {
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveText("192.168.50.251:5555"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveText("https://private.example.test/dashboard"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveText("51.507351, -0.127758"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveText("Latitude: 51.507351"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveText("owner@example.test"))
+    }
+
+    @Test
+    fun doesNotMaskOrdinaryVehicleMetrics() {
+        assertFalse(ScreenshotPrivacyPolicy.isSensitiveText("100% state of charge"))
+        assertFalse(ScreenshotPrivacyPolicy.isSensitiveText("244 mi · SOH 98%"))
+        assertFalse(ScreenshotPrivacyPolicy.isSensitiveText("Version 36.6"))
+    }
+
+    @Test
+    fun masksKnownPrivateViewRolesWithoutPageSpecificWiring() {
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveResourceName("tvCurrentUrl"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveResourceName("ivQrCode"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveResourceName("ivThumbnail"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveResourceName("tvLocation"))
+        assertTrue(ScreenshotPrivacyPolicy.isSensitiveResourceName("cameraPreview"))
+        assertFalse(ScreenshotPrivacyPolicy.isSensitiveResourceName("tvBatteryPercent"))
+    }
+}


### PR DESCRIPTION
## Summary

- add an opt-in **Screenshot privacy mode** switch under **Settings → Privacy & data → Developer tools**
- persist the setting in shared configuration and keep native and web interfaces synchronised
- apply one native policy above app content to cover URLs/IPs, coordinates, email, QR/device identity, maps/locations/addresses, camera and recording imagery, and number-plate content without changing underlying values/actions
- apply the same policy in the shared web runtime, including dynamic mutation tracking and an explicit data-screenshot-private component hook
- use opaque fuzzy striped masks clipped to rounded bounds rather than a reversible visual blur
- cache-bust the privacy-aware shared core on every current web page, including pages added upstream after the original PR

## Why

OverDrive screenshots routinely include a private dashboard address, QR/device identity, exact charging coordinates, and recording/camera imagery. Manually editing every capture is slow and easy to get wrong.

## Impact

The mode is off by default for normal use. When enabled, it provides consistent source-level screenshot preparation across native and web surfaces while leaving the covered data and controls unchanged.

## Current rebase validation — 24 August 2026

- rebased directly onto main 79b56e602ca2871d435e08e189e0b890967a0ebf
- exact PR head: 8cafe1fe9618601e4245fc270810592fdd49c4c4
- focused privacy policy and native/web wiring tests pass, including all current core.js consumers
- assembleDebug passes; ARM64 debug APK SHA-256: 6C4968E9603532A392DCF934C39A8CD69D968672025E41B664FBD2E457523DB8
- test and testDebugUnitTest were rerun. On this Windows checkout, clean main currently has 68 failures in each variant; this head has the identical 68-test failure set and zero PR-only failures by exact XML comparison
- a disposable combined candidate with PR #224 also passed all focused tests, matched the clean-main failure set exactly, and assembled successfully at bebdad1d85e745ac3dcc358d3cde8f6009ea9337 (APK SHA-256 A840CE334CF8FDEA830DCB9862B666F7F5A2B72B46C3552AF436E6553F7425DC)

## Historical vehicle evidence — pre-rebase

The earlier aggregate 743354e5687da24d0b273646a3d8fb4db8addbeb passed test, testDebugUnitTest, and assembleDebug with all 104 actions rerun. Its ARM64 APK SHA-256 was 49355A2DC0D19A05CC17B88262FC1984A33A49C68C4500B0C871435AF04F77D8.

On-car 1920 × 1080 testing of that earlier aggregate verified native QR/URL/device masks, web address masks, recording thumbnails, and three-decimal charging coordinates, and closed rounded mask-texture clipping and coordinate gaps before capture.

The rebased head above has not been installed on the vehicle; the car remains on the official Braveheart release. No dashboard redesign changes are included.

## Visual evidence

An unsafe unprotected comparison is deliberately omitted because it would disclose the information this mode is designed to protect.

### Developer setting enabled

![Screenshot privacy setting enabled](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/12105b1b9aaff9411a66314060fe5f5df6d94f3a/docs/pr-evidence/2026-08-12/privacy/settings-enabled.png)

### Sensitive Dashboard fields covered

![Sensitive Dashboard fields covered](https://raw.githubusercontent.com/MetalHepple/Overdrive-release/12105b1b9aaff9411a66314060fe5f5df6d94f3a/docs/pr-evidence/2026-08-12/privacy/dashboard-sensitive-fields-covered.png)