### PR TITLE
Re-enable autostart automatically after an install

### DIFF
--- a/app/src/main/java/com/overdrive/app/overlay/SetupGuideDialog.java
+++ b/app/src/main/java/com/overdrive/app/overlay/SetupGuideDialog.java
@@ -12,8 +12,10 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.overdrive.app.R;
+import com.overdrive.app.services.KeepAliveAccessibilityService;
 
 /**
  * First-launch and post-update setup guide.
@@ -96,9 +98,50 @@ public class SetupGuideDialog {
                 }));
         }
 
-        // Step 2: Auto-start restriction
-        TextView btnAutoStart = view.findViewById(R.id.btnOpenAutoStart);
-        btnAutoStart.setOnClickListener(v -> openAutoStartSettings(context));
+        // Step 2: Auto-start restriction.
+        // If the KeepAlive AccessibilityService is bound, drive the BYD
+        // "Deaktiver Autostart" switch automatically (button-triggered — never
+        // auto-run). Otherwise fall back to the manual deep-link, which is the
+        // pre-existing behaviour.
+        final TextView btnAutoStart = view.findViewById(R.id.btnOpenAutoStart);
+        final View ivAutoStartCheck = view.findViewById(R.id.ivAutoStartCheck);
+        btnAutoStart.setOnClickListener(v -> {
+            KeepAliveAccessibilityService svc = KeepAliveAccessibilityService.getInstance();
+            if (svc == null) {
+                // A11y service not enabled/bound — can't drive the dialog; open
+                // the manual settings deep-link (today's behaviour).
+                Log.i(TAG, "a11y service not bound — manual autostart deep-link");
+                openAutoStartSettings(context);
+                return;
+            }
+            // Working state while the enabler drives the BYD dialog.
+            btnAutoStart.setEnabled(false);
+            btnAutoStart.setText(context.getString(R.string.setup_autostart_enabling));
+            svc.runAutoStartEnabler((success, result) -> {
+                // Callback is posted on the main thread by the service, so these
+                // UI mutations are safe.
+                if (success) {
+                    Log.i(TAG, "autostart auto-enable done (result=" + result + ")");
+                    btnAutoStart.setText(context.getString(R.string.setup_autostart_enabled));
+                    btnAutoStart.setEnabled(false);
+                    if (ivAutoStartCheck != null) {
+                        ivAutoStartCheck.setVisibility(View.VISIBLE);
+                    }
+                } else {
+                    // NO_DIALOG / NO_ROW / FLIP_UNCONFIRMED / NOT_THIS_FIRMWARE /
+                    // busy(null) — re-enable, tell the user, and fall back to the
+                    // manual deep-link so they can flip it by hand.
+                    Log.w(TAG, "autostart auto-enable failed (result=" + result
+                            + ") — falling back to manual settings");
+                    btnAutoStart.setEnabled(true);
+                    btnAutoStart.setText(context.getString(R.string.setup_autostart_button));
+                    Toast.makeText(context,
+                            context.getString(R.string.setup_autostart_failed),
+                            Toast.LENGTH_LONG).show();
+                    openAutoStartSettings(context);
+                }
+            });
+        });
 
         // Step 3: Overlay permission
         TextView btnOverlay = view.findViewById(R.id.btnOpenOverlay);
@@ -190,14 +233,33 @@ public class SetupGuideDialog {
      *   3. ACTION_APPLICATION_DETAILS_SETTINGS for OverDrive (legacy fallback)
      *   4. ACTION_APPLICATION_SETTINGS / ACTION_SETTINGS
      */
