### PR TITLE
TunnelLauncher: guard against duplicate cloudflared launches

### DIFF
--- a/app/src/main/java/com/overdrive/app/launcher/TunnelLauncher.kt
+++ b/app/src/main/java/com/overdrive/app/launcher/TunnelLauncher.kt
@@ -16,13 +16,27 @@ class TunnelLauncher(
 ) {
     companion object {
         private const val TAG = "TunnelLauncher"
-        
+
         // Cloudflared paths
         private const val CLOUDFLARED_TMP_PATH = "/data/local/tmp/cloudflared"
         private const val CLOUDFLARED_LOG = "/data/local/tmp/cloudflared.log"
-        
+
         // Process name for identification
         private const val CLOUDFLARED_PROCESS = "cloudflared"
+
+        // Process-wide single-flight guard for cloudflared launches.
+        //
+        // The running-check (`ps | grep cloudflared`) and the spawn are two
+        // separate async ADB round-trips, and cloudflared takes ~1-2s to
+        // appear in `ps`. Multiple launch triggers fire during that window
+        // (boot brings up several AdbDaemonLauncher instances, each with its
+        // own TunnelLauncher), so every check returns "not running" and each
+        // spawns its own cloudflared — observed 3x to the same token on the
+        // 2026-07-06 reboot. A companion (static) flag is shared across all
+        // TunnelLauncher instances in the process, so concurrent requests
+        // collapse to one. It lives in memory only, so an app restart clears
+        // it — it can never wedge launches the way an on-disk lock could.
+        private val launchInProgress = java.util.concurrent.atomic.AtomicBoolean(false)
     }
     
     interface TunnelCallback {
@@ -56,6 +70,29 @@ class TunnelLauncher(
      * NOTE: Cloudflared and Zrok are mutually exclusive - this will kill zrok first.
      */
     fun launchCloudflared(callback: TunnelCallback) {
+        // Single-flight: if a launch is already in flight, drop this duplicate
+        // request instead of racing it into a second cloudflared process.
+        if (!launchInProgress.compareAndSet(false, true)) {
+            logManager.info(TAG, "Cloudflared launch already in progress — skipping duplicate request")
+            callback.onLog("Tunnel launch already in progress")
+            return
+        }
+        // Safety net: never leave the flag stuck if a terminal callback is
+        // missed (e.g. an exception inside a nested ADB callback). 90s is well
+        // beyond the 30-attempt (~30s) URL-wait plus kill/settle delays.
+        pollScheduler.schedule({ launchInProgress.set(false) }, 90, java.util.concurrent.TimeUnit.SECONDS)
+
+        // Clear the flag on every terminal outcome (URL obtained or error),
+        // while passing through non-terminal onLog calls untouched.
+        val guarded = object : TunnelCallback {
+            override fun onLog(message: String) { callback.onLog(message) }
+            override fun onTunnelUrl(url: String) { launchInProgress.set(false); callback.onTunnelUrl(url) }
+            override fun onError(error: String) { launchInProgress.set(false); callback.onError(error) }
+        }
+        launchCloudflaredGuarded(guarded)
+    }
+
+    private fun launchCloudflaredGuarded(callback: TunnelCallback) {
         logManager.info(TAG, "Launching Cloudflared tunnel...")
         callback.onLog("Checking for existing tunnel...")
         


### PR DESCRIPTION
Three `cloudflared` processes ended up running against the same tunnel token after one reboot.

The check for "is it already running" and the spawn are two separate async adb round-trips, and `cloudflared` takes 1–2 seconds to show up in `ps`. Boot brings up several `AdbDaemonLauncher` instances, each with its own `TunnelLauncher`, so every one of them checks inside that window, every check answers "not running", and each spawns its own process. Observed three times over on one reboot.

That matters beyond tidiness: the "already running?" detection greps `ps` for `cloudflared` as a substring, so duplicates confuse it, and multiple clients on one token is not something the tunnel handles gracefully.

## The fix

A process-wide `AtomicBoolean` on the companion object, so concurrent requests across instances collapse to one launch.

Two deliberate choices:

**In memory, not on disk.** An app restart clears it, so a stuck flag can never wedge tunnel launches the way a lockfile could.

**A 90-second safety net** resets the flag in case a terminal callback is missed — for instance an exception thrown inside a nested adb callback. 90s is comfortably past the 30-attempt URL wait plus the kill and settle delays, so it cannot fire early and let a duplicate through.

The callback is wrapped so the flag clears on both terminal outcomes (URL obtained, or error) while non-terminal `onLog` calls pass through untouched.

## Testing

Verified on a BYD Seal head unit across reboots: one `cloudflared` process per boot instead of the three seen before, and the duplicate requests log the skip rather than racing.
