### PR TITLE
fix(dashboard): vertical gap before custom quick-controls

### DIFF
--- a/app/src/main/assets/web/local/index.html
+++ b/app/src/main/assets/web/local/index.html
@@ -1178,6 +1178,10 @@
             grid-template-columns: repeat(3, minmax(0, 1fr));
         }
 
+        #dashCustomCommands {
+            margin-top: 10px;
+        }
+
         .dash-command {
             min-height: 78px;
             display: flex;


### PR DESCRIPTION
### Problem
On the dashboard, custom **Quick controls** buttons rendered flush against the built-in commands above them — no vertical gap — while the media grid (Live / Recordings / Trips) below already had one.
<img width="607" height="504" alt="Screenshot 2026-08-24 at 15 30 01" src="https://github.com/user-attachments/assets/a1f2a448-c12e-4d2a-87ea-609a1e31c01a" />
### Fix
The custom grid `#dashCustomCommands` had no top margin. Give it the same `margin-top: 10px` the media grid uses, so the three groups are evenly separated:

```
built-in commands
  ↕ 10px
custom quick-controls   ← was flush, now spaced
  ↕ 10px
Live / Recordings / Trips
```

The gap only appears while the grid is visible — it stays `display:none` when there are no custom buttons, so there's no stray space otherwise. One-line CSS change, no markup or JS touched.