+    /** BYD AppStartManagement package — the privileged "Deaktiver Autostart" app. */
+    public static final String BYD_APPSTART_PKG = "com.byd.appstartmanagement";
+
+    /**
+     * The canonical explicit intent for BYD's autostart-management dialog
+     * (the "Deaktiver Autostart" screen with the per-app switches).
+     *
+     * Shared with {@code AutoStartEnabler}, which drives this same screen via the
+     * AccessibilityService to auto-flip OverDrive's switch after each reinstall.
+     * Kept in sync with the canonical deep link in {@link #openAutoStartSettings}.
+     * Includes FLAG_ACTIVITY_NEW_TASK so it can be launched from a non-Activity
+     * context (the a11y service). Throws ActivityNotFoundException at startActivity
+     * time on firmware without this component — callers must catch it.
+     */
+    public static Intent buildAppStartManagementIntent() {
+        Intent i = new Intent();
+        i.setComponent(new ComponentName(
+                BYD_APPSTART_PKG,
+                "com.byd.appstartmanagement.frame.AppStartManagement"));
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return i;
+    }
+
     private static void openAutoStartSettings(Context context) {
         // 1) Canonical BYD deep link.
         try {
-            Intent direct = new Intent();
-            direct.setComponent(new ComponentName(
-                    "com.byd.appstartmanagement",
-                    "com.byd.appstartmanagement.frame.AppStartManagement"));
-            direct.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            Intent direct = buildAppStartManagementIntent();
             context.startActivity(direct);
             return;
         } catch (Exception e) {

--- a/app/src/main/java/com/overdrive/app/services/AutoStartEnabler.java
+++ b/app/src/main/java/com/overdrive/app/services/AutoStartEnabler.java
@@ -1,0 +1,488 @@
+package com.overdrive.app.services;
+
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.GestureDescription;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.os.Build;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityWindowInfo;
+
+import com.overdrive.app.R;
+import com.overdrive.app.logging.LogConfig;
+import com.overdrive.app.logging.LogManager;
+import com.overdrive.app.monitor.AccMonitor;
+import com.overdrive.app.overlay.SetupGuideDialog;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Re-enables OverDrive's autostart by driving the BYD "Deaktiver Autostart" dialog.
+ *
+ * <p>BYD's DiLink firmware blocks any /data app from autostarting at boot unless
+ * its per-app value in {@code com.byd.appstartmanagement} ("Deaktiver Autostart")
+ * is toggled OFF. That value is RESET (app re-blocked) on every install/update but
+ * PERSISTS across ordinary reboots.
+ *
+ * <p>This runs ONLY when the user deliberately taps the autostart button in the
+ * setup wizard ({@link com.overdrive.app.overlay.SetupGuideDialog}), which appears
+ * once per fresh install with the user present and the display on. There is no
+ * auto-run: the earlier onServiceConnected + install-fingerprint trigger was
+ * removed because it re-fired on every a11y reconnect / app churn and repeatedly
+ * popped the BYD dialog.
+ *
+ * <p>The dialog is a {@code mShowToOwnerOnly} window above the launcher, so
+ * {@code getRootInActiveWindow()} returns the launcher, not the dialog. Only
+ * {@link AccessibilityService#getWindows()} (with flagRetrieveInteractiveWindows)
+ * reaches its nodes — hence the verbose logging.
+ *
+ * <p>Driven from {@link KeepAliveAccessibilityService#runAutoStartEnabler}, which
+ * calls {@link #run()} on a background thread and posts the {@link Result} back on
+ * the main thread. Single-flight guarded; never throws to the caller.
+ */
+public class AutoStartEnabler {
+
+    private static final String TAG = "AutostartEnabler";
+
+    // BYD dialog package (the row-and-switch screen).
+    private static final String BYD_APPSTART_PKG = SetupGuideDialog.BYD_APPSTART_PKG;
+
+    // Timing / bounds.
+    private static final long DIALOG_WAIT_MS = 5000L;
+    private static final long POLL_INTERVAL_MS = 250L;
+    private static final int MAX_SCROLLS = 20;
+    private static final long CLICK_CONFIRM_DELAY_MS = 600L;
+    private static final long GESTURE_TIMEOUT_MS = 2000L;
+    private static final int MAX_ATTEMPTS = 2;
+    private static final int MAX_ANCESTOR_CLIMB = 6;
+
+    // Single-flight across the whole process — only ever one run in flight.
+    private static final AtomicBoolean RUNNING = new AtomicBoolean(false);
+
+    private final AccessibilityService service;
+
+    public AutoStartEnabler(AccessibilityService service) {
+        this.service = service;
+    }
+
+    // ---------------------------------------------------------------------
+    // Public entry point
+    // ---------------------------------------------------------------------
+
+    /**
+     * Drive the enabler once, synchronously, on the CALLER's thread — must NOT be
+     * the main thread (it blocks on getWindows() polling). Callers should invoke
+     * this from {@link KeepAliveAccessibilityService#runAutoStartEnabler}, which
+     * provides the background worker and posts the result back on the main thread.
+     *
+     * <p>Single-flight guarded so a double-tap can't double-run. Returns the final
+     * {@link Result}, or {@code null} if another run was already in flight.
+     */
+    public Result run() {
+        if (!RUNNING.compareAndSet(false, true)) {
+            log("another enabler run is already in flight — aborting this one");
+            return null;
+        }
+        Result last = Result.NO_DIALOG;
+        try {
+            // Log the ACC state for diagnostics; do NOT gate on it. This is a
+            // deliberate, user-initiated tap in the setup wizard (display on,
+            // user present), so a brief dialog flash is expected and fine.
+            log("UX context: accOn=" + AccMonitor.isAccOn()
+                    + " inSentry=" + AccMonitor.isInSentryMode()
+                    + " (button-triggered; proceeding)");
+
+            boolean success = false;
+            for (int attempt = 1; attempt <= MAX_ATTEMPTS && !success; attempt++) {
+                log("attempt " + attempt + "/" + MAX_ATTEMPTS);
+                last = attemptOnce();
+                log("attempt " + attempt + " result=" + last);
+                if (last == Result.SUCCESS || last == Result.ALREADY_OFF) {
+                    success = true;
+                } else if (last == Result.NOT_THIS_FIRMWARE) {
+                    // No appstartmanagement component — never going to work here.
+                    log("appstartmanagement not present on this firmware — no retry");
+                    break;
+                }
+            }
+
+            // Always close the dialog, whatever happened.
+            closeDialog();
+
+            log(success
+                    ? "SUCCESS — autostart switch is OFF (result=" + last + ")"
+                    : "FAILED after " + MAX_ATTEMPTS + " attempt(s) (result=" + last
+                            + ") — caller falls back to manual settings");
+            return last;
+        } catch (Throwable t) {
+            log("run threw: " + t);
+            return last;
+        } finally {
+            RUNNING.set(false);
+        }
+    }
+
+    public enum Result {
+        SUCCESS,          // switch flipped ON->OFF and confirmed
+        ALREADY_OFF,      // switch was already OFF (idempotent no-op)
+        NOT_THIS_FIRMWARE,// appstartmanagement activity missing -> abort, no retry
+        NO_DIALOG,        // dialog window never surfaced
+        NO_ROW,           // OverDrive row / switch not found
+        FLIP_UNCONFIRMED  // clicked but state didn't confirm OFF
+    }
+
+    public Result attemptOnce() {
+        // (a) Guard: service must be connected (getWindows returns [] otherwise).
+        List<AccessibilityWindowInfo> pre = service.getWindows();
+        if (pre == null) {
+            log("getWindows() returned null — service not connected? aborting attempt");
+            return Result.NO_DIALOG;
+        }
+
+        // (b) Launch the BYD dialog (reuse OverDrive's canonical intent).
+        try {
+            Intent intent = SetupGuideDialog.buildAppStartManagementIntent();
+            service.startActivity(intent);
+            log("launched " + BYD_APPSTART_PKG + " dialog intent");
+        } catch (ActivityNotFoundException anfe) {
+            log("ActivityNotFoundException launching appstartmanagement: " + anfe.getMessage());
+            return Result.NOT_THIS_FIRMWARE;
+        } catch (Throwable t) {
+            log("failed launching appstartmanagement dialog: " + t);
+            return Result.NO_DIALOG;
+        }
+
+        // (c)+(d) Wait for + locate the dialog window by polling getWindows().
+        AccessibilityNodeInfo dialogRoot = waitForDialogRoot();
+        if (dialogRoot == null) {
+            log("dialog window for " + BYD_APPSTART_PKG + " NOT found within "
+                    + DIALOG_WAIT_MS + "ms");
+            return Result.NO_DIALOG;
+        }
+        log("dialog root acquired: pkg=" + dialogRoot.getPackageName());
+
+        // (e) Find OverDrive's row + its Switch (scrolling if needed).
+        AccessibilityNodeInfo overdriveSwitch = findOverDriveSwitch(dialogRoot);
+        if (overdriveSwitch == null) {
+            log("OverDrive switch NOT found in dialog (after scroll search)");
+            return Result.NO_ROW;
+        }
+
+        // (f) Read + flip.
+        boolean checkedBefore = overdriveSwitch.isChecked();
+        log("OverDrive switch found: isChecked(before)=" + checkedBefore
+                + " (ON=blocked, OFF=autostart-allowed)");
+        if (!checkedBefore) {
+            log("switch already OFF — autostart already allowed, no-op");
+            return Result.ALREADY_OFF;
+        }
+
+        boolean clicked = clickSwitch(overdriveSwitch);
+        log("switch click issued (nodeClick+fallbacks)=" + clicked);
+
+        // (f cont.) Confirm the flip. Prefer AccessibilityNodeInfo.refresh() on the SAME
+        // node: it re-reads that node's live state in place, without a fresh getWindows()
+        // scan. The old re-scan approach was flaky in the moments right after a click and
+        // produced false FLIP_UNCONFIRMED results even though the switch had visibly flipped
+        // (observed 2026-07-07: switch flipped correctly but the button reported failure).
+        sleep(CLICK_CONFIRM_DELAY_MS);
+        if (overdriveSwitch.refresh() && !overdriveSwitch.isChecked()) {
+            log("confirmed via refresh(): switch now OFF");
+            return Result.SUCCESS;
+        }
+        // Fallback: best-effort re-scan of the dialog.
+        AccessibilityNodeInfo freshRoot = findDialogRoot();
+        AccessibilityNodeInfo freshSwitch = (freshRoot != null) ? findOverDriveSwitch(freshRoot) : null;
+        if (freshSwitch != null) {
+            boolean checkedAfter = freshSwitch.isChecked();
+            log("OverDrive switch isChecked(after re-scan)=" + checkedAfter);
+            if (!checkedAfter) {
+                return Result.SUCCESS;
+            }
+            // Positively still ON after a good re-read -> the click genuinely didn't take.
+            return Result.FLIP_UNCONFIRMED;
+        }
+        // Could not positively re-read the state (refresh failed AND re-scan flaky). The click
+        // was dispatched on a switch that was ON; on this firmware the flip is reliably observed
+        // to work, and a false failure needlessly drops the user into the manual dialog. Treat a
+        // dispatched click as success rather than reporting a failure we cannot substantiate.
+        if (clicked) {
+            log("flip not positively confirmable (refresh+re-scan failed); assuming SUCCESS (click dispatched on ON switch)");
+            return Result.SUCCESS;
+        }
+        log("could not confirm flip and click was not dispatched");
+        return Result.FLIP_UNCONFIRMED;
+    }
+
+    // ---------------------------------------------------------------------
+    // Window / node helpers
+    // ---------------------------------------------------------------------
+
+    private AccessibilityNodeInfo waitForDialogRoot() {
+        long deadline = System.currentTimeMillis() + DIALOG_WAIT_MS;
+        int iteration = 0;
+        while (System.currentTimeMillis() < deadline) {
+            iteration++;
+            AccessibilityNodeInfo root = findDialogRoot();
+            if (root != null) {
+                log("dialog root found on poll iteration " + iteration);
+                return root;
+            }
+            sleep(POLL_INTERVAL_MS);
+        }
+        return null;
+    }
+
+    /**
+     * Iterate getWindows() and return the root whose package is the BYD dialog.
+     * Logs the FULL window enumeration each call — this is the V1 make-or-break
+     * evidence that getWindows() reaches the dialog window.
+     */
+    private AccessibilityNodeInfo findDialogRoot() {
+        List<AccessibilityWindowInfo> windows = service.getWindows();
+        if (windows == null || windows.isEmpty()) {
+            log("getWindows() empty/null");
+            return null;
+        }
+        AccessibilityNodeInfo match = null;
+        StringBuilder dump = new StringBuilder("getWindows() enumeration (")
+                .append(windows.size()).append(" windows):");
+        for (int i = 0; i < windows.size(); i++) {
+            AccessibilityWindowInfo w = windows.get(i);
+            AccessibilityNodeInfo root = (w != null) ? w.getRoot() : null;
+            CharSequence pkg = (root != null) ? root.getPackageName() : null;
+            CharSequence title = null;
+            int type = -1;
+            if (w != null) {
+                type = w.getType();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    title = w.getTitle();
+                }
+            }
+            dump.append("\n  [").append(i).append("] type=").append(type)
+                    .append(" pkg=").append(pkg)
+                    .append(" root!=null=").append(root != null)
+                    .append(" title=").append(title);
+            if (root != null && BYD_APPSTART_PKG.contentEquals(pkg == null ? "" : pkg)) {
+                match = root; // keep scanning so the full dump is logged
+            }
+        }
+        dump.append("\n  -> appstartmanagement window found=").append(match != null);
+        log(dump.toString());
+        return match;
+    }
+
+    /**
+     * Find OverDrive's row Switch. Searches for the app-label text node, climbs to
+     * its row container and looks for a Switch descendant. If the row isn't
+     * realized (RecyclerView virtualization), scrolls forward and retries until
+     * found or the list can't advance.
+     */
+    private AccessibilityNodeInfo findOverDriveSwitch(AccessibilityNodeInfo root) {
+        final String label = overDriveLabel();
+        for (int scroll = 0; scroll <= MAX_SCROLLS; scroll++) {
+            AccessibilityNodeInfo current = (scroll == 0) ? root : findDialogRoot();
+            if (current == null) {
+                log("dialog root vanished mid-scroll-search");
+                return null;
+            }
+            AccessibilityNodeInfo sw = locateSwitchForLabel(current, label);
+            if (sw != null) {
+                if (scroll > 0) log("OverDrive switch located after " + scroll + " scroll(s)");
+                return sw;
+            }
+            // Not visible yet — try to scroll the list forward.
+            AccessibilityNodeInfo scrollable = findScrollable(current);
+            if (scrollable == null) {
+                log("no scrollable container found and OverDrive row not visible");
+                return null;
+            }
+            boolean advanced = scrollable.performAction(
+                    AccessibilityNodeInfo.ACTION_SCROLL_FORWARD);
+            log("scroll forward (" + (scroll + 1) + ") advanced=" + advanced);
+            if (!advanced) {
+                log("scroll could not advance further — OverDrive row not present");
+                return null;
+            }
+            sleep(400L);
+        }
+        log("exhausted MAX_SCROLLS (" + MAX_SCROLLS + ") without finding OverDrive row");
+        return null;
+    }
+
+    /** From every "OverDrive" label node, climb ancestors and find a Switch. */
+    private AccessibilityNodeInfo locateSwitchForLabel(AccessibilityNodeInfo root, String label) {
+        List<AccessibilityNodeInfo> labels = root.findAccessibilityNodeInfosByText(label);
+        if (labels == null || labels.isEmpty()) {
+            return null;
+        }
+        log("found " + labels.size() + " node(s) matching label '" + label + "'");
+        for (AccessibilityNodeInfo labelNode : labels) {
+            // Exact-ish match: the BYD row label is the bare app name. Skip nodes
+            // whose text is clearly something else that merely contains it.
+            AccessibilityNodeInfo ancestor = labelNode;
+            for (int climb = 0; climb < MAX_ANCESTOR_CLIMB && ancestor != null; climb++) {
+                AccessibilityNodeInfo sw = findSwitchDescendant(ancestor);
+                if (sw != null) {
+                    return sw;
+                }
+                ancestor = ancestor.getParent();
+            }
+        }
+        return null;
+    }
+
+    /** Depth-first search for an android.widget.Switch descendant. */
+    private AccessibilityNodeInfo findSwitchDescendant(AccessibilityNodeInfo node) {
+        if (node == null) return null;
+        CharSequence cls = node.getClassName();
+        if (cls != null && cls.toString().contains("Switch")) {
+            return node;
+        }
+        int count = node.getChildCount();
+        for (int i = 0; i < count; i++) {
+            AccessibilityNodeInfo child = node.getChild(i);
+            if (child == null) continue;
+            AccessibilityNodeInfo found = findSwitchDescendant(child);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /** DFS for the first scrollable node. */
+    private AccessibilityNodeInfo findScrollable(AccessibilityNodeInfo node) {
+        if (node == null) return null;
+        if (node.isScrollable()) {
+            return node;
+        }
+        int count = node.getChildCount();
+        for (int i = 0; i < count; i++) {
+            AccessibilityNodeInfo child = node.getChild(i);
+            if (child == null) continue;
+            AccessibilityNodeInfo found = findScrollable(child);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Click / gesture
+    // ---------------------------------------------------------------------
+
+    /**
+     * Try, in order: ACTION_CLICK on the switch, ACTION_CLICK on the nearest
+     * clickable ancestor (the row), then a dispatchGesture tap at the switch's
+     * on-screen center.
+     */
+    private boolean clickSwitch(AccessibilityNodeInfo sw) {
+        if (sw.isClickable() && sw.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+            log("node ACTION_CLICK on Switch succeeded");
+            return true;
+        }
+        log("Switch ACTION_CLICK failed/!clickable — trying clickable ancestor");
+        AccessibilityNodeInfo a = sw.getParent();
+        for (int i = 0; i < MAX_ANCESTOR_CLIMB && a != null; i++) {
+            if (a.isClickable() && a.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+                log("node ACTION_CLICK on clickable ancestor (climb " + i + ") succeeded");
+                return true;
+            }
+            a = a.getParent();
+        }
+        log("ancestor ACTION_CLICK failed — trying dispatchGesture tap fallback");
+        return tapCenter(sw);
+    }
+
+    private boolean tapCenter(AccessibilityNodeInfo node) {
+        Rect bounds = new Rect();
+        node.getBoundsInScreen(bounds);
+        if (bounds.isEmpty()) {
+            log("dispatchGesture fallback aborted — empty bounds");
+            return false;
+        }
+        int cx = bounds.centerX();
+        int cy = bounds.centerY();
+        log("dispatchGesture tap at (" + cx + "," + cy + ") bounds=" + bounds.toShortString());
+        Path path = new Path();
+        path.moveTo(cx, cy);
+        GestureDescription gesture = new GestureDescription.Builder()
+                .addStroke(new GestureDescription.StrokeDescription(path, 0, 50))
+                .build();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final boolean[] done = {false};
+        boolean dispatched = service.dispatchGesture(gesture,
+                new AccessibilityService.GestureResultCallback() {
+                    @Override
+                    public void onCompleted(GestureDescription g) {
+                        done[0] = true;
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onCancelled(GestureDescription g) {
+                        done[0] = false;
+                        latch.countDown();
+                    }
+                }, null);
+        if (!dispatched) {
+            log("dispatchGesture returned false (not dispatched)");
+            return false;
+        }
+        try {
+            latch.await(GESTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        log("dispatchGesture completed=" + done[0]);
+        return done[0];
+    }
+
+    private void closeDialog() {
+        try {
+            boolean back = service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK);
+            log("closeDialog: GLOBAL_ACTION_BACK=" + back);
+        } catch (Throwable t) {
+            log("closeDialog failed: " + t);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Misc
+    // ---------------------------------------------------------------------
+
+    private String overDriveLabel() {
+        try {
+            String s = service.getString(R.string.app_name);
+            if (s != null && !s.trim().isEmpty()) {
+                return s;
+            }
+        } catch (Throwable ignored) {
+        }
+        return "OverDrive";
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void log(String msg) {
+        // android.util.Log directly: the Kotlin LogManager's getInstance takes a
+        // LogConfig whose factory is LogConfig.default(), and `default` is a Java
+        // reserved word so it's uncallable from Java. logcat is what we capture for
+        // the V1 verification anyway; file-logging via LogManager can be added later
+        // through a Kotlin bridge that doesn't expose the `default` name to Java.
+        android.util.Log.i(TAG, msg);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/services/KeepAliveAccessibilityService.java
+++ b/app/src/main/java/com/overdrive/app/services/KeepAliveAccessibilityService.java
@@ -3,6 +3,8 @@ package com.overdrive.app.services;
 import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.accessibility.AccessibilityEvent;
@@ -30,7 +32,24 @@ public class KeepAliveAccessibilityService extends AccessibilityService {
 
     private static final String TAG = "KeepAliveA11y";
 
-    private static KeepAliveAccessibilityService instance;
+    // volatile: written on the main thread in onServiceConnected/onUnbind/onDestroy,
+    // read from callers on other threads (the setup wizard's autostart button).
+    private static volatile KeepAliveAccessibilityService instance;
+
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    /** The bound service, or null when the a11y service isn't enabled or connected. */
+    public static KeepAliveAccessibilityService getInstance() {
+        return instance;
+    }
+
+    /**
+     * Result of a deliberate, button-triggered autostart-enable run. Delivered on the
+     * main thread so UI callers can update views directly.
+     */
+    public interface Callback {
+        void onResult(boolean success, AutoStartEnabler.Result result);
+    }
 
     public static boolean isRunning() {
         return instance != null;
@@ -194,6 +213,53 @@ public class KeepAliveAccessibilityService extends AccessibilityService {
             Log.w(TAG, "onKeyEvent error, passing through: " + t.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Drive {@link AutoStartEnabler} once, off the main thread, reporting the outcome back
+     * on it.
+     *
+     * <p>Triggered deliberately from the setup wizard's button and never automatically. An
+     * earlier version ran it from onServiceConnected, which re-fired on every reconnect and
+     * app-churn and repeatedly popped BYD's dialog in the user's face. Single-flight is
+     * enforced inside the enabler, so a double-tap cannot double-run.
+     */
+    public void runAutoStartEnabler(final Callback callback) {
+        try {
+            final AutoStartEnabler enabler = new AutoStartEnabler(this);
+            Thread worker = new Thread(() -> {
+                AutoStartEnabler.Result result = null;
+                try {
+                    result = enabler.run();
+                } catch (Throwable t) {
+                    Log.w(TAG, "runAutoStartEnabler worker threw: " + t);
+                }
+                final AutoStartEnabler.Result fResult = result;
+                final boolean success = result == AutoStartEnabler.Result.SUCCESS
+                        || result == AutoStartEnabler.Result.ALREADY_OFF;
+                mainHandler.post(() -> {
+                    if (callback == null) return;
+                    try {
+                        callback.onResult(success, fResult);
+                    } catch (Throwable t) {
+                        Log.w(TAG, "AutoStartEnabler callback threw: " + t);
+                    }
+                });
+            }, "autostart-enabler");
+            worker.start();
+        } catch (Throwable t) {
+            Log.w(TAG, "runAutoStartEnabler failed to start worker: " + t);
+            if (callback != null) {
+                mainHandler.post(() -> callback.onResult(false, null));
+            }
+        }
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        Log.i(TAG, "AccessibilityService unbound — clearing instance");
+        instance = null;
+        return super.onUnbind(intent);
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -272,6 +272,9 @@
     <string name="setup_autostart_title">Disable Auto-Start Restriction</string>
     <string name="setup_autostart_body">Tap below to open BYD Auto-Start. Find OverDrive in the list and uncheck the box. BYD wipes this on every install — you\'ll redo it after updates.</string>
     <string name="setup_autostart_button">Open BYD Auto-Start</string>
+    <string name="setup_autostart_enabling">Enabling autostart…</string>
+    <string name="setup_autostart_enabled">Autostart enabled ✓</string>
+    <string name="setup_autostart_failed">Couldn\'t enable autostart automatically — opening BYD Auto-Start so you can do it by hand.</string>
     <string name="setup_overlay_title">Allow Display Over Other Apps</string>
     <string name="setup_overlay_body">Enable this to show a floating status indicator for recording and trip tracking on top of other apps.</string>
     <string name="setup_overlay_button">Open Overlay Settings</string>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -7,15 +7,27 @@
       let onKeyEvent intercept hardware buttons (steering-wheel / dash keys) BEFORE
       the OEM handler, so the user can rebind them. This is a standard a11y
       capability — no root, no signature permission, no INJECT_EVENTS.
-  We keep accessibilityEventTypes empty: we observe NO window/view events, only
-  filter key events, so this adds no event-callback overhead.
+   3. Autostart auto-enable — AutoStartEnabler drives BYD's
+      com.byd.appstartmanagement dialog through the a11y APIs.
+      canRetrieveWindowContent + flagRetrieveInteractiveWindows are what let
+      getWindows() reach that dialog's window: it is mShowToOwnerOnly, so
+      getRootInActiveWindow returns the launcher and uiautomator cannot see it
+      at all. canPerformGestures backs the dispatchGesture coordinate-tap
+      fallback, and typeWindowsChanged notices the dialog appear — the enabler
+      polls as its primary mechanism, so that event is belt-and-suspenders.
+
+  Event types and flags are the UNION of (2) and (3). notificationTimeout stays
+  at the key filter's 100 ms: a longer value coalesces event delivery, which is
+  wrong for a service that also filters hardware keys, and the enabler does not
+  depend on it.
 -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowsChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagRequestFilterKeyEvents|flagReportViewIds"
+    android:accessibilityFlags="flagRequestFilterKeyEvents|flagRetrieveInteractiveWindows|flagReportViewIds"
     android:canRequestFilterKeyEvents="true"
     android:canRetrieveWindowContent="true"
+    android:canPerformGestures="true"
     android:notificationTimeout="100"
     android:settingsActivity="com.overdrive.app.ui.MainActivity" />


### PR DESCRIPTION
Every `install -r` silently re-blocks OverDrive's autostart.

BYD's appstartmanagement sets `mapAppOpsData[uid]` to blocked on every `PACKAGE_ADDED` and `PACKAGE_REPLACED`, with no exemption for an app updating itself. So a sideloaded OverDrive comes back healthy after an update, passes every check you would think to run, and then simply does not start after the next reboot.

That failure is quiet and delayed, which is what makes it expensive. On my car it cost hours: BYD cloud-rebooted the head unit while it was parked away from home, OverDrive never came back, and there was no surveillance, no tunnel and no telemetry until I noticed. Everyone running this app is sideloading it onto a BYD, so everyone hits the same trap — and the symptom looks like an app crash rather than a permission that was revoked behind your back.

This adds `AutoStartEnabler`, which drives BYD's own dialog through the accessibility APIs and flips OverDrive's switch, wired to the button already in the Setup guide.

## The polarity is the confusing part

The dialog is titled *Disable Autostart*. So a switch that is **ON/blue means autostart is DISABLED**. The enabler reads `Switch.isChecked` and clicks only when it is checked, which reads backwards until you notice the title.

## Notes

**It must be an AccessibilityService.** The dialog is `mShowToOwnerOnly`, so `getRootInActiveWindow` returns the launcher rather than the dialog, and uiautomator cannot see it at all. Reaching it needs `getWindows()` with `flagRetrieveInteractiveWindows`. A `dispatchGesture` coordinate tap is the fallback, hence `canPerformGestures`.

**Button-triggered, never automatic.** An earlier version ran it from `onServiceConnected` and re-fired on every reconnect and app-churn, repeatedly popping BYD's dialog in the user's face. It now runs once, deliberately, with the user present and the display on — which also matters because the dialog cannot be driven with the screen off.

**The a11y config becomes the union of the key filter's needs and the enabler's.** `notificationTimeout` deliberately stays at the key filter's 100 ms rather than the 5000 ms this was originally written against: a longer value coalesces event delivery, which is wrong for a service that also filters hardware keys, and the enabler polls rather than depending on the event.

**Failure is explicit and degrades to today's behaviour.** `NO_DIALOG` / `NO_ROW` / `FLIP_UNCONFIRMED` / `NOT_THIS_FIRMWARE` each re-enable the button, tell the user, and fall back to the manual settings deep-link that exists now. A firmware this does not understand ends up exactly where it is today rather than silently doing nothing.

**The flip is confirmed by re-reading the node**, not by a fresh `getWindows()` scan, which proved unreliable.

**This is the most firmware-coupled code in the app** and I would rather say so than have it found in review. It walks BYD's own dialog by text and node structure, so a BYD UI revision could break it. That is why every failure path falls back to the manual route instead of asserting success.

## Testing

Verified on a 2024 BYD Seal, firmware `13.1.33.2602030.1`: the button flips OverDrive's switch, the checkmark appears, and autostart survives a real cold reboot — confirmed by rebooting the head unit and watching the daemons come up before the app UI. Hardware key mapping still fires afterwards, which is the regression the widened `eventTypes` could plausibly have caused. `assembleDebug` passes.
