### PR TITLE
Gate the per-fix location log on isLoggable, not BuildConfig.DEBUG

### DIFF
--- a/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
+++ b/app/src/main/java/com/overdrive/app/services/LocationSidecarService.java
@@ -520,8 +520,13 @@ public class LocationSidecarService extends Service implements LocationListener 
 
             if (isFirstFix) {
                 Log.i(TAG, "First location fix: " + latitude + ", " + longitude);
-            } else if (com.overdrive.app.BuildConfig.DEBUG) {
-                // Individual fixes go to DEBUG; only shown if explicitly requested in logcat.
+            } else if (Log.isLoggable(TAG, Log.DEBUG)) {
+                // Opt-in per fix. The gate has to be isLoggable, not BuildConfig.DEBUG: that
+                // is a compile-time constant which is true for every debug build, so the line
+                // always ran at the provider's 1 Hz, and Log.d reaches logcat regardless —
+                // there was no mechanism behind "only shown if explicitly requested". Enable
+                // at runtime, no reinstall:
+                //   adb shell setprop log.tag.LocationSidecar DEBUG
                 Log.d(TAG, "Location update (moved=" + String.format("%.1f", distanceMoved) + "m): " + latitude + ", " + longitude);
             }
             


### PR DESCRIPTION
## Problem

The 1 Hz `Location update` line in `LocationSidecarService` is wrapped in `BuildConfig.DEBUG`, with the comment *"only shown if explicitly requested in logcat"*. There is no mechanism behind that: `BuildConfig.DEBUG` is a compile-time constant that is true for every debug build, so the line always runs, and `Log.d` reaches logcat regardless.

## Change

`Log.isLoggable(TAG, Log.DEBUG)` is the check that matches the stated intent. It is false by default and can be turned on at runtime with no reinstall:

```
adb shell setprop log.tag.LocationSidecar DEBUG
```

`TAG` is 15 characters, inside the 23-character limit for a `log.tag.*` property name.

## Scope, honestly

This does **not** meaningfully improve logcat retention. Measured on a BYD Seal head unit, the system emits roughly 400 lines/second on its own, so the stock 256 KiB main buffer holds about 17 seconds of history either way — `logcat -G 16M` is what actually helps there. Worth changing because the gate was broken, not because it fixes diagnosability.

`:app:compileDebugJavaWithJavac` clean on this base.