### PR TITLE
Keep GPS tracking while parked so departures start with a warm fix

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -513,6 +513,49 @@ public class CameraDaemon {
     private static java.io.RandomAccessFile lockFile;
     private static java.nio.channels.FileLock fileLock;
 
+    /**
+     * Re-assert secure setting location_mode=3 whenever the system flips it
+     * off (the head unit sets 0 on car-off/standby). Daemon-only: guarded on
+     * uid 2000 (shell), the uid this daemon always runs as and the one allowed
+     * to write secure settings — a defensive no-op anywhere else. Checks every
+     * 60s; logs only on an actual re-assert, not every tick.
+     */
+    private static void startLocationModeKeeper() {
+        if (android.os.Process.myUid() != 2000) {
+            log("LocationModeKeeper: not shell uid, keeper disabled");
+            return;
+        }
+        Thread keeper = new Thread(() -> {
+            while (true) {
+                try {
+                    Process p = Runtime.getRuntime().exec(
+                            new String[]{"settings", "get", "secure", "location_mode"});
+                    String mode;
+                    try (java.io.BufferedReader r = new java.io.BufferedReader(
+                            new java.io.InputStreamReader(p.getInputStream()))) {
+                        mode = r.readLine();
+                    }
+                    p.waitFor();
+                    if (mode != null && !"3".equals(mode.trim())) {
+                        Runtime.getRuntime().exec(
+                                new String[]{"settings", "put", "secure", "location_mode", "3"})
+                                .waitFor();
+                        log("LocationModeKeeper: re-asserted location_mode=3 (was " + mode.trim() + ")");
+                    }
+                } catch (Throwable t) {
+                    // settings binary missing/denied — stay quiet, retry next tick
+                }
+                try {
+                    Thread.sleep(60_000);
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }, "location-mode-keeper");
+        keeper.setDaemon(true);
+        keeper.start();
+    }
+
     public static void main(String[] args) {
         initFileLogging();
 
@@ -571,6 +614,18 @@ public class CameraDaemon {
 
         // Grant all manifest permissions via shell (supplements PermissionBypassContext)
         PermissionGranter.grantAllPermissions(APP_PACKAGE_NAME());
+
+        // Keep Android location enabled so GPS keeps tracking while parked.
+        // The head unit re-asserts location_mode=0 on car-off/standby
+        // transitions, which powers the GNSS chip down: every location
+        // consumer (LocationSidecarService, even the factory nav's
+        // "initializing" wait) then eats a cold time-to-first-fix at the next
+        // drive, and trip-start positions are missing or late. This daemon
+        // runs as shell (uid 2000), which may write secure settings, so it
+        // re-asserts location_mode=3 whenever the system flips it off. The
+        // power cost of continuous GNSS tracking is negligible next to the
+        // surveillance pipeline this daemon already runs.
+        startLocationModeKeeper();
 
         // Global exception handler - NEVER let the daemon die from uncaught exceptions
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {


### PR DESCRIPTION
The head unit sets the secure setting `location_mode` to 0 at car-off, which powers the GNSS chip down. Every departure then starts from a cold receiver, and everything that wants a position waits for it — OverDrive's own location, the trip recorder, and the factory nav's own startup fix too.

This re-asserts `location_mode=3` on a 60-second tick from the daemon, so the system's flip to 0 gets undone and tracking continues while parked. A warm fix is then available from t=0 at the next departure.

**Why a periodic re-assert rather than reacting once to car-off.** The system re-flips the setting rather than honouring a single write, so this is a tug-of-war by necessity rather than by preference — a one-shot write on the car-off event gets reverted.

**Daemon-side only**, because writing that secure setting needs the shell uid, which the app process does not have.

## The trade-off

GNSS stays powered while parked. On a car that already runs surveillance while parked this is marginal, but on a vehicle left standing for weeks it is not free. Worth stating plainly rather than leaving it to be discovered: this trades a small continuous draw for never waiting on a cold fix.

## Testing

Verified on a 2024 BYD Seal: `location_mode` stays at 3 across car-off, and departures start with an immediate fix instead of the previous cold-start wait.
