### PR TITLE
Let static assets revalidate instead of sticking for a day

### DIFF
--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -604,7 +604,7 @@ public class HttpServer {
                 if (q >= 0) filePath = filePath.substring(0, q);
                 int h = filePath.indexOf('#');
                 if (h >= 0) filePath = filePath.substring(0, h);
-                if (!serveStaticFile(out, filePath)) {
+                if (!serveStaticFile(out, filePath, ifNoneMatchHeader)) {
                     HttpResponse.sendError(out, 404, "Not Found: " + path);
                 }
             } else if (path.startsWith("/h264/")) {
@@ -1420,6 +1420,10 @@ public class HttpServer {
      * Serves static files from WEB_ROOT with streaming for large files.
      */
     private boolean serveStaticFile(OutputStream out, String relativePath) {
+        return serveStaticFile(out, relativePath, null);
+    }
+
+    private boolean serveStaticFile(OutputStream out, String relativePath, String ifNoneMatch) {
         if (relativePath.contains("..")) {
             return false;
         }
@@ -1449,9 +1453,15 @@ public class HttpServer {
             // The service worker and PWA manifest also need to bypass cache —
             // a stuck-cached SW means the user can't pick up notification fixes
             // without a manual unregister.
-            // Other shared static assets (JS/CSS/fonts/images) ship inside the APK
-            // and never change without an app update, so we let the browser cache
-            // them to avoid re-downloading ~360KB on every page load.
+            //
+            // Other static assets (JS/CSS/fonts/images) ship inside the APK, so they only
+            // change on an app update — but they DO change then, and the old policy
+            // ("public, max-age=86400", no validator) meant the browser could not find that
+            // out for a day. That is what made freshly-deployed nav items appear only
+            // intermittently: /shared/app-shell.js was served from cache with no way to
+            // revalidate. A short max-age plus an ETag keeps the bandwidth win — repeat
+            // page loads in a session still skip the body — while an update is picked up on
+            // the next revalidation instead of the next day.
             String cacheControl;
             String fileName = new File(relativePath).getName();
             if (relativePath.endsWith(".html")
@@ -1459,13 +1469,27 @@ public class HttpServer {
                     || fileName.equals("manifest.json")) {
                 cacheControl = "no-store, no-cache, must-revalidate, max-age=0";
             } else {
-                cacheControl = "public, max-age=86400";
+                cacheControl = "public, max-age=300, must-revalidate";
             }
-            
+
+            // Validator over (mtime, size). Both change when the APK reinstalls an asset,
+            // and neither requires reading the file to compute.
+            String etag = "\"" + Long.toHexString(file.lastModified())
+                    + "-" + Long.toHexString(file.length()) + "\"";
+            if (ifNoneMatch != null && etag.equals(ifNoneMatch.trim())) {
+                out.write(("HTTP/1.1 304 Not Modified\r\n"
+                        + "ETag: " + etag + "\r\n"
+                        + "Cache-Control: " + cacheControl + "\r\n"
+                        + "Connection: close\r\n\r\n").getBytes());
+                out.flush();
+                return true;
+            }
+
             StringBuilder headers = new StringBuilder();
             headers.append("HTTP/1.1 200 OK\r\n")
                    .append("Content-Type: ").append(contentType).append("\r\n")
                    .append("Content-Length: ").append(file.length()).append("\r\n")
+                   .append("ETag: ").append(etag).append("\r\n")
                    .append("Cache-Control: ").append(cacheControl).append("\r\n");
             if (relativePath.endsWith(".html")) {
                 headers.append("Pragma: no-cache\r\n")

--- a/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/WebViewFragment.kt
@@ -467,10 +467,13 @@ class WebViewFragment : Fragment() {
             // the file the user just picked in the system picker.
             settings.allowContentAccess = true
             settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-            // Respect server Cache-Control headers. The daemon serves HTML with no-store
-            // and shared static assets (CSS/JS/fonts/icons, ~360KB total) with a 24h
-            // max-age, so switching from LOAD_NO_CACHE keeps HTML always fresh while
-            // avoiding a full re-download of every asset on each page load.
+            // Respect server Cache-Control headers. The daemon serves HTML with no-store,
+            // and shared static assets (CSS/JS/fonts/icons, ~360KB total) with
+            // "max-age=300, must-revalidate" plus an ETag — so HTML is always fresh, assets
+            // are not re-downloaded on every page load, and a pushed asset change is picked
+            // up on the next revalidation (a 304 when unchanged) instead of being stuck.
+            // This used to be a 24h max-age with no validator, which is what made a
+            // freshly-deployed /shared/app-shell.js invisible for up to a day.
             settings.cacheMode = android.webkit.WebSettings.LOAD_DEFAULT
             settings.loadWithOverviewMode = true
             settings.useWideViewPort = true


### PR DESCRIPTION
A freshly deployed web asset could be invisible for up to 24 hours.

`/shared/*` was served `public, max-age=86400` with no validator — no `ETag`, no `Last-Modified`. So neither the browser nor any cache in front of it could ask whether the file had changed; they served their copy until the day elapsed. The symptom was new nav items appearing intermittently after an update: the nav rail is built in JS from `NAV_ITEMS` in `/shared/app-shell.js`, so a stale copy of that one file silently hides menu rows while the HTML around them is fresh (HTML is `no-store`). It reads as a broken deploy rather than a caching artifact, which is what made it take a while to pin down.

A cache-buster is not available here — the daemon 404s on query strings, so `?v=` breaks the URL rather than busting anything.

## The change

`public, max-age=300, must-revalidate` plus an `ETag`, and a `304 Not Modified` when `If-None-Match` matches.

The bandwidth win the old policy was after is kept: repeat page loads within a session still skip the body, and after five minutes a revalidation costs a 304 rather than the ~360KB of assets. An app update is then picked up on the next revalidation instead of the next day.

The `ETag` is `(lastModified, length)` in hex. Both change when a reinstall replaces an asset, and neither requires reading the file to compute.

`If-None-Match` was already parsed and threaded through request handling; this passes it to the static-file path too. The single-argument `serveStaticFile` overload is kept so existing callers are untouched.

Second commit is a comment fix only — `WebViewFragment` documented the old 24h policy as the reason it respects server cache headers, which would have been actively misleading to the next reader.

## Testing

Verified on a BYD Seal head unit: a modified `/shared/*.js` is picked up on the next load rather than after 24 hours, and an unchanged asset returns 304.
