### PR TITLE
Recover the H2 trip store when it closes underneath the daemon

### DIFF
--- a/app/src/main/java/com/overdrive/app/trips/TripDatabase.java
+++ b/app/src/main/java/com/overdrive/app/trips/TripDatabase.java
@@ -153,15 +153,60 @@ public class TripDatabase {
                 reconnect();
                 return connection != null && !connection.isClosed();
             }
-            return true;
+            // isClosed() is not enough. It reports only whether THIS Connection object was
+            // closed on our side; when H2 shuts the DATABASE down underneath us it keeps
+            // returning false while every statement throws 90098 "The database has been
+            // closed". Observed on a BYD Seal head unit on 2026-08-14: the store closed
+            // mid-session and stayed dead for hours until the daemon was restarted. The
+            // failure is near-silent, because every DAO logs its SQLException and returns an
+            // empty result — so GET /api/trips answered `success:true, trips:[]`, anything
+            // derived from trip history (recent consumption, range estimates) went null, and
+            // a real drive was recorded to the telemetry file only, to be rebuilt later by
+            // recoverTripsFromDisk. So probe the store instead of trusting the flag.
+            if (probe()) return true;
+            logger.warn("connection alive but database unusable — forcing a reopen");
+            forceReconnect();
+            return probe();
         } catch (Exception e) {
             logger.error("Connection check failed", e);
-            reconnect();
+            forceReconnect();
             try {
                 return connection != null && !connection.isClosed();
             } catch (Exception e2) {
                 return false;
             }
+        }
+    }
+
+    /**
+     * Cheapest round-trip that actually reaches the store. Embedded H2, so this is
+     * microseconds; the alternative is trusting a client-side flag that lies.
+     */
+    private boolean probe() {
+        Connection c = connection;
+        if (c == null) return false;
+        try (java.sql.Statement st = c.createStatement()) {
+            st.execute("SELECT 1");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Reopen unconditionally. {@link #reconnect()} is a no-op when {@code isClosed()} returns
+     * false, which is exactly the case that needs reopening here, so the handle is dropped
+     * first.
+     */
+    private synchronized void forceReconnect() {
+        Connection old = connection;
+        connection = null;
+        if (old != null) {
+            try { old.close(); } catch (Exception ignored) { }
+        }
+        reconnect();
+        if (connection != null) {
+            logger.info("Trip database reopened after the store closed underneath us");
         }
     }
 


### PR DESCRIPTION
## Problem

`TripDatabase.ensureConnection()` only reconnects when `connection.isClosed()` returns true. That flag is client-side: when H2 shuts the *database* down underneath the process, the `Connection` keeps reporting open while every statement throws `90098 "The database has been closed"`.

The guard therefore passes, the query throws, and each DAO logs its `SQLException` and returns an empty result — so the failure is near-silent:

```
GET /api/trips  ->  {"success":true,"trips":[]}
```

Anything derived from trip history (recent consumption, range estimates) goes null, and a drive is recorded to its telemetry file only, to be rebuilt later by `recoverTripsFromDisk`. Nothing reopens the store until the daemon restarts.

Observed on a BYD Seal head unit on 2026-08-14: the store closed at 14:20 and stayed dead for hours, roughly 2000 failed queries per hour, while the 20 MB `.mv.db` sat intact on disk.

## Change

`ensureConnection()` now probes the store with `SELECT 1` — embedded H2, so microseconds — and on failure drops the handle and reopens. Dropping it first is necessary because `reconnect()` is itself a no-op while `isClosed()` lies.

## What this does not do

**It does not identify the trigger.** Time from open to close varied 105 s – 2243 s, so it is not a timer; nothing called `TripAnalyticsManager.shutdown()`; no H2 or MVStore error preceded it. `cleanupStaleLocks()` deleting a live lock file was the obvious suspect and was tested directly — deleting the lock file does *not* close the store, so that is ruled out rather than merely unconfirmed.

`DB_CLOSE_DELAY=-1` would prevent the close rather than recover from it, but it changes lock lifetime: the store would then need an explicit `SHUTDOWN` on close, and orphaned locks blocking the next daemon start is a failure this code has already been bitten by (see the `DB_CLOSE_ON_EXIT=FALSE` comment). That belongs in its own change.

## Verification

- Normal operation undisturbed: 139 trips readable, recent consumption computing, no change in the trips API.
- `:app:compileDebugJavaWithJavac` clean on this base.
- The recovery path itself has **not** been observed healing a real closure, because the close cannot be forced on demand. It is proven not to disturb normal operation; it is not proven to have healed a live incident.