### PR TITLE
Send a place to the factory Telenav navigation

### DIFF
--- a/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
+++ b/app/src/main/java/com/overdrive/app/OverdriveApplication.kt
@@ -57,6 +57,10 @@ class OverdriveApplication : Application() {
         // - SCREEN_OFF receiver registration
         // - Daemon startup
         DaemonKeepaliveService.start(this)
+
+        // App-process listener that binds Telenav's OEM AIDL for the daemon's
+        // HTTP endpoint (the daemon can't bindService itself). Idempotent.
+        com.overdrive.app.telenav.TelenavIpcServer.start(this)
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
+++ b/app/src/main/java/com/overdrive/app/config/UnifiedConfigManager.kt
@@ -2036,7 +2036,40 @@ object UnifiedConfigManager {
     fun getSurveillance(): JSONObject {
         return loadConfig().optJSONObject("surveillance") ?: JSONObject()
     }
-    
+
+    // ---- Deferred "navigate here" (section: deferred_nav) --------------------
+    // A phone/OverDrive "Navigate here" that arrives while the car is off is stored
+    // here and offered as a floating prompt on the next ACC-on. Latest overwrites.
+    fun getDeferredNav(): JSONObject = loadConfig().optJSONObject("deferred_nav") ?: JSONObject()
+
+    fun setPendingNav(name: String, lat: Double, lng: Double, receivedAt: Long): Boolean =
+        updateValues(
+            "deferred_nav",
+            mapOf(
+                "pending" to true,
+                "name" to name,
+                "lat" to lat,
+                "lng" to lng,
+                "receivedAt" to receivedAt,
+            ),
+        )
+
+    fun clearPendingNav(): Boolean = updateValues("deferred_nav", mapOf("pending" to false))
+
+    /** Max age (hours) a queued target is still offered on ACC-on. Default 4. */
+    fun getDeferredNavExpiryHours(): Int = getDeferredNav().optInt("expiryHours", 4).coerceIn(1, 72)
+
+    /** Saved floating-prompt position, or null when never dragged. */
+    fun getNavPromptPos(): Pair<Int, Int>? {
+        val d = getDeferredNav()
+        val x = d.optInt("posX", Int.MIN_VALUE)
+        val y = d.optInt("posY", Int.MIN_VALUE)
+        return if (x == Int.MIN_VALUE || y == Int.MIN_VALUE) null else x to y
+    }
+
+    fun setNavPromptPos(x: Int, y: Int): Boolean =
+        updateValues("deferred_nav", mapOf("posX" to x, "posY" to y))
+
     /**
      * Get the surveillance schedule from config.
      * Returns a SurveillanceSchedule loaded from the surveillance section.

--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -572,6 +572,15 @@ public class CameraDaemon {
         // Grant all manifest permissions via shell (supplements PermissionBypassContext)
         PermissionGranter.grantAllPermissions(APP_PACKAGE_NAME());
 
+        // Deferred "navigate here": watch for ACC-on to offer a target that a phone/on-car
+        // Navigate queued while the car was off. Self-contained (own ACC watcher); guarded
+        // so it can never take the daemon down.
+        try {
+            com.overdrive.app.telenav.DeferredNavManager.start();
+        } catch (Throwable t) {
+            log("DeferredNavManager start failed: " + t.getMessage());
+        }
+
         // Global exception handler - NEVER let the daemon die from uncaught exceptions
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             if (!(throwable instanceof ThreadDeath)) {

--- a/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
+++ b/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
@@ -2831,6 +2831,18 @@ open class RoadSenseMapActivity : AppCompatActivity() {
                 routeToResult(SearchResult(label, lat, lng)) // explicit navigate → destination
             }
 
+        // Hand the POI to the car's built-in navigation (factory nav via the Telenav bridge).
+        view.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnPoiCarNavNavigate)
+            ?.setOnClickListener {
+                sheet.dismiss()
+                sendToCarNav(SearchResult(label, lat, lng), navigate = true)
+            }
+        view.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnPoiCarNavSave)
+            ?.setOnClickListener {
+                sheet.dismiss()
+                sendToCarNav(SearchResult(label, lat, lng), navigate = false)
+            }
+
         sheet.setContentView(view)
         sheet.show()
     }
@@ -4048,6 +4060,16 @@ open class RoadSenseMapActivity : AppCompatActivity() {
         }
         findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRouteStart)
             ?.setOnClickListener { startSelectedRoute() }
+
+        // Hand the destination to the car's built-in navigation instead of OverDrive's route.
+        findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRouteCarNavNavigate)
+            ?.setOnClickListener {
+                routeStops.lastOrNull()?.let { dest -> sendToCarNav(dest, navigate = true) }
+            }
+        findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRouteCarNavSave)
+            ?.setOnClickListener {
+                routeStops.lastOrNull()?.let { dest -> sendToCarNav(dest, navigate = false) }
+            }
 
         // Build the ordered trip itinerary (origin → stops → destination + an
         // "Add stop" row) above the route candidates.

--- a/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
+++ b/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
@@ -4110,6 +4110,21 @@ open class RoadSenseMapActivity : AppCompatActivity() {
             skipCollapsed = true
             state = com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
         }
+
+        // Cap the scrollable middle so the whole sheet fits the short landscape
+        // screen: with many route candidates the content would otherwise push the
+        // sheet past the screen and the fixed header (with the car-nav icon) off the
+        // top. Capping lets the middle scroll while the header + Start stay pinned.
+        // Short content (a couple of routes) stays under the cap → sheet stays compact.
+        findViewById<androidx.core.widget.NestedScrollView>(R.id.routeSheetScroll)?.let { scroll ->
+            scroll.post {
+                val cap = (resources.displayMetrics.heightPixels * 0.45f).toInt()
+                if (scroll.height > cap) {
+                    scroll.layoutParams = scroll.layoutParams.apply { height = cap }
+                    scroll.requestLayout()
+                }
+            }
+        }
     }
 
     /** A route-options row (or its map line) was selected → re-highlight + remember. */

--- a/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
+++ b/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
@@ -2893,6 +2893,40 @@ open class RoadSenseMapActivity : AppCompatActivity() {
      * never have its title/result clobbered by the older callback (and the [alive]
      * guard drops a callback that lands after dismissal).
      */
+    /** Send a place to the car's built-in navigation (factory nav) — navigate or save-favourite. */
+    private fun sendToCarNav(result: SearchResult, navigate: Boolean) {
+        val name = result.label
+        val lat = result.lat
+        val lng = result.lng
+        android.widget.Toast.makeText(this, R.string.carnav_sending, android.widget.Toast.LENGTH_SHORT).show()
+        Thread {
+            try {
+                if (navigate) {
+                    val ok = com.overdrive.app.telenav.TelenavActions.navigate(applicationContext, name, lat, lng)
+                    runOnUiThread {
+                        android.widget.Toast.makeText(
+                            this,
+                            if (ok) R.string.carnav_navigate_ok else R.string.carnav_navigate_fail,
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                } else {
+                    com.overdrive.app.telenav.TelenavActions.addFavorite(applicationContext, name, lat, lng, "Normal")
+                    runOnUiThread {
+                        android.widget.Toast.makeText(this, R.string.carnav_saved_ok, android.widget.Toast.LENGTH_SHORT).show()
+                    }
+                }
+            } catch (e: Exception) {
+                runOnUiThread {
+                    android.widget.Toast.makeText(
+                        this, getString(R.string.carnav_failed, e.message ?: ""),
+                        android.widget.Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }.start()
+    }
+
     private fun showPlaceSheet(
         result: SearchResult,
         isDroppedPin: Boolean,
@@ -2955,6 +2989,16 @@ open class RoadSenseMapActivity : AppCompatActivity() {
         view.findViewById<MaterialButton>(R.id.btnPlaceSaveFav).setOnClickListener {
             sheet.dismiss()
             savePlace(SavedPlacesStore.KIND_CUSTOM, current)
+        }
+
+        // Hand the place to the car's built-in navigation (factory nav via Telenav bridge).
+        view.findViewById<MaterialButton>(R.id.btnCarNavNavigate).setOnClickListener {
+            sheet.dismiss()
+            sendToCarNav(current, navigate = true)
+        }
+        view.findViewById<MaterialButton>(R.id.btnCarNavSave).setOnClickListener {
+            sheet.dismiss()
+            sendToCarNav(current, navigate = false)
         }
 
         sheet.setOnDismissListener {

--- a/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
+++ b/app/src/main/java/com/overdrive/app/navmap/RoadSenseMapActivity.kt
@@ -2833,9 +2833,8 @@ open class RoadSenseMapActivity : AppCompatActivity() {
 
         // Hand the POI to the car's built-in navigation (factory nav via the Telenav bridge).
         view.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnPoiCarNavNavigate)
-            ?.setOnClickListener {
-                sheet.dismiss()
-                sendToCarNav(SearchResult(label, lat, lng), navigate = true)
+            ?.setOnClickListener { anchor ->
+                showCarNavMenu(anchor, SearchResult(label, lat, lng), includeSave = false) { sheet.dismiss() }
             }
         view.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnPoiCarNavSave)
             ?.setOnClickListener {
@@ -2905,8 +2904,38 @@ open class RoadSenseMapActivity : AppCompatActivity() {
      * never have its title/result clobbered by the older callback (and the [alive]
      * guard drops a callback that lands after dismissal).
      */
+    /**
+     * Popup offering the three car-navigation actions for a place. Anchored on the tapped
+     * control so it stays visible regardless of sheet height (the earlier bottom-of-sheet
+     * buttons scrolled off the head unit's short landscape screen). [includeSave] adds the
+     * favourite action for surfaces that lack a separate Save control (the route sheet's
+     * header). [onChosen] runs before the action — used to dismiss the host sheet.
+     */
+    private fun showCarNavMenu(
+        anchor: View,
+        result: SearchResult?,
+        includeSave: Boolean,
+        onChosen: () -> Unit = {},
+    ) {
+        val target = result ?: return
+        val menu = androidx.appcompat.widget.PopupMenu(this, anchor)
+        menu.menu.add(0, 0, 0, getString(R.string.carnav_menu_navigate_here))
+        menu.menu.add(0, 1, 1, getString(R.string.carnav_menu_add_stop))
+        if (includeSave) menu.menu.add(0, 2, 2, getString(R.string.carnav_save_favourite))
+        menu.setOnMenuItemClickListener { item ->
+            onChosen()
+            when (item.itemId) {
+                0 -> sendToCarNav(target, navigate = true, replace = true)   // fresh route
+                1 -> sendToCarNav(target, navigate = true, replace = false)  // add as stop
+                else -> sendToCarNav(target, navigate = false)               // save favourite
+            }
+            true
+        }
+        menu.show()
+    }
+
     /** Send a place to the car's built-in navigation (factory nav) — navigate or save-favourite. */
-    private fun sendToCarNav(result: SearchResult, navigate: Boolean) {
+    private fun sendToCarNav(result: SearchResult, navigate: Boolean, replace: Boolean = false) {
         val name = result.label
         val lat = result.lat
         val lng = result.lng
@@ -2914,7 +2943,7 @@ open class RoadSenseMapActivity : AppCompatActivity() {
         Thread {
             try {
                 if (navigate) {
-                    val ok = com.overdrive.app.telenav.TelenavActions.navigate(applicationContext, name, lat, lng)
+                    val ok = com.overdrive.app.telenav.TelenavActions.navigate(applicationContext, name, lat, lng, replace)
                     runOnUiThread {
                         android.widget.Toast.makeText(
                             this,
@@ -3004,9 +3033,8 @@ open class RoadSenseMapActivity : AppCompatActivity() {
         }
 
         // Hand the place to the car's built-in navigation (factory nav via Telenav bridge).
-        view.findViewById<MaterialButton>(R.id.btnCarNavNavigate).setOnClickListener {
-            sheet.dismiss()
-            sendToCarNav(current, navigate = true)
+        view.findViewById<MaterialButton>(R.id.btnCarNavNavigate).setOnClickListener { anchor ->
+            showCarNavMenu(anchor, current, includeSave = false) { sheet.dismiss() }
         }
         view.findViewById<MaterialButton>(R.id.btnCarNavSave).setOnClickListener {
             sheet.dismiss()
@@ -4062,14 +4090,10 @@ open class RoadSenseMapActivity : AppCompatActivity() {
             ?.setOnClickListener { startSelectedRoute() }
 
         // Hand the destination to the car's built-in navigation instead of OverDrive's route.
-        findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRouteCarNavNavigate)
-            ?.setOnClickListener {
-                routeStops.lastOrNull()?.let { dest -> sendToCarNav(dest, navigate = true) }
-            }
-        findViewById<com.google.android.material.button.MaterialButton>(R.id.btnRouteCarNavSave)
-            ?.setOnClickListener {
-                routeStops.lastOrNull()?.let { dest -> sendToCarNav(dest, navigate = false) }
-            }
+        // In the header (always visible) so it never scrolls off the short landscape screen.
+        findViewById<View>(R.id.btnRouteCarNav)?.setOnClickListener { anchor ->
+            showCarNavMenu(anchor, routeStops.lastOrNull(), includeSave = true)
+        }
 
         // Build the ordered trip itinerary (origin → stops → destination + an
         // "Add stop" row) above the route candidates.

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -995,6 +995,12 @@ public class HttpServer {
             return SeatDebugApiHandler.handle(method, path, body, out);
         }
 
+        // Telenav OEM user-data AIDL — READ-ONLY spike: bind TnNaviService and read
+        // the favourite buckets + recents to confirm the bind and learn the heart's
+        // FavoriteType. No writes. See TelenavDebugApiHandler / TelenavClient.
+        if (path.startsWith("/api/debug/telenav/")) {
+            return TelenavDebugApiHandler.handle(method, path, body, out);
+        }
         // Radar blind-spot ALERT register probe — read-only. The `blindSpot` automation
         // signal has never been confirmed on a car, and its whole read path logs at DEBUG
         // (stripped by R8 in release), so the values have to come back as JSON.

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -998,7 +998,7 @@ public class HttpServer {
         // Telenav OEM user-data AIDL — READ-ONLY spike: bind TnNaviService and read
         // the favourite buckets + recents to confirm the bind and learn the heart's
         // FavoriteType. No writes. See TelenavDebugApiHandler / TelenavClient.
-        if (path.startsWith("/api/debug/telenav/")) {
+        if (path.startsWith("/api/debug/telenav/") || path.startsWith("/api/telenav/")) {
             return TelenavDebugApiHandler.handle(method, path, body, out);
         }
         // Radar blind-spot ALERT register probe — read-only. The `blindSpot` automation

--- a/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
@@ -1,0 +1,86 @@
+package com.overdrive.app.server;
+
+import com.overdrive.app.telenav.TelenavIpcServer;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * READ-ONLY spike endpoint for Telenav's exported user-data AIDL. The daemon
+ * (uid-2000, synthetic ActivityThread) cannot {@code bindService}, so this handler
+ * forwards to {@link TelenavIpcServer} in the app process over
+ * {@code 127.0.0.1:19878}, which does the bind and returns the JSON.
+ *
+ * <p>{@code GET /api/debug/telenav/favorites} — read all favourite buckets + recent.
+ */
+public final class TelenavDebugApiHandler {
+
+    private TelenavDebugApiHandler() {}
+
+    public static boolean handle(String method, String path, String body, OutputStream out) throws Exception {
+        String pathOnly = path;
+        int qIdx = path.indexOf('?');
+        if (qIdx >= 0) pathOnly = path.substring(0, qIdx);
+
+        final JSONObject req;
+        if (pathOnly.equals("/api/debug/telenav/favorites")) {
+            if (!"GET".equals(method)) {
+                HttpResponse.sendError(out, 405, "Method Not Allowed");
+                return true;
+            }
+            req = new JSONObject().put("op", "getFavorites");
+        } else if (pathOnly.equals("/api/debug/telenav/addFavorite")) {
+            if (!"POST".equals(method)) {
+                HttpResponse.sendError(out, 405, "Method Not Allowed");
+                return true;
+            }
+            JSONObject in = (body == null || body.isEmpty()) ? new JSONObject() : new JSONObject(body);
+            req = new JSONObject()
+                    .put("op", "addFavorite")
+                    .put("favoriteType", in.optString("favoriteType", "Normal"))
+                    .put("name", in.optString("name", ""))
+                    .put("lat", in.getDouble("lat"))
+                    .put("lng", in.getDouble("lng"))
+                    .put("formattedAddress", in.optString("formattedAddress", in.optString("name", "")));
+        } else {
+            HttpResponse.sendError(out, 404, "Unknown telenav debug endpoint");
+            return true;
+        }
+
+        String resp = forwardToApp(req.toString(), 25_000);
+        if (resp == null) {
+            JSONObject err = new JSONObject();
+            err.put("success", false);
+            err.put("error", "app IPC unreachable on 127.0.0.1:" + TelenavIpcServer.PORT
+                    + " (is the OverDrive app process running?)");
+            HttpResponse.sendJson(out, 200, err.toString());
+            return true;
+        }
+        HttpResponse.sendJson(out, 200, resp);
+        return true;
+    }
+
+    /** One line of JSON to the app-process listener, one line back. */
+    private static String forwardToApp(String requestLine, int readTimeoutMs) {
+        Socket socket = null;
+        try {
+            socket = new Socket();
+            socket.connect(new InetSocketAddress("127.0.0.1", TelenavIpcServer.PORT), 2000);
+            socket.setSoTimeout(readTimeoutMs);
+            PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            writer.println(requestLine);
+            return reader.readLine();
+        } catch (Exception e) {
+            return null;
+        } finally {
+            try { if (socket != null) socket.close(); } catch (Exception ignore) {}
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
@@ -39,6 +39,12 @@ public final class TelenavDebugApiHandler {
                 return true;
             }
             req = new JSONObject().put("op", "getFavorites");
+        } else if (p.equals("/api/telenav/navstate")) {
+            if (!"GET".equals(method)) { HttpResponse.sendError(out, 405, "Method Not Allowed"); return true; }
+            req = new JSONObject().put("op", "navState");
+        } else if (p.equals("/api/telenav/stopnav")) {
+            if (!"POST".equals(method)) { HttpResponse.sendError(out, 405, "Method Not Allowed"); return true; }
+            req = new JSONObject().put("op", "stopNav");
         } else if (p.equals("/api/telenav/addFavorite") || p.equals("/api/telenav/navigate")) {
             if (!"POST".equals(method)) {
                 HttpResponse.sendError(out, 405, "Method Not Allowed");
@@ -52,6 +58,7 @@ public final class TelenavDebugApiHandler {
                     .put("name", in.optString("name", ""))
                     .put("lat", in.getDouble("lat"))
                     .put("lng", in.getDouble("lng"))
+                    .put("replace", in.optBoolean("replace", false))
                     .put("formattedAddress", in.optString("formattedAddress", in.optString("name", "")));
         } else {
             HttpResponse.sendError(out, 404, "Unknown telenav endpoint");

--- a/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
@@ -72,6 +72,24 @@ public final class TelenavDebugApiHandler {
         // here, before the app process runs startNavigation. Save-to-Favourites persists
         // silently and must NOT steal the screen, so it is deliberately excluded.
         if (p.equals("/api/telenav/navigate")) {
+            if (isAccOff()) {
+                // Car is off — foregrounding Telenav now is pointless (screen off). Queue
+                // the target; DeferredNavManager offers it as a prompt on the next ACC-on.
+                double qlat = req.optDouble("lat", Double.NaN);
+                double qlng = req.optDouble("lng", Double.NaN);
+                if (Double.isNaN(qlat) || Double.isNaN(qlng)) {
+                    HttpResponse.sendError(out, 400, "lat/lng required");
+                    return true;
+                }
+                com.overdrive.app.telenav.DeferredNavManager.storePending(
+                        req.optString("name", ""), qlat, qlng);
+                JSONObject queued = new JSONObject();
+                queued.put("success", true);
+                queued.put("queued", true);
+                queued.put("message", "Car is off — navigation will be offered on next start.");
+                HttpResponse.sendJson(out, 200, queued.toString());
+                return true;
+            }
             foregroundTelenav();
         }
 
@@ -86,6 +104,25 @@ public final class TelenavDebugApiHandler {
         }
         HttpResponse.sendJson(out, 200, resp);
         return true;
+    }
+
+    /**
+     * True when the car is off (ACC off). {@code sys.accanim.status} is "0" or empty while
+     * ACC is on; non-zero once the shutdown animation runs / the car is off. Same signal
+     * {@code AccMonitorController} polls. Unknown → treat as ON (navigate immediately),
+     * which is the safe default (never silently swallow a request into the queue).
+     */
+    private static boolean isAccOff() {
+        try {
+            Process pr = new ProcessBuilder("getprop", "sys.accanim.status")
+                    .redirectErrorStream(true).start();
+            String v = new BufferedReader(new InputStreamReader(pr.getInputStream())).readLine();
+            pr.waitFor(2, java.util.concurrent.TimeUnit.SECONDS);
+            v = v == null ? "" : v.trim();
+            return !(v.isEmpty() || v.equals("0"));
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
@@ -65,6 +65,16 @@ public final class TelenavDebugApiHandler {
             return true;
         }
 
+        // Navigate is a silent no-op unless Telenav is the foreground app (verified live
+        // 2026-08-23). This request arrives while the OverDrive app process is backgrounded,
+        // so it can't foreground an activity itself (background-activity-launch limits) — but
+        // this handler runs in the daemon (UID 2000), which can `am start` regardless. Do it
+        // here, before the app process runs startNavigation. Save-to-Favourites persists
+        // silently and must NOT steal the screen, so it is deliberately excluded.
+        if (p.equals("/api/telenav/navigate")) {
+            foregroundTelenav();
+        }
+
         String resp = forwardToApp(req.toString(), 25_000);
         if (resp == null) {
             JSONObject err = new JSONObject();
@@ -76,6 +86,27 @@ public final class TelenavDebugApiHandler {
         }
         HttpResponse.sendJson(out, 200, resp);
         return true;
+    }
+
+    /**
+     * Bring Telenav's map to the foreground from the daemon (UID 2000). Uses {@code am
+     * start} via {@code sh -c} — the same privileged path {@code ShellAction} uses — because
+     * the backgrounded app process is blocked from launching activities. Best effort: a
+     * failure here still lets the navigate command through (it just won't be visible).
+     */
+    private static void foregroundTelenav() {
+        try {
+            Process pr = new ProcessBuilder("sh", "-c",
+                    "am start -n com.telenav.app.arp/com.telenav.arp.module.map.MainActivity")
+                    .redirectErrorStream(true)
+                    .start();
+            pr.waitFor(5, java.util.concurrent.TimeUnit.SECONDS);
+            Thread.sleep(1000); // let Telenav reach the front before startNavigation binds
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        } catch (Exception ignore) {
+            // Best effort — navigate still proceeds, just not visibly.
+        }
     }
 
     /** One line of JSON to the app-process listener, one line back. */

--- a/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/TelenavDebugApiHandler.java
@@ -28,28 +28,33 @@ public final class TelenavDebugApiHandler {
         int qIdx = path.indexOf('?');
         if (qIdx >= 0) pathOnly = path.substring(0, qIdx);
 
+        // Accept the stable /api/telenav/* path and the older /api/debug/telenav/*.
+        String p = pathOnly;
+        if (p.startsWith("/api/debug/telenav/")) p = "/api/telenav/" + p.substring("/api/debug/telenav/".length());
+
         final JSONObject req;
-        if (pathOnly.equals("/api/debug/telenav/favorites")) {
+        if (p.equals("/api/telenav/favorites")) {
             if (!"GET".equals(method)) {
                 HttpResponse.sendError(out, 405, "Method Not Allowed");
                 return true;
             }
             req = new JSONObject().put("op", "getFavorites");
-        } else if (pathOnly.equals("/api/debug/telenav/addFavorite")) {
+        } else if (p.equals("/api/telenav/addFavorite") || p.equals("/api/telenav/navigate")) {
             if (!"POST".equals(method)) {
                 HttpResponse.sendError(out, 405, "Method Not Allowed");
                 return true;
             }
             JSONObject in = (body == null || body.isEmpty()) ? new JSONObject() : new JSONObject(body);
+            String op = p.endsWith("/navigate") ? "navigate" : "addFavorite";
             req = new JSONObject()
-                    .put("op", "addFavorite")
+                    .put("op", op)
                     .put("favoriteType", in.optString("favoriteType", "Normal"))
                     .put("name", in.optString("name", ""))
                     .put("lat", in.getDouble("lat"))
                     .put("lng", in.getDouble("lng"))
                     .put("formattedAddress", in.optString("formattedAddress", in.optString("name", "")));
         } else {
-            HttpResponse.sendError(out, 404, "Unknown telenav debug endpoint");
+            HttpResponse.sendError(out, 404, "Unknown telenav endpoint");
             return true;
         }
 

--- a/app/src/main/java/com/overdrive/app/telenav/DeferredNavManager.kt
+++ b/app/src/main/java/com/overdrive/app/telenav/DeferredNavManager.kt
@@ -1,0 +1,137 @@
+package com.overdrive.app.telenav
+
+import android.util.Log
+import com.overdrive.app.config.UnifiedConfigManager
+import com.overdrive.app.daemon.sentry.AccMonitorController
+import com.overdrive.app.monitor.GearMonitor
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.PrintWriter
+import java.net.InetSocketAddress
+import java.net.Socket
+
+/**
+ * Deferred "navigate here". A phone / on-car "Navigate here" that arrives while the
+ * car is off (ACC off) would otherwise be a silent no-op — guidance only engages
+ * while Telenav is foregrounded, and the screen is off. So instead we store the
+ * latest such target and, on the next ACC-on, offer it as a floating prompt.
+ *
+ * Runs entirely in the daemon process (byd_cam_daemon), started once from
+ * [com.overdrive.app.daemon.CameraDaemon]. It uses its OWN [AccMonitorController]
+ * (the same `sys.accanim.status` signal the surveillance side and the automation
+ * engine watch) so it is fully isolated from the surveillance ACC state machine.
+ * Gear comes from the daemon's [GearMonitor]; the overlay itself lives in the APP
+ * process (Telenav bind + SYSTEM_ALERT_WINDOW), reached over 127.0.0.1:19878.
+ */
+object DeferredNavManager {
+
+    private const val TAG = "DeferredNav"
+    private const val SHOW_DELAY_MS = 5_000L        // let the launcher/Telenav settle after power-on
+    private const val REVERSE_WAIT_MAX_MS = 30_000L // hold the prompt while reversing (rear cam)
+    private const val REVERSE_POLL_MS = 1_000L
+
+    @Volatile private var started = false
+    private var accMonitor: AccMonitorController? = null
+
+    /** Start the ACC watcher. Idempotent; safe to call from daemon boot. */
+    @JvmStatic
+    fun start() {
+        if (started) return
+        try {
+            accMonitor = AccMonitorController(onAccOff = {}, onAccOn = { onAccOn() })
+                .also { it.startPolling() }
+            started = true
+            Log.i(TAG, "started (ACC watcher for deferred navigate)")
+        } catch (t: Throwable) {
+            Log.w(TAG, "start failed: ${t.message}")
+        }
+    }
+
+    /** Store the latest target received while the car is off. Called by the endpoint. */
+    @JvmStatic
+    fun storePending(name: String?, lat: Double, lng: Double) {
+        try {
+            UnifiedConfigManager.setPendingNav(name ?: "", lat, lng, System.currentTimeMillis())
+            Log.i(TAG, "queued pending navigate: '$name' ($lat,$lng)")
+        } catch (t: Throwable) {
+            Log.w(TAG, "storePending failed: ${t.message}")
+        }
+    }
+
+    private fun onAccOn() {
+        // Off the ACC poller thread; this waits and does IPC.
+        Thread({
+            try {
+                val d = UnifiedConfigManager.getDeferredNav()
+                if (!d.optBoolean("pending", false)) return@Thread
+
+                val receivedAt = d.optLong("receivedAt", 0L)
+                val ageMs = System.currentTimeMillis() - receivedAt
+                val maxMs = UnifiedConfigManager.getDeferredNavExpiryHours() * 3_600_000L
+                if (receivedAt <= 0L || ageMs > maxMs) {
+                    Log.i(TAG, "pending expired (age ${ageMs / 60_000}m > ${maxMs / 3_600_000}h) — clearing")
+                    UnifiedConfigManager.clearPendingNav()
+                    return@Thread
+                }
+
+                Thread.sleep(SHOW_DELAY_MS)
+
+                // Don't pop over the reversing camera — wait until out of R (brief cap).
+                var waited = 0L
+                while (GearMonitor.getInstance().currentGear == GearMonitor.GEAR_R &&
+                    waited < REVERSE_WAIT_MAX_MS
+                ) {
+                    Thread.sleep(REVERSE_POLL_MS)
+                    waited += REVERSE_POLL_MS
+                }
+                if (GearMonitor.getInstance().currentGear == GearMonitor.GEAR_R) {
+                    Log.i(TAG, "still in reverse after ${REVERSE_WAIT_MAX_MS / 1000}s — skipping, clearing")
+                    UnifiedConfigManager.clearPendingNav()
+                    return@Thread
+                }
+
+                val name = d.optString("name", "Shared location")
+                val lat = d.optDouble("lat", Double.NaN)
+                val lng = d.optDouble("lng", Double.NaN)
+                if (lat.isNaN() || lng.isNaN()) {
+                    UnifiedConfigManager.clearPendingNav()
+                    return@Thread
+                }
+
+                val shown = sendShowPrompt(name, lat, lng)
+                // One-shot: clear once handed to the app (offered on the next start, not every start).
+                UnifiedConfigManager.clearPendingNav()
+                Log.i(TAG, "ACC-on: prompt ${if (shown) "shown" else "send-failed"}; pending cleared")
+            } catch (ie: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } catch (t: Throwable) {
+                Log.w(TAG, "onAccOn failed: ${t.message}")
+            }
+        }, "deferrednav-accon").start()
+    }
+
+    /** Ask the APP process to draw the prompt overlay. Mirrors TelenavDebugApiHandler.forwardToApp. */
+    private fun sendShowPrompt(name: String, lat: Double, lng: Double): Boolean {
+        var socket: Socket? = null
+        return try {
+            val req = JSONObject()
+                .put("op", "showNavPrompt")
+                .put("name", name)
+                .put("lat", lat)
+                .put("lng", lng)
+            val s = Socket()
+            s.connect(InetSocketAddress("127.0.0.1", TelenavIpcServer.PORT), 2000)
+            s.soTimeout = 8000
+            socket = s
+            PrintWriter(s.getOutputStream(), true).println(req.toString())
+            val resp = BufferedReader(InputStreamReader(s.getInputStream())).readLine()
+            resp != null && resp.contains("\"success\":true")
+        } catch (e: Exception) {
+            Log.w(TAG, "sendShowPrompt failed: ${e.message}")
+            false
+        } finally {
+            try { socket?.close() } catch (ignore: Exception) {}
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
+++ b/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
@@ -129,13 +129,14 @@ object NavPromptOverlay {
                 }.start()
             }
         }
+        // Accept (primary) on the left, Decline on the right.
         row.addView(
-            cancel,
+            yes,
             LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
                 .apply { rightMargin = dp(6) },
         )
         row.addView(
-            yes,
+            cancel,
             LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
                 .apply { leftMargin = dp(6) },
         )

--- a/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
+++ b/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
@@ -2,7 +2,7 @@ package com.overdrive.app.telenav
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Color
+import android.content.res.Configuration
 import android.graphics.PixelFormat
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
@@ -12,26 +12,35 @@ import android.os.Looper
 import android.provider.Settings
 import android.util.Log
 import android.util.TypedValue
+import android.view.ContextThemeWrapper
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
-import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatDelegate
+import com.google.android.material.R as MR
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.color.MaterialColors
+import com.overdrive.app.R
 import com.overdrive.app.config.UnifiedConfigManager
 import kotlin.math.abs
 
 /**
- * Floating "Navigate to X? [Cancel] [Yes]" prompt drawn over everything via the
- * granted SYSTEM_ALERT_WINDOW (TYPE_APPLICATION_OVERLAY). Shown in the APP process
- * by [TelenavIpcServer] when the daemon's [DeferredNavManager] reports, on ACC-on,
- * a target that was queued while the car was off.
+ * Floating "Navigate in the car?" prompt drawn over everything via the granted
+ * SYSTEM_ALERT_WINDOW. Shown in the APP process by [TelenavIpcServer] when the
+ * daemon's [DeferredNavManager] reports, on ACC-on, a target queued while the car
+ * was off.
  *
- * Draggable by its header (position persisted to config so it reappears where the
- * user left it). Auto-dismisses after 20s. "Yes" runs the exact live navigate-here
- * path ([TelenavActions.navigate] with replace = fresh route). Must be shown on the
- * main thread.
+ * Styled with OverDrive's own Material 3 theme ([R.style.Theme_Overdrive_M3]) so it
+ * matches the rest of the app and flips day/night with the head unit: the views are
+ * built against a ContextThemeWrapper whose configuration carries the current night
+ * state, and colours are resolved from theme attributes (surface / onSurface /
+ * primary / outline), not hardcoded. Buttons are MaterialButtons.
+ *
+ * Draggable by its header (position persisted). Auto-dismisses after 20s. "Yes" runs
+ * the live navigate-here path. Must be shown on the main thread.
  */
 object NavPromptOverlay {
 
@@ -46,50 +55,74 @@ object NavPromptOverlay {
     @JvmStatic
     @SuppressLint("ClickableViewAccessibility")
     fun show(context: Context, name: String, lat: Double, lng: Double) {
-        val ctx = context.applicationContext
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(ctx)) {
+        val app = context.applicationContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(app)) {
             Log.w(TAG, "no draw-overlay permission — cannot show prompt")
             return
         }
         dismiss() // never stack two
 
+        // Theme the context: match OverDrive's night choice (AppCompatDelegate has no
+        // Activity here, so resolve it ourselves), then wrap in Theme.Overdrive.M3 so
+        // the same day/night palette as the rest of the app resolves from attributes.
+        val nightYes = when (AppCompatDelegate.getDefaultNightMode()) {
+            AppCompatDelegate.MODE_NIGHT_YES -> true
+            AppCompatDelegate.MODE_NIGHT_NO -> false
+            else -> (app.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                Configuration.UI_MODE_NIGHT_YES
+        }
+        val cfg = Configuration(app.resources.configuration).apply {
+            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                if (nightYes) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+        }
+        val ctx: Context = ContextThemeWrapper(
+            app.createConfigurationContext(cfg), R.style.Theme_Overdrive_M3,
+        )
+
         fun dp(v: Int): Int = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP, v.toFloat(), ctx.resources.displayMetrics,
         ).toInt()
+        fun attr(a: Int, fallback: Int): Int = MaterialColors.getColor(ctx, a, fallback)
+
+        val surface = attr(MR.attr.colorSurfaceContainer, attr(MR.attr.colorSurface, 0xFF2A2A2E.toInt()))
+        val onSurface = attr(MR.attr.colorOnSurface, 0xFFFFFFFF.toInt())
+        val onSurfaceVar = attr(MR.attr.colorOnSurfaceVariant, 0xFFDDDDDD.toInt())
+        val outline = attr(MR.attr.colorOutlineVariant, 0x55FFFFFF)
 
         val card = LinearLayout(ctx).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(dp(20), dp(16), dp(20), dp(16))
             background = GradientDrawable().apply {
-                cornerRadius = dp(18).toFloat()
-                setColor(Color.parseColor("#F02A2A2E"))
-                setStroke(dp(1), Color.parseColor("#55FFFFFF"))
+                cornerRadius = dp(20).toFloat()
+                setColor(surface)
+                setStroke(dp(1), outline)
             }
+            elevation = dp(8).toFloat()
         }
         val title = TextView(ctx).apply {
-            text = "Navigate in the car?"
-            setTextColor(Color.WHITE)
+            text = ctx.getString(R.string.carnav_deferred_prompt_title)
+            setTextColor(onSurface)
             textSize = 16f
             typeface = Typeface.create(typeface, Typeface.BOLD)
         }
         val body = TextView(ctx).apply {
             text = name
-            setTextColor(Color.parseColor("#DDDDDD"))
+            setTextColor(onSurfaceVar)
             textSize = 14f
             setPadding(0, dp(4), 0, dp(14))
         }
         val row = LinearLayout(ctx).apply { orientation = LinearLayout.HORIZONTAL }
-        val cancel = Button(ctx).apply {
-            text = "Cancel"
+        val cancel = MaterialButton(ctx, null, MR.attr.materialButtonOutlinedStyle).apply {
+            text = ctx.getString(R.string.carnav_deferred_cancel)
             setOnClickListener { dismiss() }
         }
-        val yes = Button(ctx).apply {
-            text = "Yes, navigate"
+        val yes = MaterialButton(ctx).apply {
+            text = ctx.getString(R.string.carnav_deferred_yes)
             setOnClickListener {
                 dismiss()
                 Thread {
                     try {
-                        TelenavActions.navigate(ctx, name, lat, lng, true)
+                        TelenavActions.navigate(app, name, lat, lng, true)
                     } catch (t: Throwable) {
                         Log.w(TAG, "navigate failed: ${t.message}")
                     }
@@ -116,7 +149,7 @@ object NavPromptOverlay {
             @Suppress("DEPRECATION") WindowManager.LayoutParams.TYPE_PHONE
         }
         val lp = WindowManager.LayoutParams(
-            dp(300),
+            dp(320),
             WindowManager.LayoutParams.WRAP_CONTENT,
             type,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
@@ -133,8 +166,7 @@ object NavPromptOverlay {
             }
         }
 
-        // Drag by the header (title + body). Buttons keep their own clicks because the
-        // drag listener is only on these two views, not the button row.
+        // Drag by the header (title + body); buttons keep their own clicks.
         val dragListener = object : View.OnTouchListener {
             private var startX = 0
             private var startY = 0
@@ -173,12 +205,12 @@ object NavPromptOverlay {
         title.setOnTouchListener(dragListener)
         body.setOnTouchListener(dragListener)
 
-        wm = ctx.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        wm = app.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         try {
             wm?.addView(card, lp)
             view = card
             main.postDelayed(dismissRunnable, AUTO_DISMISS_MS)
-            Log.i(TAG, "prompt shown for '$name'")
+            Log.i(TAG, "prompt shown for '$name' (night=$nightYes)")
         } catch (t: Throwable) {
             Log.w(TAG, "addView failed: ${t.message}")
             view = null

--- a/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
+++ b/app/src/main/java/com/overdrive/app/telenav/NavPromptOverlay.kt
@@ -1,0 +1,195 @@
+package com.overdrive.app.telenav
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowManager
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.overdrive.app.config.UnifiedConfigManager
+import kotlin.math.abs
+
+/**
+ * Floating "Navigate to X? [Cancel] [Yes]" prompt drawn over everything via the
+ * granted SYSTEM_ALERT_WINDOW (TYPE_APPLICATION_OVERLAY). Shown in the APP process
+ * by [TelenavIpcServer] when the daemon's [DeferredNavManager] reports, on ACC-on,
+ * a target that was queued while the car was off.
+ *
+ * Draggable by its header (position persisted to config so it reappears where the
+ * user left it). Auto-dismisses after 20s. "Yes" runs the exact live navigate-here
+ * path ([TelenavActions.navigate] with replace = fresh route). Must be shown on the
+ * main thread.
+ */
+object NavPromptOverlay {
+
+    private const val TAG = "NavPromptOverlay"
+    private const val AUTO_DISMISS_MS = 20_000L
+
+    private val main = Handler(Looper.getMainLooper())
+    private val dismissRunnable = Runnable { dismiss() }
+    private var view: View? = null
+    private var wm: WindowManager? = null
+
+    @JvmStatic
+    @SuppressLint("ClickableViewAccessibility")
+    fun show(context: Context, name: String, lat: Double, lng: Double) {
+        val ctx = context.applicationContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(ctx)) {
+            Log.w(TAG, "no draw-overlay permission — cannot show prompt")
+            return
+        }
+        dismiss() // never stack two
+
+        fun dp(v: Int): Int = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP, v.toFloat(), ctx.resources.displayMetrics,
+        ).toInt()
+
+        val card = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(16), dp(20), dp(16))
+            background = GradientDrawable().apply {
+                cornerRadius = dp(18).toFloat()
+                setColor(Color.parseColor("#F02A2A2E"))
+                setStroke(dp(1), Color.parseColor("#55FFFFFF"))
+            }
+        }
+        val title = TextView(ctx).apply {
+            text = "Navigate in the car?"
+            setTextColor(Color.WHITE)
+            textSize = 16f
+            typeface = Typeface.create(typeface, Typeface.BOLD)
+        }
+        val body = TextView(ctx).apply {
+            text = name
+            setTextColor(Color.parseColor("#DDDDDD"))
+            textSize = 14f
+            setPadding(0, dp(4), 0, dp(14))
+        }
+        val row = LinearLayout(ctx).apply { orientation = LinearLayout.HORIZONTAL }
+        val cancel = Button(ctx).apply {
+            text = "Cancel"
+            setOnClickListener { dismiss() }
+        }
+        val yes = Button(ctx).apply {
+            text = "Yes, navigate"
+            setOnClickListener {
+                dismiss()
+                Thread {
+                    try {
+                        TelenavActions.navigate(ctx, name, lat, lng, true)
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "navigate failed: ${t.message}")
+                    }
+                }.start()
+            }
+        }
+        row.addView(
+            cancel,
+            LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                .apply { rightMargin = dp(6) },
+        )
+        row.addView(
+            yes,
+            LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                .apply { leftMargin = dp(6) },
+        )
+        card.addView(title)
+        card.addView(body)
+        card.addView(row)
+
+        val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        } else {
+            @Suppress("DEPRECATION") WindowManager.LayoutParams.TYPE_PHONE
+        }
+        val lp = WindowManager.LayoutParams(
+            dp(300),
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            type,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            val pos = runCatching { UnifiedConfigManager.getNavPromptPos() }.getOrNull()
+            if (pos != null) {
+                gravity = Gravity.TOP or Gravity.START
+                x = pos.first
+                y = pos.second
+            } else {
+                gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                y = dp(80)
+            }
+        }
+
+        // Drag by the header (title + body). Buttons keep their own clicks because the
+        // drag listener is only on these two views, not the button row.
+        val dragListener = object : View.OnTouchListener {
+            private var startX = 0
+            private var startY = 0
+            private var downRawX = 0f
+            private var downRawY = 0f
+            private var dragging = false
+
+            override fun onTouch(v: View, e: MotionEvent): Boolean {
+                when (e.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        startX = lp.x; startY = lp.y
+                        downRawX = e.rawX; downRawY = e.rawY
+                        dragging = false
+                        return true
+                    }
+                    MotionEvent.ACTION_MOVE -> {
+                        val dx = (e.rawX - downRawX).toInt()
+                        val dy = (e.rawY - downRawY).toInt()
+                        if (!dragging && (abs(dx) > dp(6) || abs(dy) > dp(6))) dragging = true
+                        if (dragging) {
+                            lp.gravity = Gravity.TOP or Gravity.START
+                            lp.x = startX + dx
+                            lp.y = startY + dy
+                            runCatching { wm?.updateViewLayout(card, lp) }
+                        }
+                        return true
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        if (dragging) runCatching { UnifiedConfigManager.setNavPromptPos(lp.x, lp.y) }
+                        return true
+                    }
+                }
+                return false
+            }
+        }
+        title.setOnTouchListener(dragListener)
+        body.setOnTouchListener(dragListener)
+
+        wm = ctx.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        try {
+            wm?.addView(card, lp)
+            view = card
+            main.postDelayed(dismissRunnable, AUTO_DISMISS_MS)
+            Log.i(TAG, "prompt shown for '$name'")
+        } catch (t: Throwable) {
+            Log.w(TAG, "addView failed: ${t.message}")
+            view = null
+        }
+    }
+
+    @JvmStatic
+    fun dismiss() {
+        main.removeCallbacks(dismissRunnable)
+        val v = view ?: return
+        runCatching { wm?.removeView(v) }
+        view = null
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
@@ -1,0 +1,59 @@
+package com.overdrive.app.telenav;
+
+import android.content.Context;
+
+import com.telenav.app.external.constants.FavoriteType;
+import com.telenav.app.external.model.search.Address;
+import com.telenav.app.external.model.search.Place;
+
+/**
+ * High-level Telenav actions shared by both clients: the on-car RoadSense map
+ * (calls these directly, in-process) and the phone via {@link TelenavIpcServer}.
+ * One place that maps a plain (name, lat, lng) into a Telenav {@link Place} and
+ * invokes the bridge.
+ */
+public final class TelenavActions {
+
+    private static final long TIMEOUT_MS = 20_000L;
+
+    private TelenavActions() {}
+
+    /** Telenav rejects a null placeId; we store by coordinates, so a synthetic id is fine. */
+    public static Place buildPlace(
+            String name, double lat, double lng, String favoriteType,
+            String placeId, String formattedAddress) {
+        String pid = (placeId == null || placeId.trim().isEmpty())
+                ? "OD-" + lat + "_" + lng : placeId.trim();
+        String addr = (formattedAddress == null || formattedAddress.isEmpty()) ? name : formattedAddress;
+
+        Place p = new Place();
+        p.setPlaceId(pid);
+        p.setSearchSourceType("ON_BOARD");
+        p.setPlaceName(name);
+        p.setPlaceDisplayLabel(name);
+        p.setPlaceType("ADDRESS");
+        p.setFavoriteType(favoriteType);
+        p.setGeoLatitude(lat);
+        p.setGeoLongitude(lng);
+        p.setNavLatitude(lat);
+        p.setNavLongitude(lng);
+        Address a = new Address();
+        a.setFormattedAddress(addr);
+        a.setFullAddress(addr);
+        p.setAddress(a);
+        return p;
+    }
+
+    /** Save a place to the favourites (default type Normal = the heart list). Blocking. */
+    public static void addFavorite(Context ctx, String name, double lat, double lng, String favoriteType)
+            throws Exception {
+        String type = (favoriteType == null || favoriteType.isEmpty()) ? FavoriteType.Normal : favoriteType;
+        TelenavClient.addFavorite(ctx, TIMEOUT_MS, type, buildPlace(name, lat, lng, type, null, null));
+    }
+
+    /** Start turn-by-turn navigation to a place. Blocking; returns Telenav's result. */
+    public static boolean navigate(Context ctx, String name, double lat, double lng) throws Exception {
+        return TelenavClient.startNavigation(
+                ctx, TIMEOUT_MS, buildPlace(name, lat, lng, FavoriteType.Normal, null, null));
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
@@ -88,7 +88,27 @@ public final class TelenavActions {
      * only engages while Telenav is on screen). Blocking; returns Telenav's result.
      */
     public static boolean navigate(Context ctx, String name, double lat, double lng) throws Exception {
+        return navigate(ctx, name, lat, lng, false);
+    }
+
+    /**
+     * Start navigation to a place, choosing how it combines with any active route.
+     *
+     * <p>Telenav's external {@code startNavigation(Place)} takes no mode: called while a
+     * route is active it ADDS the place as an intermediate waypoint; called idle it starts
+     * fresh. To force a fresh single-destination route ({@code replace = true}) we stop the
+     * active nav first, then start — verified live 2026-08-23.
+     *
+     * @param replace {@code true} = fresh route (stopNav + start); {@code false} = add as a
+     *                stop when navigating, or start fresh when idle (Telenav's own default).
+     */
+    public static boolean navigate(Context ctx, String name, double lat, double lng, boolean replace)
+            throws Exception {
         foregroundTelenav(ctx);
+        if (replace) {
+            try { TelenavClient.stopNav(ctx, TIMEOUT_MS); } catch (Exception ignore) {}
+            try { Thread.sleep(1200); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+        }
         return TelenavClient.startNavigation(
                 ctx, TIMEOUT_MS, buildPlace(name, lat, lng, FavoriteType.Normal, null, null));
     }

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavActions.java
@@ -1,6 +1,7 @@
 package com.overdrive.app.telenav;
 
 import android.content.Context;
+import android.content.Intent;
 
 import com.telenav.app.external.constants.FavoriteType;
 import com.telenav.app.external.model.search.Address;
@@ -16,7 +17,38 @@ public final class TelenavActions {
 
     private static final long TIMEOUT_MS = 20_000L;
 
+    private static final String TELENAV_PKG = "com.telenav.app.arp";
+    private static final String TELENAV_MAP_ACTIVITY = "com.telenav.arp.module.map.MainActivity";
+    /** Let Telenav come to the front and its nav service settle before we start guidance. */
+    private static final long FOREGROUND_SETTLE_MS = 1200L;
+
     private TelenavActions() {}
+
+    /**
+     * Bring Telenav's map to the foreground. Verified live 2026-08-23: Telenav only
+     * engages turn-by-turn guidance while it is the foreground app — {@code startNavigation}
+     * is accepted and returns success even when Telenav is backgrounded, but nothing
+     * is shown. Idempotent (a running task is brought to front, not restarted).
+     *
+     * <p>This uses {@code startActivity}, so the CALLER MUST be in the foreground (the
+     * on-car map is). A backgrounded process is subject to Android's background-activity
+     * -launch limits and this silently no-ops; the phone/endpoint path foregrounds from
+     * the daemon (UID 2000, {@code am start}) instead — see {@code TelenavDebugApiHandler}.
+     */
+    public static void foregroundTelenav(Context ctx) {
+        try {
+            Intent i = new Intent(Intent.ACTION_MAIN);
+            i.addCategory(Intent.CATEGORY_LAUNCHER);
+            i.setClassName(TELENAV_PKG, TELENAV_MAP_ACTIVITY);
+            i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                    | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                    | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            ctx.startActivity(i);
+            Thread.sleep(FOREGROUND_SETTLE_MS);
+        } catch (Exception ignore) {
+            // Best effort: if we can't foreground, still attempt the nav command below.
+        }
+    }
 
     /** Telenav rejects a null placeId; we store by coordinates, so a synthetic id is fine. */
     public static Place buildPlace(
@@ -51,8 +83,12 @@ public final class TelenavActions {
         TelenavClient.addFavorite(ctx, TIMEOUT_MS, type, buildPlace(name, lat, lng, type, null, null));
     }
 
-    /** Start turn-by-turn navigation to a place. Blocking; returns Telenav's result. */
+    /**
+     * Start turn-by-turn navigation to a place. Foregrounds Telenav first (guidance
+     * only engages while Telenav is on screen). Blocking; returns Telenav's result.
+     */
     public static boolean navigate(Context ctx, String name, double lat, double lng) throws Exception {
+        foregroundTelenav(ctx);
         return TelenavClient.startNavigation(
                 ctx, TIMEOUT_MS, buildPlace(name, lat, lng, FavoriteType.Normal, null, null));
     }

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
@@ -1,0 +1,123 @@
+package com.overdrive.app.telenav;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.util.Log;
+
+import com.telenav.app.external.IServiceInitCallback;
+import com.telenav.app.external.IServiceManager;
+import com.telenav.app.external.IUserDataService;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Binds Telenav's exported OEM AIDL ({@code com.telenav.app.service.TnNaviService},
+ * action {@code com.telenav.app.external.service.NAVI}) and hands back the
+ * {@link IUserDataService} for the duration of one operation.
+ *
+ * <p>The service is exported with no permission and {@code onBind} returns
+ * unconditionally (the only "gate" is a client-version major-number check), so no
+ * PermissiveContext is needed here — a normal bind is enough.
+ *
+ * <p>Runs inside the uid-2000 daemon. We use the {@code bindService(Intent, int,
+ * Executor, ServiceConnection)} overload (API 29+) so the connection callback is
+ * delivered on our own executor rather than a main Looper the daemon isn't running.
+ * The two-step handshake is: bind → {@code IServiceManager} → {@code
+ * registerUserDataServiceCallback} → {@code onServiceInitSuccess} delivers the
+ * {@code IUserDataService} on a Binder thread.
+ */
+public final class TelenavClient {
+
+    private static final String TAG = "TelenavClient";
+
+    private static final String TELENAV_PKG = "com.telenav.app.arp";
+    private static final String NAVI_SERVICE = "com.telenav.app.service.TnNaviService";
+    private static final String NAVI_ACTION = "com.telenav.app.external.service.NAVI";
+    // isValidClient compares the major (before the first ".") to the service's "2.1.1".
+    private static final String CLIENT_VERSION = "2.1.1";
+
+    private TelenavClient() {}
+
+    /** An operation to run against the bound user-data service. */
+    public interface UserDataOp<T> {
+        T run(IUserDataService svc) throws Exception;
+    }
+
+    /**
+     * Bind, obtain {@link IUserDataService}, run {@code op}, then unbind. Blocking,
+     * with an overall timeout. Must be called off the main thread.
+     */
+    public static <T> T withUserData(Context ctx, long timeoutMs, UserDataOp<T> op) throws Exception {
+        if (ctx == null) throw new IllegalStateException("no context");
+
+        final CountDownLatch connected = new CountDownLatch(1);
+        final CountDownLatch serviceReady = new CountDownLatch(1);
+        final AtomicReference<IServiceManager> manager = new AtomicReference<>();
+        final AtomicReference<IUserDataService> userData = new AtomicReference<>();
+        final AtomicReference<String> failure = new AtomicReference<>();
+
+        final IServiceInitCallback initCallback = new IServiceInitCallback.Stub() {
+            @Override public void onServiceInitSuccess(IBinder binder) {
+                userData.set(IUserDataService.Stub.asInterface(binder));
+                serviceReady.countDown();
+            }
+            @Override public void onServiceInitFailed() {
+                failure.set("Telenav reported onServiceInitFailed");
+                serviceReady.countDown();
+            }
+        };
+
+        final ServiceConnection conn = new ServiceConnection() {
+            @Override public void onServiceConnected(ComponentName name, IBinder binder) {
+                IServiceManager sm = IServiceManager.Stub.asInterface(binder);
+                manager.set(sm);
+                connected.countDown();
+                try {
+                    boolean valid = sm.isValid(CLIENT_VERSION);
+                    Log.i(TAG, "isValid(" + CLIENT_VERSION + ")=" + valid);
+                    sm.registerUserDataServiceCallback(initCallback);
+                } catch (RemoteException e) {
+                    failure.set("registerUserDataServiceCallback: " + e.getMessage());
+                    serviceReady.countDown();
+                }
+            }
+            @Override public void onServiceDisconnected(ComponentName name) {
+                Log.w(TAG, "onServiceDisconnected");
+            }
+        };
+
+        Intent intent = new Intent(NAVI_ACTION);
+        intent.setComponent(new ComponentName(TELENAV_PKG, NAVI_SERVICE));
+
+        boolean bindRequested = ctx.bindService(
+                intent, Context.BIND_AUTO_CREATE, Executors.newSingleThreadExecutor(), conn);
+        if (!bindRequested) {
+            try { ctx.unbindService(conn); } catch (Throwable ignore) {}
+            throw new IllegalStateException("bindService returned false for " + NAVI_SERVICE);
+        }
+
+        try {
+            if (!connected.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("timed out binding TnNaviService");
+            }
+            if (!serviceReady.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("timed out waiting for IUserDataService");
+            }
+            IUserDataService svc = userData.get();
+            if (svc == null) {
+                throw new IllegalStateException(failure.get() != null ? failure.get()
+                        : "IUserDataService not delivered");
+            }
+            return op.run(svc);
+        } finally {
+            try { ctx.unbindService(conn); } catch (Throwable ignore) {}
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
@@ -44,6 +44,8 @@ public final class TelenavClient {
     // descriptor and startNavigation's transaction code. We raw-transact this one
     // method to avoid vendoring the whole navi/listener/model tree.
     private static final String NAV_DESCRIPTOR = "com.telenav.app.external.INavigationService";
+    private static final int TRANSACTION_getNavState = 1;
+    private static final int TRANSACTION_stopNav = 3;
     private static final int TRANSACTION_startNavigation = 8;
 
     private TelenavClient() {}
@@ -83,6 +85,40 @@ public final class TelenavClient {
         Boolean r = withService(ctx, timeoutMs,
                 IServiceManager::registerNavigationServiceCallback,
                 binder -> rawStartNavigation(binder, place));
+        return Boolean.TRUE.equals(r);
+    }
+
+    /** Current nav state (NavigationState int), or throws. */
+    public static int getNavState(Context ctx, long timeoutMs) throws Exception {
+        Integer r = withService(ctx, timeoutMs,
+                IServiceManager::registerNavigationServiceCallback,
+                binder -> {
+                    Parcel data = Parcel.obtain();
+                    Parcel reply = Parcel.obtain();
+                    try {
+                        data.writeInterfaceToken(NAV_DESCRIPTOR);
+                        binder.transact(TRANSACTION_getNavState, data, reply, 0);
+                        reply.readException();
+                        return reply.readInt();
+                    } finally { reply.recycle(); data.recycle(); }
+                });
+        return r == null ? Integer.MIN_VALUE : r;
+    }
+
+    /** Stop the active navigation. */
+    public static boolean stopNav(Context ctx, long timeoutMs) throws Exception {
+        Boolean r = withService(ctx, timeoutMs,
+                IServiceManager::registerNavigationServiceCallback,
+                binder -> {
+                    Parcel data = Parcel.obtain();
+                    Parcel reply = Parcel.obtain();
+                    try {
+                        data.writeInterfaceToken(NAV_DESCRIPTOR);
+                        binder.transact(TRANSACTION_stopNav, data, reply, 0);
+                        reply.readException();
+                        return reply.readInt() != 0;
+                    } finally { reply.recycle(); data.recycle(); }
+                });
         return Boolean.TRUE.equals(r);
     }
 

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
@@ -69,6 +69,15 @@ public final class TelenavClient {
                 binder -> op.run(IUserDataService.Stub.asInterface(binder)));
     }
 
+    /** Add a favourite of the given type. Blocking. */
+    public static void addFavorite(Context ctx, long timeoutMs, String favoriteType, Place place)
+            throws Exception {
+        withUserData(ctx, timeoutMs, svc -> {
+            svc.addFavorite(favoriteType, place);
+            return Boolean.TRUE;
+        });
+    }
+
     /** Start turn-by-turn navigation to a place. Returns Telenav's boolean result. */
     public static boolean startNavigation(Context ctx, long timeoutMs, Place place) throws Exception {
         Boolean r = withService(ctx, timeoutMs,

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavClient.java
@@ -5,12 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.os.Parcel;
 import android.os.RemoteException;
 import android.util.Log;
 
 import com.telenav.app.external.IServiceInitCallback;
 import com.telenav.app.external.IServiceManager;
 import com.telenav.app.external.IUserDataService;
+import com.telenav.app.external.model.search.Place;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -19,19 +21,15 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Binds Telenav's exported OEM AIDL ({@code com.telenav.app.service.TnNaviService},
- * action {@code com.telenav.app.external.service.NAVI}) and hands back the
- * {@link IUserDataService} for the duration of one operation.
+ * action {@code com.telenav.app.external.service.NAVI}) and hands back a per-service
+ * binder for one operation. The service is exported with no permission and
+ * {@code onBind} returns unconditionally, so a normal bind is enough (no
+ * PermissiveContext).
  *
- * <p>The service is exported with no permission and {@code onBind} returns
- * unconditionally (the only "gate" is a client-version major-number check), so no
- * PermissiveContext is needed here — a normal bind is enough.
- *
- * <p>Runs inside the uid-2000 daemon. We use the {@code bindService(Intent, int,
- * Executor, ServiceConnection)} overload (API 29+) so the connection callback is
- * delivered on our own executor rather than a main Looper the daemon isn't running.
- * The two-step handshake is: bind → {@code IServiceManager} → {@code
- * registerUserDataServiceCallback} → {@code onServiceInitSuccess} delivers the
- * {@code IUserDataService} on a Binder thread.
+ * <p>Must run in the APP process — the uid-2000 daemon can't {@code bindService}
+ * (no AMS-registered app record). We use the {@code bindService(Intent, int,
+ * Executor, ServiceConnection)} overload (API 29+) so the connection callback
+ * lands on our executor, not a main Looper the daemon isn't running.
  */
 public final class TelenavClient {
 
@@ -40,32 +38,81 @@ public final class TelenavClient {
     private static final String TELENAV_PKG = "com.telenav.app.arp";
     private static final String NAVI_SERVICE = "com.telenav.app.service.TnNaviService";
     private static final String NAVI_ACTION = "com.telenav.app.external.service.NAVI";
-    // isValidClient compares the major (before the first ".") to the service's "2.1.1".
-    private static final String CLIENT_VERSION = "2.1.1";
+    private static final String CLIENT_VERSION = "2.1.1"; // isValidClient checks major == "2"
+
+    // From the decompiled INavigationService.Stub (Telenav v9.0.152): the AIDL
+    // descriptor and startNavigation's transaction code. We raw-transact this one
+    // method to avoid vendoring the whole navi/listener/model tree.
+    private static final String NAV_DESCRIPTOR = "com.telenav.app.external.INavigationService";
+    private static final int TRANSACTION_startNavigation = 8;
 
     private TelenavClient() {}
 
-    /** An operation to run against the bound user-data service. */
+    /** Calls the specific "register …ServiceCallback" method on the manager. */
+    public interface Registrar {
+        void register(IServiceManager mgr, IServiceInitCallback cb) throws RemoteException;
+    }
+
+    /** Runs against the raw per-service binder delivered by onServiceInitSuccess. */
+    public interface BinderOp<T> {
+        T run(IBinder serviceBinder) throws Exception;
+    }
+
+    /** An operation against the typed user-data service. */
     public interface UserDataOp<T> {
         T run(IUserDataService svc) throws Exception;
     }
 
-    /**
-     * Bind, obtain {@link IUserDataService}, run {@code op}, then unbind. Blocking,
-     * with an overall timeout. Must be called off the main thread.
-     */
     public static <T> T withUserData(Context ctx, long timeoutMs, UserDataOp<T> op) throws Exception {
+        return withService(ctx, timeoutMs,
+                IServiceManager::registerUserDataServiceCallback,
+                binder -> op.run(IUserDataService.Stub.asInterface(binder)));
+    }
+
+    /** Start turn-by-turn navigation to a place. Returns Telenav's boolean result. */
+    public static boolean startNavigation(Context ctx, long timeoutMs, Place place) throws Exception {
+        Boolean r = withService(ctx, timeoutMs,
+                IServiceManager::registerNavigationServiceCallback,
+                binder -> rawStartNavigation(binder, place));
+        return Boolean.TRUE.equals(r);
+    }
+
+    private static boolean rawStartNavigation(IBinder binder, Place place) throws RemoteException {
+        Parcel data = Parcel.obtain();
+        Parcel reply = Parcel.obtain();
+        try {
+            data.writeInterfaceToken(NAV_DESCRIPTOR);
+            if (place != null) {
+                data.writeInt(1);
+                place.writeToParcel(data, 0);
+            } else {
+                data.writeInt(0);
+            }
+            binder.transact(TRANSACTION_startNavigation, data, reply, 0);
+            reply.readException();
+            return reply.readInt() != 0;
+        } finally {
+            reply.recycle();
+            data.recycle();
+        }
+    }
+
+    /**
+     * Bind, obtain a service binder via {@code registrar}, run {@code op}, unbind.
+     * Blocking with an overall timeout. Must be called off the main thread.
+     */
+    private static <T> T withService(Context ctx, long timeoutMs, Registrar registrar, BinderOp<T> op)
+            throws Exception {
         if (ctx == null) throw new IllegalStateException("no context");
 
         final CountDownLatch connected = new CountDownLatch(1);
         final CountDownLatch serviceReady = new CountDownLatch(1);
-        final AtomicReference<IServiceManager> manager = new AtomicReference<>();
-        final AtomicReference<IUserDataService> userData = new AtomicReference<>();
+        final AtomicReference<IBinder> serviceBinder = new AtomicReference<>();
         final AtomicReference<String> failure = new AtomicReference<>();
 
         final IServiceInitCallback initCallback = new IServiceInitCallback.Stub() {
             @Override public void onServiceInitSuccess(IBinder binder) {
-                userData.set(IUserDataService.Stub.asInterface(binder));
+                serviceBinder.set(binder);
                 serviceReady.countDown();
             }
             @Override public void onServiceInitFailed() {
@@ -77,14 +124,13 @@ public final class TelenavClient {
         final ServiceConnection conn = new ServiceConnection() {
             @Override public void onServiceConnected(ComponentName name, IBinder binder) {
                 IServiceManager sm = IServiceManager.Stub.asInterface(binder);
-                manager.set(sm);
                 connected.countDown();
                 try {
                     boolean valid = sm.isValid(CLIENT_VERSION);
                     Log.i(TAG, "isValid(" + CLIENT_VERSION + ")=" + valid);
-                    sm.registerUserDataServiceCallback(initCallback);
+                    registrar.register(sm, initCallback);
                 } catch (RemoteException e) {
-                    failure.set("registerUserDataServiceCallback: " + e.getMessage());
+                    failure.set("register callback: " + e.getMessage());
                     serviceReady.countDown();
                 }
             }
@@ -108,14 +154,14 @@ public final class TelenavClient {
                 throw new IllegalStateException("timed out binding TnNaviService");
             }
             if (!serviceReady.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                throw new IllegalStateException("timed out waiting for IUserDataService");
+                throw new IllegalStateException("timed out waiting for service");
             }
-            IUserDataService svc = userData.get();
-            if (svc == null) {
+            IBinder b = serviceBinder.get();
+            if (b == null) {
                 throw new IllegalStateException(failure.get() != null ? failure.get()
-                        : "IUserDataService not delivered");
+                        : "service binder not delivered");
             }
-            return op.run(svc);
+            return op.run(b);
         } finally {
             try { ctx.unbindService(conn); } catch (Throwable ignore) {}
         }

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
@@ -123,6 +123,20 @@ public final class TelenavIpcServer {
             o.put("success", TelenavClient.stopNav(appCtx, 20_000));
             return o;
         }
+        if ("showNavPrompt".equals(op)) {
+            // Deferred navigate: the daemon queued this while the car was off and, on
+            // ACC-on, asks us (app process) to draw the floating prompt. Must run on the
+            // main thread — WindowManager overlay + Telenav bind live here.
+            JSONObject o = new JSONObject();
+            if (appCtx == null) { o.put("success", false); o.put("error", "no app context"); return o; }
+            final String name = req.optString("name", "Shared location");
+            final double lat = req.getDouble("lat");
+            final double lng = req.getDouble("lng");
+            new android.os.Handler(android.os.Looper.getMainLooper()).post(
+                    () -> NavPromptOverlay.show(appCtx, name, lat, lng));
+            o.put("success", true);
+            return o;
+        }
         JSONObject o = new JSONObject();
         o.put("success", false);
         o.put("error", "unknown op: " + op);

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
@@ -118,29 +118,13 @@ public final class TelenavIpcServer {
 
     /** Build a Telenav Place from a request. Coordinates are required; placeId must be non-null. */
     private static Place buildPlace(JSONObject req) throws JSONException {
-        final String name = req.optString("name", "");
-        final double lat = req.getDouble("lat");
-        final double lng = req.getDouble("lng");
-        final String formattedAddress = req.optString("formattedAddress", name);
-        final String favoriteType = req.optString("favoriteType", FavoriteType.Normal);
-        final String placeId = req.optString("placeId", "OD-" + lat + "_" + lng).trim();
-
-        Place place = new Place();
-        place.setPlaceId(placeId);
-        place.setSearchSourceType("ON_BOARD");
-        place.setPlaceName(name);
-        place.setPlaceDisplayLabel(name);
-        place.setPlaceType("ADDRESS");
-        place.setFavoriteType(favoriteType);
-        place.setGeoLatitude(lat);
-        place.setGeoLongitude(lng);
-        place.setNavLatitude(lat);
-        place.setNavLongitude(lng);
-        Address addr = new Address();
-        addr.setFormattedAddress(formattedAddress);
-        addr.setFullAddress(formattedAddress);
-        place.setAddress(addr);
-        return place;
+        return TelenavActions.buildPlace(
+                req.optString("name", ""),
+                req.getDouble("lat"),
+                req.getDouble("lng"),
+                req.optString("favoriteType", FavoriteType.Normal),
+                req.optString("placeId", null),
+                req.optString("formattedAddress", null));
     }
 
     private static JSONObject navigate(JSONObject req) throws Exception {

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
@@ -110,6 +110,19 @@ public final class TelenavIpcServer {
         if ("navigate".equals(op)) {
             return navigate(req);
         }
+        if ("navState".equals(op)) {
+            JSONObject o = new JSONObject();
+            if (appCtx == null) { o.put("success", false); o.put("error", "no app context"); return o; }
+            o.put("success", true);
+            o.put("navState", TelenavClient.getNavState(appCtx, 20_000));
+            return o;
+        }
+        if ("stopNav".equals(op)) {
+            JSONObject o = new JSONObject();
+            if (appCtx == null) { o.put("success", false); o.put("error", "no app context"); return o; }
+            o.put("success", TelenavClient.stopNav(appCtx, 20_000));
+            return o;
+        }
         JSONObject o = new JSONObject();
         o.put("success", false);
         o.put("error", "unknown op: " + op);
@@ -135,6 +148,11 @@ public final class TelenavIpcServer {
             return o;
         }
         Place place = buildPlace(req);
+        if (req.optBoolean("replace", false)) {
+            // Force a fresh route (REPLACE): stop any active nav first, then start.
+            try { TelenavClient.stopNav(appCtx, 20_000); } catch (Exception ignore) {}
+            try { Thread.sleep(1200); } catch (InterruptedException ignore) {}
+        }
         boolean started = TelenavClient.startNavigation(appCtx, 20_000, place);
         o.put("success", started);
         if (!started) o.put("error", "Telenav startNavigation returned false");

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
@@ -1,0 +1,228 @@
+package com.overdrive.app.telenav;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.telenav.app.external.constants.FavoriteType;
+import com.telenav.app.external.model.search.Address;
+import com.telenav.app.external.model.search.Place;
+import com.telenav.app.external.model.userservice.UserDataResult;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.List;
+
+/**
+ * Localhost IPC listener that runs in the APP process and binds Telenav's OEM
+ * AIDL on behalf of the daemon. The daemon's HTTP server ({@code :8080}) cannot
+ * {@code bindService} itself — its synthetic {@code ActivityThread} isn't an
+ * AMS-registered app process ("Unable to find app for caller … when binding
+ * service") — so {@link TelenavDebugApiHandler} forwards Telenav requests here
+ * over {@code 127.0.0.1:19878}, mirroring the app→daemon {@code DaemonIpcClient}
+ * socket in reverse.
+ *
+ * <p>Protocol: one line of JSON request in, one line of JSON response out.
+ * Started from {@code OverdriveApplication.onCreate} (main app process).
+ */
+public final class TelenavIpcServer {
+
+    private static final String TAG = "TelenavIpc";
+    public static final int PORT = 19878;
+
+    // Query every bucket: null / "" (unfiltered) plus each named FavoriteType.
+    private static final String[] TYPES = {
+            null, "", "Home", "Work", "Normal", "School", "Gym", "Daycare", "Custom",
+    };
+
+    private static volatile boolean started = false;
+    private static Context appCtx;
+
+    private TelenavIpcServer() {}
+
+    public static synchronized void start(Context ctx) {
+        if (started) return;
+        appCtx = ctx.getApplicationContext();
+        Thread t = new Thread(TelenavIpcServer::serve, "telenav-ipc");
+        t.setDaemon(true);
+        t.start();
+        started = true;
+    }
+
+    private static void serve() {
+        ServerSocket server = null;
+        try {
+            server = new ServerSocket(PORT, 4, InetAddress.getByName("127.0.0.1"));
+            Log.i(TAG, "listening on 127.0.0.1:" + PORT);
+            while (true) {
+                Socket client = server.accept();
+                handle(client);
+            }
+        } catch (Exception e) {
+            // Most likely another process already bound the port (multi-process); harmless.
+            Log.w(TAG, "server not running: " + e.getMessage());
+        } finally {
+            if (server != null) try { server.close(); } catch (Exception ignore) {}
+        }
+    }
+
+    private static void handle(Socket socket) {
+        try {
+            socket.setSoTimeout(30_000);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
+            String line = reader.readLine();
+            JSONObject resp;
+            try {
+                JSONObject req = (line == null || line.isEmpty())
+                        ? new JSONObject() : new JSONObject(line);
+                resp = dispatch(req);
+            } catch (Exception e) {
+                resp = new JSONObject();
+                try {
+                    resp.put("success", false);
+                    resp.put("error", String.valueOf(e.getMessage()));
+                } catch (JSONException ignore) {}
+            }
+            writer.println(resp.toString());
+        } catch (Exception e) {
+            Log.e(TAG, "handle failed: " + e.getMessage());
+        } finally {
+            try { socket.close(); } catch (Exception ignore) {}
+        }
+    }
+
+    private static JSONObject dispatch(JSONObject req) throws Exception {
+        String op = req.optString("op", "");
+        if ("getFavorites".equals(op)) {
+            return getFavorites();
+        }
+        if ("addFavorite".equals(op)) {
+            return addFavorite(req);
+        }
+        JSONObject o = new JSONObject();
+        o.put("success", false);
+        o.put("error", "unknown op: " + op);
+        return o;
+    }
+
+    private static JSONObject addFavorite(JSONObject req) throws Exception {
+        JSONObject o = new JSONObject();
+        if (appCtx == null) {
+            o.put("success", false);
+            o.put("error", "no app context");
+            return o;
+        }
+        final String type = req.optString("favoriteType", FavoriteType.Normal);
+        final String name = req.optString("name", "");
+        final double lat = req.getDouble("lat");
+        final double lng = req.getDouble("lng");
+        final String formattedAddress = req.optString("formattedAddress", name);
+
+        final Place place = new Place();
+        place.setPlaceName(name);
+        place.setPlaceDisplayLabel(name);
+        place.setPlaceType("ADDRESS");
+        place.setFavoriteType(type);
+        place.setGeoLatitude(lat);
+        place.setGeoLongitude(lng);
+        place.setNavLatitude(lat);
+        place.setNavLongitude(lng);
+        Address addr = new Address();
+        addr.setFormattedAddress(formattedAddress);
+        addr.setFullAddress(formattedAddress);
+        place.setAddress(addr);
+
+        // Read back the bucket after adding so we can confirm it landed + its type.
+        JSONObject readback = TelenavClient.withUserData(appCtx, 20_000, svc -> {
+            svc.addFavorite(type, place);
+            JSONObject rb = new JSONObject();
+            try {
+                UserDataResult r = svc.getFavorites(type);
+                rb.put("bucketType", type);
+                rb.put("maxCount", r == null ? -1 : r.getMaxCount());
+                rb.put("places", placesToJson(r == null ? null : r.getData()));
+            } catch (Exception e) {
+                rb.put("readbackError", String.valueOf(e.getMessage()));
+            }
+            return rb;
+        });
+        o.put("success", true);
+        o.put("wrote", new JSONObject()
+                .put("favoriteType", type).put("name", name).put("lat", lat).put("lng", lng));
+        o.put("readback", readback);
+        return o;
+    }
+
+    private static JSONObject getFavorites() throws Exception {
+        if (appCtx == null) {
+            JSONObject o = new JSONObject();
+            o.put("success", false);
+            o.put("error", "no app context");
+            return o;
+        }
+        JSONObject result = TelenavClient.withUserData(appCtx, 20_000, svc -> {
+            JSONObject o = new JSONObject();
+            JSONArray buckets = new JSONArray();
+            for (String type : TYPES) {
+                JSONObject b = new JSONObject();
+                b.put("queryType", type == null ? JSONObject.NULL : type);
+                try {
+                    UserDataResult r = svc.getFavorites(type);
+                    b.put("resultType", r == null ? JSONObject.NULL : r.getType());
+                    b.put("maxCount", r == null ? -1 : r.getMaxCount());
+                    b.put("places", placesToJson(r == null ? null : r.getData()));
+                } catch (Exception e) {
+                    b.put("error", String.valueOf(e.getMessage()));
+                }
+                buckets.put(b);
+            }
+            o.put("favorites", buckets);
+            try {
+                UserDataResult recent = svc.getRecent();
+                JSONObject rc = new JSONObject();
+                rc.put("maxCount", recent == null ? -1 : recent.getMaxCount());
+                rc.put("places", placesToJson(recent == null ? null : recent.getData()));
+                o.put("recent", rc);
+            } catch (Exception e) {
+                o.put("recentError", String.valueOf(e.getMessage()));
+            }
+            return o;
+        });
+        result.put("success", true);
+        return result;
+    }
+
+    private static JSONArray placesToJson(List<Place> places) throws JSONException {
+        JSONArray arr = new JSONArray();
+        if (places == null) return arr;
+        for (Place p : places) {
+            if (p == null) continue;
+            JSONObject j = new JSONObject();
+            try {
+                j.put("placeName", p.getPlaceName());
+                j.put("displayLabel", p.getPlaceDisplayLabel());
+                j.put("favoriteType", p.getFavoriteType());
+                j.put("placeType", p.getPlaceType());
+                j.put("placeId", p.getPlaceId());
+                j.put("geoLat", p.getGeoLatitude());
+                j.put("geoLng", p.getGeoLongitude());
+                j.put("navLat", p.getNavLatitude());
+                j.put("navLng", p.getNavLongitude());
+                Address a = p.getAddress();
+                if (a != null) j.put("formattedAddress", a.getFormattedAddress());
+            } catch (Throwable t) {
+                j.put("parseError", String.valueOf(t.getMessage()));
+            }
+            arr.put(j);
+        }
+        return arr;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
+++ b/app/src/main/java/com/overdrive/app/telenav/TelenavIpcServer.java
@@ -107,9 +107,57 @@ public final class TelenavIpcServer {
         if ("addFavorite".equals(op)) {
             return addFavorite(req);
         }
+        if ("navigate".equals(op)) {
+            return navigate(req);
+        }
         JSONObject o = new JSONObject();
         o.put("success", false);
         o.put("error", "unknown op: " + op);
+        return o;
+    }
+
+    /** Build a Telenav Place from a request. Coordinates are required; placeId must be non-null. */
+    private static Place buildPlace(JSONObject req) throws JSONException {
+        final String name = req.optString("name", "");
+        final double lat = req.getDouble("lat");
+        final double lng = req.getDouble("lng");
+        final String formattedAddress = req.optString("formattedAddress", name);
+        final String favoriteType = req.optString("favoriteType", FavoriteType.Normal);
+        final String placeId = req.optString("placeId", "OD-" + lat + "_" + lng).trim();
+
+        Place place = new Place();
+        place.setPlaceId(placeId);
+        place.setSearchSourceType("ON_BOARD");
+        place.setPlaceName(name);
+        place.setPlaceDisplayLabel(name);
+        place.setPlaceType("ADDRESS");
+        place.setFavoriteType(favoriteType);
+        place.setGeoLatitude(lat);
+        place.setGeoLongitude(lng);
+        place.setNavLatitude(lat);
+        place.setNavLongitude(lng);
+        Address addr = new Address();
+        addr.setFormattedAddress(formattedAddress);
+        addr.setFullAddress(formattedAddress);
+        place.setAddress(addr);
+        return place;
+    }
+
+    private static JSONObject navigate(JSONObject req) throws Exception {
+        JSONObject o = new JSONObject();
+        if (appCtx == null) {
+            o.put("success", false);
+            o.put("error", "no app context");
+            return o;
+        }
+        Place place = buildPlace(req);
+        boolean started = TelenavClient.startNavigation(appCtx, 20_000, place);
+        o.put("success", started);
+        if (!started) o.put("error", "Telenav startNavigation returned false");
+        o.put("wrote", new JSONObject()
+                .put("name", req.optString("name", ""))
+                .put("lat", req.getDouble("lat"))
+                .put("lng", req.getDouble("lng")));
         return o;
     }
 
@@ -124,21 +172,7 @@ public final class TelenavIpcServer {
         final String name = req.optString("name", "");
         final double lat = req.getDouble("lat");
         final double lng = req.getDouble("lng");
-        final String formattedAddress = req.optString("formattedAddress", name);
-
-        final Place place = new Place();
-        place.setPlaceName(name);
-        place.setPlaceDisplayLabel(name);
-        place.setPlaceType("ADDRESS");
-        place.setFavoriteType(type);
-        place.setGeoLatitude(lat);
-        place.setGeoLongitude(lng);
-        place.setNavLatitude(lat);
-        place.setNavLongitude(lng);
-        Address addr = new Address();
-        addr.setFormattedAddress(formattedAddress);
-        addr.setFullAddress(formattedAddress);
-        place.setAddress(addr);
+        final Place place = buildPlace(req);
 
         // Read back the bucket after adding so we can confirm it landed + its type.
         JSONObject readback = TelenavClient.withUserData(appCtx, 20_000, svc -> {

--- a/app/src/main/java/com/telenav/app/external/IServiceInitCallback.java
+++ b/app/src/main/java/com/telenav/app/external/IServiceInitCallback.java
@@ -1,0 +1,142 @@
+package com.telenav.app.external;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public interface IServiceInitCallback extends IInterface {
+
+    public static class Default implements IServiceInitCallback {
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IServiceInitCallback
+        public void onServiceInitFailed() throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceInitCallback
+        public void onServiceInitSuccess(IBinder iBinder) throws RemoteException {
+        }
+    }
+
+    public static abstract class Stub extends Binder implements IServiceInitCallback {
+        private static final String DESCRIPTOR = "com.telenav.app.external.IServiceInitCallback";
+        public static final int TRANSACTION_onServiceInitFailed = 2;
+        public static final int TRANSACTION_onServiceInitSuccess = 1;
+
+        public static class Proxy implements IServiceInitCallback {
+            public static IServiceInitCallback sDefaultImpl;
+            private IBinder mRemote;
+
+            public Proxy(IBinder iBinder) {
+                this.mRemote = iBinder;
+            }
+
+            @Override // android.os.IInterface
+            public IBinder asBinder() {
+                return this.mRemote;
+            }
+
+            public String getInterfaceDescriptor() {
+                return Stub.DESCRIPTOR;
+            }
+
+            @Override // com.telenav.app.external.IServiceInitCallback
+            public void onServiceInitFailed() throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    if (this.mRemote.transact(2, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().onServiceInitFailed();
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceInitCallback
+            public void onServiceInitSuccess(IBinder iBinder) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iBinder);
+                    if (this.mRemote.transact(1, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().onServiceInitSuccess(iBinder);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+        }
+
+        public Stub() {
+            attachInterface(this, DESCRIPTOR);
+        }
+
+        public static IServiceInitCallback asInterface(IBinder iBinder) {
+            if (iBinder == null) {
+                return null;
+            }
+            IInterface iInterfaceQueryLocalInterface = iBinder.queryLocalInterface(DESCRIPTOR);
+            return (iInterfaceQueryLocalInterface == null || !(iInterfaceQueryLocalInterface instanceof IServiceInitCallback)) ? new Proxy(iBinder) : (IServiceInitCallback) iInterfaceQueryLocalInterface;
+        }
+
+        public static IServiceInitCallback getDefaultImpl() {
+            return Proxy.sDefaultImpl;
+        }
+
+        public static boolean setDefaultImpl(IServiceInitCallback iServiceInitCallback) {
+            if (Proxy.sDefaultImpl != null) {
+                throw new IllegalStateException("setDefaultImpl() called twice");
+            }
+            if (iServiceInitCallback == null) {
+                return false;
+            }
+            Proxy.sDefaultImpl = iServiceInitCallback;
+            return true;
+        }
+
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return this;
+        }
+
+        @Override // android.os.Binder
+        public boolean onTransact(int i, Parcel parcel, Parcel parcel2, int i2) throws RemoteException {
+            if (i == 1) {
+                parcel.enforceInterface(DESCRIPTOR);
+                onServiceInitSuccess(parcel.readStrongBinder());
+                parcel2.writeNoException();
+                return true;
+            }
+            if (i != 2) {
+                if (i != 1598968902) {
+                    return super.onTransact(i, parcel, parcel2, i2);
+                }
+                parcel2.writeString(DESCRIPTOR);
+                return true;
+            }
+            parcel.enforceInterface(DESCRIPTOR);
+            onServiceInitFailed();
+            parcel2.writeNoException();
+            return true;
+        }
+    }
+
+    void onServiceInitFailed() throws RemoteException;
+
+    void onServiceInitSuccess(IBinder iBinder) throws RemoteException;
+}

--- a/app/src/main/java/com/telenav/app/external/IServiceManager.java
+++ b/app/src/main/java/com/telenav/app/external/IServiceManager.java
@@ -1,0 +1,566 @@
+package com.telenav.app.external;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public interface IServiceManager extends IInterface {
+
+    public static class Default implements IServiceManager {
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void getFlowInteractionService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void getMapService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void getNavigtionService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void getSettingService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void getUserDataService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public boolean isValid(String str) throws RemoteException {
+            return false;
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void registerFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void registerMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void registerNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void registerSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void registerUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void unRegisterFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void unRegisterMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void unRegisterNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void unRegisterSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IServiceManager
+        public void unRegisterUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+        }
+    }
+
+    public static abstract class Stub extends Binder implements IServiceManager {
+        private static final String DESCRIPTOR = "com.telenav.app.external.IServiceManager";
+        public static final int TRANSACTION_getFlowInteractionService = 1;
+        public static final int TRANSACTION_getMapService = 4;
+        public static final int TRANSACTION_getNavigtionService = 2;
+        public static final int TRANSACTION_getSettingService = 3;
+        public static final int TRANSACTION_getUserDataService = 5;
+        public static final int TRANSACTION_isValid = 16;
+        public static final int TRANSACTION_registerFlowInteractionServiceCallback = 6;
+        public static final int TRANSACTION_registerMapServiceCallback = 12;
+        public static final int TRANSACTION_registerNavigationServiceCallback = 8;
+        public static final int TRANSACTION_registerSettingServiceCallback = 10;
+        public static final int TRANSACTION_registerUserDataServiceCallback = 14;
+        public static final int TRANSACTION_unRegisterFlowInteractionServiceCallback = 7;
+        public static final int TRANSACTION_unRegisterMapServiceCallback = 13;
+        public static final int TRANSACTION_unRegisterNavigationServiceCallback = 9;
+        public static final int TRANSACTION_unRegisterSettingServiceCallback = 11;
+        public static final int TRANSACTION_unRegisterUserDataServiceCallback = 15;
+
+        public static class Proxy implements IServiceManager {
+            public static IServiceManager sDefaultImpl;
+            private IBinder mRemote;
+
+            public Proxy(IBinder iBinder) {
+                this.mRemote = iBinder;
+            }
+
+            @Override // android.os.IInterface
+            public IBinder asBinder() {
+                return this.mRemote;
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void getFlowInteractionService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(1, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().getFlowInteractionService(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            public String getInterfaceDescriptor() {
+                return Stub.DESCRIPTOR;
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void getMapService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(4, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().getMapService(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void getNavigtionService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(2, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().getNavigtionService(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void getSettingService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(3, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().getSettingService(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void getUserDataService(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(5, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().getUserDataService(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public boolean isValid(String str) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeString(str);
+                    if (!this.mRemote.transact(16, parcelObtain, parcelObtain2, 0) && Stub.getDefaultImpl() != null) {
+                        return Stub.getDefaultImpl().isValid(str);
+                    }
+                    parcelObtain2.readException();
+                    return parcelObtain2.readInt() != 0;
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void registerFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(6, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerFlowInteractionServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void registerMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(12, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerMapServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void registerNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(8, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerNavigationServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void registerSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(10, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerSettingServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void registerUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(14, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerUserDataServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void unRegisterFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(7, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterFlowInteractionServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void unRegisterMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(13, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterMapServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void unRegisterNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(9, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterNavigationServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void unRegisterSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(11, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterSettingServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IServiceManager
+            public void unRegisterUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iServiceInitCallback != null ? iServiceInitCallback.asBinder() : null);
+                    if (this.mRemote.transact(15, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterUserDataServiceCallback(iServiceInitCallback);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+        }
+
+        public Stub() {
+            attachInterface(this, DESCRIPTOR);
+        }
+
+        public static IServiceManager asInterface(IBinder iBinder) {
+            if (iBinder == null) {
+                return null;
+            }
+            IInterface iInterfaceQueryLocalInterface = iBinder.queryLocalInterface(DESCRIPTOR);
+            return (iInterfaceQueryLocalInterface == null || !(iInterfaceQueryLocalInterface instanceof IServiceManager)) ? new Proxy(iBinder) : (IServiceManager) iInterfaceQueryLocalInterface;
+        }
+
+        public static IServiceManager getDefaultImpl() {
+            return Proxy.sDefaultImpl;
+        }
+
+        public static boolean setDefaultImpl(IServiceManager iServiceManager) {
+            if (Proxy.sDefaultImpl != null) {
+                throw new IllegalStateException("setDefaultImpl() called twice");
+            }
+            if (iServiceManager == null) {
+                return false;
+            }
+            Proxy.sDefaultImpl = iServiceManager;
+            return true;
+        }
+
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return this;
+        }
+
+        @Override // android.os.Binder
+        public boolean onTransact(int i, Parcel parcel, Parcel parcel2, int i2) throws RemoteException {
+            if (i == 1598968902) {
+                parcel2.writeString(DESCRIPTOR);
+                return true;
+            }
+            switch (i) {
+                case 1:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    getFlowInteractionService(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 2:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    getNavigtionService(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 3:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    getSettingService(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 4:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    getMapService(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 5:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    getUserDataService(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 6:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerFlowInteractionServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 7:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterFlowInteractionServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 8:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerNavigationServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 9:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterNavigationServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 10:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerSettingServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 11:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterSettingServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 12:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerMapServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 13:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterMapServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 14:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerUserDataServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 15:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterUserDataServiceCallback(IServiceInitCallback.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 16:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    boolean zIsValid = isValid(parcel.readString());
+                    parcel2.writeNoException();
+                    parcel2.writeInt(zIsValid ? 1 : 0);
+                    return true;
+                default:
+                    return super.onTransact(i, parcel, parcel2, i2);
+            }
+        }
+    }
+
+    void getFlowInteractionService(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void getMapService(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void getNavigtionService(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void getSettingService(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void getUserDataService(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    boolean isValid(String str) throws RemoteException;
+
+    void registerFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void registerMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void registerNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void registerSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void registerUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void unRegisterFlowInteractionServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void unRegisterMapServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void unRegisterNavigationServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void unRegisterSettingServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+
+    void unRegisterUserDataServiceCallback(IServiceInitCallback iServiceInitCallback) throws RemoteException;
+}

--- a/app/src/main/java/com/telenav/app/external/IUserDataListener.java
+++ b/app/src/main/java/com/telenav/app/external/IUserDataListener.java
@@ -1,0 +1,119 @@
+package com.telenav.app.external;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+import com.telenav.app.external.model.userservice.UserDataResult;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public interface IUserDataListener extends IInterface {
+
+    public static class Default implements IUserDataListener {
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IUserDataListener
+        public void onFavoriteChanged(String str, UserDataResult userDataResult) throws RemoteException {
+        }
+    }
+
+    public static abstract class Stub extends Binder implements IUserDataListener {
+        private static final String DESCRIPTOR = "com.telenav.app.external.IUserDataListener";
+        public static final int TRANSACTION_onFavoriteChanged = 1;
+
+        public static class Proxy implements IUserDataListener {
+            public static IUserDataListener sDefaultImpl;
+            private IBinder mRemote;
+
+            public Proxy(IBinder iBinder) {
+                this.mRemote = iBinder;
+            }
+
+            @Override // android.os.IInterface
+            public IBinder asBinder() {
+                return this.mRemote;
+            }
+
+            public String getInterfaceDescriptor() {
+                return Stub.DESCRIPTOR;
+            }
+
+            @Override // com.telenav.app.external.IUserDataListener
+            public void onFavoriteChanged(String str, UserDataResult userDataResult) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeString(str);
+                    if (userDataResult != null) {
+                        parcelObtain.writeInt(1);
+                        userDataResult.writeToParcel(parcelObtain, 0);
+                    } else {
+                        parcelObtain.writeInt(0);
+                    }
+                    if (this.mRemote.transact(1, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().onFavoriteChanged(str, userDataResult);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+        }
+
+        public Stub() {
+            attachInterface(this, DESCRIPTOR);
+        }
+
+        public static IUserDataListener asInterface(IBinder iBinder) {
+            if (iBinder == null) {
+                return null;
+            }
+            IInterface iInterfaceQueryLocalInterface = iBinder.queryLocalInterface(DESCRIPTOR);
+            return (iInterfaceQueryLocalInterface == null || !(iInterfaceQueryLocalInterface instanceof IUserDataListener)) ? new Proxy(iBinder) : (IUserDataListener) iInterfaceQueryLocalInterface;
+        }
+
+        public static IUserDataListener getDefaultImpl() {
+            return Proxy.sDefaultImpl;
+        }
+
+        public static boolean setDefaultImpl(IUserDataListener iUserDataListener) {
+            if (Proxy.sDefaultImpl != null) {
+                throw new IllegalStateException("setDefaultImpl() called twice");
+            }
+            if (iUserDataListener == null) {
+                return false;
+            }
+            Proxy.sDefaultImpl = iUserDataListener;
+            return true;
+        }
+
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return this;
+        }
+
+        @Override // android.os.Binder
+        public boolean onTransact(int i, Parcel parcel, Parcel parcel2, int i2) throws RemoteException {
+            if (i != 1) {
+                if (i != 1598968902) {
+                    return super.onTransact(i, parcel, parcel2, i2);
+                }
+                parcel2.writeString(DESCRIPTOR);
+                return true;
+            }
+            parcel.enforceInterface(DESCRIPTOR);
+            onFavoriteChanged(parcel.readString(), parcel.readInt() != 0 ? UserDataResult.CREATOR.createFromParcel(parcel) : null);
+            parcel2.writeNoException();
+            return true;
+        }
+    }
+
+    void onFavoriteChanged(String str, UserDataResult userDataResult) throws RemoteException;
+}

--- a/app/src/main/java/com/telenav/app/external/IUserDataService.java
+++ b/app/src/main/java/com/telenav/app/external/IUserDataService.java
@@ -1,0 +1,349 @@
+package com.telenav.app.external;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+import com.telenav.app.external.model.search.Place;
+import com.telenav.app.external.model.userservice.UserDataResult;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public interface IUserDataService extends IInterface {
+
+    public static class Default implements IUserDataService {
+        @Override // com.telenav.app.external.IUserDataService
+        public void addFavorite(String str, Place place) throws RemoteException {
+        }
+
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public void clearFavorites() throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public void clearRecent() throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public UserDataResult getFavorites(String str) throws RemoteException {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public UserDataResult getRecent() throws RemoteException {
+            return null;
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public void registerUserDataListener(IUserDataListener iUserDataListener) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public void removeFavorite(String str, Place place) throws RemoteException {
+        }
+
+        @Override // com.telenav.app.external.IUserDataService
+        public void unRegisterUserDataListener(IUserDataListener iUserDataListener) throws RemoteException {
+        }
+    }
+
+    public static abstract class Stub extends Binder implements IUserDataService {
+        private static final String DESCRIPTOR = "com.telenav.app.external.IUserDataService";
+        public static final int TRANSACTION_addFavorite = 2;
+        public static final int TRANSACTION_clearFavorites = 4;
+        public static final int TRANSACTION_clearRecent = 6;
+        public static final int TRANSACTION_getFavorites = 1;
+        public static final int TRANSACTION_getRecent = 5;
+        public static final int TRANSACTION_registerUserDataListener = 7;
+        public static final int TRANSACTION_removeFavorite = 3;
+        public static final int TRANSACTION_unRegisterUserDataListener = 8;
+
+        public static class Proxy implements IUserDataService {
+            public static IUserDataService sDefaultImpl;
+            private IBinder mRemote;
+
+            public Proxy(IBinder iBinder) {
+                this.mRemote = iBinder;
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void addFavorite(String str, Place place) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeString(str);
+                    if (place != null) {
+                        parcelObtain.writeInt(1);
+                        place.writeToParcel(parcelObtain, 0);
+                    } else {
+                        parcelObtain.writeInt(0);
+                    }
+                    if (this.mRemote.transact(2, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().addFavorite(str, place);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // android.os.IInterface
+            public IBinder asBinder() {
+                return this.mRemote;
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void clearFavorites() throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    if (this.mRemote.transact(4, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().clearFavorites();
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void clearRecent() throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    if (this.mRemote.transact(6, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().clearRecent();
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public UserDataResult getFavorites(String str) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeString(str);
+                    if (!this.mRemote.transact(1, parcelObtain, parcelObtain2, 0) && Stub.getDefaultImpl() != null) {
+                        return Stub.getDefaultImpl().getFavorites(str);
+                    }
+                    parcelObtain2.readException();
+                    return parcelObtain2.readInt() != 0 ? UserDataResult.CREATOR.createFromParcel(parcelObtain2) : null;
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            public String getInterfaceDescriptor() {
+                return Stub.DESCRIPTOR;
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public UserDataResult getRecent() throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    if (!this.mRemote.transact(5, parcelObtain, parcelObtain2, 0) && Stub.getDefaultImpl() != null) {
+                        return Stub.getDefaultImpl().getRecent();
+                    }
+                    parcelObtain2.readException();
+                    return parcelObtain2.readInt() != 0 ? UserDataResult.CREATOR.createFromParcel(parcelObtain2) : null;
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void registerUserDataListener(IUserDataListener iUserDataListener) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iUserDataListener != null ? iUserDataListener.asBinder() : null);
+                    if (this.mRemote.transact(7, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().registerUserDataListener(iUserDataListener);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void removeFavorite(String str, Place place) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeString(str);
+                    if (place != null) {
+                        parcelObtain.writeInt(1);
+                        place.writeToParcel(parcelObtain, 0);
+                    } else {
+                        parcelObtain.writeInt(0);
+                    }
+                    if (this.mRemote.transact(3, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().removeFavorite(str, place);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+
+            @Override // com.telenav.app.external.IUserDataService
+            public void unRegisterUserDataListener(IUserDataListener iUserDataListener) throws RemoteException {
+                Parcel parcelObtain = Parcel.obtain();
+                Parcel parcelObtain2 = Parcel.obtain();
+                try {
+                    parcelObtain.writeInterfaceToken(Stub.DESCRIPTOR);
+                    parcelObtain.writeStrongBinder(iUserDataListener != null ? iUserDataListener.asBinder() : null);
+                    if (this.mRemote.transact(8, parcelObtain, parcelObtain2, 0) || Stub.getDefaultImpl() == null) {
+                        parcelObtain2.readException();
+                    } else {
+                        Stub.getDefaultImpl().unRegisterUserDataListener(iUserDataListener);
+                    }
+                } finally {
+                    parcelObtain2.recycle();
+                    parcelObtain.recycle();
+                }
+            }
+        }
+
+        public Stub() {
+            attachInterface(this, DESCRIPTOR);
+        }
+
+        public static IUserDataService asInterface(IBinder iBinder) {
+            if (iBinder == null) {
+                return null;
+            }
+            IInterface iInterfaceQueryLocalInterface = iBinder.queryLocalInterface(DESCRIPTOR);
+            return (iInterfaceQueryLocalInterface == null || !(iInterfaceQueryLocalInterface instanceof IUserDataService)) ? new Proxy(iBinder) : (IUserDataService) iInterfaceQueryLocalInterface;
+        }
+
+        public static IUserDataService getDefaultImpl() {
+            return Proxy.sDefaultImpl;
+        }
+
+        public static boolean setDefaultImpl(IUserDataService iUserDataService) {
+            if (Proxy.sDefaultImpl != null) {
+                throw new IllegalStateException("setDefaultImpl() called twice");
+            }
+            if (iUserDataService == null) {
+                return false;
+            }
+            Proxy.sDefaultImpl = iUserDataService;
+            return true;
+        }
+
+        @Override // android.os.IInterface
+        public IBinder asBinder() {
+            return this;
+        }
+
+        @Override // android.os.Binder
+        public boolean onTransact(int i, Parcel parcel, Parcel parcel2, int i2) throws RemoteException {
+            if (i == 1598968902) {
+                parcel2.writeString(DESCRIPTOR);
+                return true;
+            }
+            switch (i) {
+                case 1:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    UserDataResult favorites = getFavorites(parcel.readString());
+                    parcel2.writeNoException();
+                    if (favorites != null) {
+                        parcel2.writeInt(1);
+                        favorites.writeToParcel(parcel2, 1);
+                    } else {
+                        parcel2.writeInt(0);
+                    }
+                    return true;
+                case 2:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    addFavorite(parcel.readString(), parcel.readInt() != 0 ? Place.CREATOR.createFromParcel(parcel) : null);
+                    parcel2.writeNoException();
+                    return true;
+                case 3:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    removeFavorite(parcel.readString(), parcel.readInt() != 0 ? Place.CREATOR.createFromParcel(parcel) : null);
+                    parcel2.writeNoException();
+                    return true;
+                case 4:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    clearFavorites();
+                    parcel2.writeNoException();
+                    return true;
+                case 5:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    UserDataResult recent = getRecent();
+                    parcel2.writeNoException();
+                    if (recent != null) {
+                        parcel2.writeInt(1);
+                        recent.writeToParcel(parcel2, 1);
+                    } else {
+                        parcel2.writeInt(0);
+                    }
+                    return true;
+                case 6:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    clearRecent();
+                    parcel2.writeNoException();
+                    return true;
+                case 7:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    registerUserDataListener(IUserDataListener.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                case 8:
+                    parcel.enforceInterface(DESCRIPTOR);
+                    unRegisterUserDataListener(IUserDataListener.Stub.asInterface(parcel.readStrongBinder()));
+                    parcel2.writeNoException();
+                    return true;
+                default:
+                    return super.onTransact(i, parcel, parcel2, i2);
+            }
+        }
+    }
+
+    void addFavorite(String str, Place place) throws RemoteException;
+
+    void clearFavorites() throws RemoteException;
+
+    void clearRecent() throws RemoteException;
+
+    UserDataResult getFavorites(String str) throws RemoteException;
+
+    UserDataResult getRecent() throws RemoteException;
+
+    void registerUserDataListener(IUserDataListener iUserDataListener) throws RemoteException;
+
+    void removeFavorite(String str, Place place) throws RemoteException;
+
+    void unRegisterUserDataListener(IUserDataListener iUserDataListener) throws RemoteException;
+}

--- a/app/src/main/java/com/telenav/app/external/LatLonData.java
+++ b/app/src/main/java/com/telenav/app/external/LatLonData.java
@@ -1,0 +1,52 @@
+package com.telenav.app.external;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class LatLonData implements Parcelable {
+    public static final Parcelable.Creator<LatLonData> CREATOR = new Parcelable.Creator<LatLonData>() { // from class: com.telenav.app.external.LatLonData.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public LatLonData createFromParcel(Parcel parcel) {
+            return new LatLonData(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public LatLonData[] newArray(int i) {
+            return new LatLonData[i];
+        }
+    };
+    private double lat;
+    private double lon;
+
+    public LatLonData(double d, double d2) {
+        this.lat = d;
+        this.lon = d2;
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public double getLat() {
+        return this.lat;
+    }
+
+    public double getLon() {
+        return this.lon;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeDouble(this.lat);
+        parcel.writeDouble(this.lon);
+    }
+
+    public LatLonData(Parcel parcel) {
+        this.lat = parcel.readDouble();
+        this.lon = parcel.readDouble();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/constants/FavoriteType.java
+++ b/app/src/main/java/com/telenav/app/external/constants/FavoriteType.java
@@ -1,0 +1,16 @@
+package com.telenav.app.external.constants;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+@Retention(RetentionPolicy.SOURCE)
+public @interface FavoriteType {
+    public static final String Custom = "Custom";
+    public static final String Daycare = "Daycare";
+    public static final String Gym = "Gym";
+    public static final String Home = "Home";
+    public static final String Normal = "Normal";
+    public static final String School = "School";
+    public static final String Work = "Work";
+}

--- a/app/src/main/java/com/telenav/app/external/model/InteractionResult.java
+++ b/app/src/main/java/com/telenav/app/external/model/InteractionResult.java
@@ -1,0 +1,63 @@
+package com.telenav.app.external.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class InteractionResult implements Parcelable {
+    public static final Parcelable.Creator<InteractionResult> CREATOR = new Parcelable.Creator<InteractionResult>() { // from class: com.telenav.app.external.model.InteractionResult.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public InteractionResult createFromParcel(Parcel parcel) {
+            return new InteractionResult(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public InteractionResult[] newArray(int i) {
+            return new InteractionResult[i];
+        }
+    };
+    private int code;
+
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ResultCode {
+        public static final int RESULT_APP_NOT_READY = 10026;
+        public static final int RESULT_DUPLICATE_WAYPOINT_ERROR = 10018;
+        public static final int RESULT_FAILED = 10014;
+        public static final int RESULT_FAILED_SDK_INIT_ERROR = -2;
+        public static final int RESULT_NETWORK_ERROR = 10011;
+        public static final int RESULT_OUT_OF_MAX_DISTANCE_ERROR = 10025;
+        public static final int RESULT_OUT_OF_MAX_NUMBER_ERROR = 10017;
+        public static final int RESULT_PARAM_ERROR = 10010;
+        public static final int RESULT_SUCCESS = 10000;
+        public static final int RESULT_UNSUPPORTED_TYPE_ERROR = 10013;
+    }
+
+    public InteractionResult() {
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public int getCode() {
+        return this.code;
+    }
+
+    public void setCode(int i) {
+        this.code = i;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeInt(this.code);
+    }
+
+    public InteractionResult(Parcel parcel) {
+        this.code = parcel.readInt();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/Address.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/Address.java
@@ -1,0 +1,179 @@
+package com.telenav.app.external.model.search;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class Address implements Parcelable {
+    public static final Parcelable.Creator<Address> CREATOR = new Parcelable.Creator<Address>() { // from class: com.telenav.app.external.model.search.Address.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Address createFromParcel(Parcel parcel) {
+            return new Address(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Address[] newArray(int i) {
+            return new Address[i];
+        }
+    };
+    private String city;
+    private String countryCode;
+    private String countryName;
+    private String county;
+    private String crossStreet;
+    private String formattedAddress;
+    private String fullAddress;
+    private String houseNumber;
+    private String postalCode;
+    private String state;
+    private String street;
+    private String subLocality;
+    private String subStreet;
+
+    public Address() {
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public String getCity() {
+        return this.city;
+    }
+
+    public String getCountryCode() {
+        return this.countryCode;
+    }
+
+    public String getCountryName() {
+        return this.countryName;
+    }
+
+    public String getCounty() {
+        return this.county;
+    }
+
+    public String getCrossStreet() {
+        return this.crossStreet;
+    }
+
+    public String getFormattedAddress() {
+        return this.formattedAddress;
+    }
+
+    public String getFullAddress() {
+        return this.fullAddress;
+    }
+
+    public String getHouseNumber() {
+        return this.houseNumber;
+    }
+
+    public String getPostalCode() {
+        return this.postalCode;
+    }
+
+    public String getState() {
+        return this.state;
+    }
+
+    public String getStreet() {
+        return this.street;
+    }
+
+    public String getSubLocality() {
+        return this.subLocality;
+    }
+
+    public String getSubStreet() {
+        return this.subStreet;
+    }
+
+    public void setCity(String str) {
+        this.city = str;
+    }
+
+    public void setCountryCode(String str) {
+        this.countryCode = str;
+    }
+
+    public void setCountryName(String str) {
+        this.countryName = str;
+    }
+
+    public void setCounty(String str) {
+        this.county = str;
+    }
+
+    public void setCrossStreet(String str) {
+        this.crossStreet = str;
+    }
+
+    public void setFormattedAddress(String str) {
+        this.formattedAddress = str;
+    }
+
+    public void setFullAddress(String str) {
+        this.fullAddress = str;
+    }
+
+    public void setHouseNumber(String str) {
+        this.houseNumber = str;
+    }
+
+    public void setPostalCode(String str) {
+        this.postalCode = str;
+    }
+
+    public void setState(String str) {
+        this.state = str;
+    }
+
+    public void setStreet(String str) {
+        this.street = str;
+    }
+
+    public void setSubLocality(String str) {
+        this.subLocality = str;
+    }
+
+    public void setSubStreet(String str) {
+        this.subStreet = str;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.formattedAddress);
+        parcel.writeString(this.fullAddress);
+        parcel.writeString(this.houseNumber);
+        parcel.writeString(this.subStreet);
+        parcel.writeString(this.street);
+        parcel.writeString(this.crossStreet);
+        parcel.writeString(this.subLocality);
+        parcel.writeString(this.city);
+        parcel.writeString(this.county);
+        parcel.writeString(this.state);
+        parcel.writeString(this.postalCode);
+        parcel.writeString(this.countryName);
+        parcel.writeString(this.countryCode);
+    }
+
+    public Address(Parcel parcel) {
+        this.formattedAddress = parcel.readString();
+        this.fullAddress = parcel.readString();
+        this.houseNumber = parcel.readString();
+        this.subStreet = parcel.readString();
+        this.street = parcel.readString();
+        this.crossStreet = parcel.readString();
+        this.subLocality = parcel.readString();
+        this.city = parcel.readString();
+        this.county = parcel.readString();
+        this.state = parcel.readString();
+        this.postalCode = parcel.readString();
+        this.countryName = parcel.readString();
+        this.countryCode = parcel.readString();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/Brand.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/Brand.java
@@ -1,0 +1,52 @@
+package com.telenav.app.external.model.search;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class Brand implements Parcelable {
+    public static final Parcelable.Creator<Brand> CREATOR = new Parcelable.Creator<Brand>() { // from class: com.telenav.app.external.model.search.Brand.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Brand createFromParcel(Parcel parcel) {
+            return new Brand(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Brand[] newArray(int i) {
+            return new Brand[i];
+        }
+    };
+    private final String brandId;
+    private final String brandName;
+
+    public Brand(String str, String str2) {
+        this.brandId = str;
+        this.brandName = str2;
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public String getBrandId() {
+        return this.brandId;
+    }
+
+    public String getBrandName() {
+        return this.brandName;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.brandId);
+        parcel.writeString(this.brandName);
+    }
+
+    public Brand(Parcel parcel) {
+        this.brandId = parcel.readString();
+        this.brandName = parcel.readString();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/Category.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/Category.java
@@ -1,0 +1,52 @@
+package com.telenav.app.external.model.search;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class Category implements Parcelable {
+    public static final Parcelable.Creator<Category> CREATOR = new Parcelable.Creator<Category>() { // from class: com.telenav.app.external.model.search.Category.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Category createFromParcel(Parcel parcel) {
+            return new Category(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Category[] newArray(int i) {
+            return new Category[i];
+        }
+    };
+    private int id;
+    private String name;
+
+    public Category(String str, int i) {
+        this.name = str;
+        this.id = i;
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.name);
+        parcel.writeInt(this.id);
+    }
+
+    public Category(Parcel parcel) {
+        this.name = parcel.readString();
+        this.id = parcel.readInt();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/Place.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/Place.java
@@ -1,0 +1,260 @@
+package com.telenav.app.external.model.search;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import com.telenav.app.external.LatLonData;
+import com.telenav.app.external.model.search.placeextrainfo.PoiExtraInfo;
+import java.util.List;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class Place implements Parcelable {
+    public static final Parcelable.Creator<Place> CREATOR = new Parcelable.Creator<Place>() { // from class: com.telenav.app.external.model.search.Place.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Place createFromParcel(Parcel parcel) {
+            return new Place(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public Place[] newArray(int i) {
+            return new Place[i];
+        }
+    };
+    private Address address;
+    private List<Brand> brands;
+    private List<Category> categories;
+    private float distanceInMeter;
+    private Bundle extraInfo;
+    private String facetsInfo;
+    private String favoriteType;
+    private String formattedDistance;
+    private double geoLatitude;
+    private double geoLongitude;
+    private double navLatitude;
+    private double navLongitude;
+    private List<LatLonData> navPoints;
+    private String phone;
+    private String placeDisplayLabel;
+    private String placeId;
+    private String placeName;
+    private String placeType;
+    private PoiExtraInfo poiExtraInfo;
+    private String searchSourceType;
+
+    public Place() {
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public Address getAddress() {
+        return this.address;
+    }
+
+    public List<Brand> getBrands() {
+        return this.brands;
+    }
+
+    public List<Category> getCategories() {
+        return this.categories;
+    }
+
+    public float getDistanceInMeter() {
+        return this.distanceInMeter;
+    }
+
+    public Bundle getExtraInfo() {
+        return this.extraInfo;
+    }
+
+    public String getFacetsInfo() {
+        return this.facetsInfo;
+    }
+
+    public String getFavoriteType() {
+        return this.favoriteType;
+    }
+
+    public String getFormattedDistance() {
+        return this.formattedDistance;
+    }
+
+    public double getGeoLatitude() {
+        return this.geoLatitude;
+    }
+
+    public double getGeoLongitude() {
+        return this.geoLongitude;
+    }
+
+    public double getNavLatitude() {
+        return this.navLatitude;
+    }
+
+    public double getNavLongitude() {
+        return this.navLongitude;
+    }
+
+    public List<LatLonData> getNavPoints() {
+        return this.navPoints;
+    }
+
+    public String getPhone() {
+        return this.phone;
+    }
+
+    public String getPlaceDisplayLabel() {
+        return this.placeDisplayLabel;
+    }
+
+    public String getPlaceId() {
+        return this.placeId;
+    }
+
+    public String getPlaceName() {
+        return this.placeName;
+    }
+
+    public String getPlaceType() {
+        return this.placeType;
+    }
+
+    public PoiExtraInfo getPoiExtraInfo() {
+        return this.poiExtraInfo;
+    }
+
+    public String getSearchSourceType() {
+        return this.searchSourceType;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public void setBrands(List<Brand> list) {
+        this.brands = list;
+    }
+
+    public void setCategories(List<Category> list) {
+        this.categories = list;
+    }
+
+    public void setDistanceInMeter(float f) {
+        this.distanceInMeter = f;
+    }
+
+    public void setExtraInfo(Bundle bundle) {
+        this.extraInfo = bundle;
+    }
+
+    public void setFacetsInfo(String str) {
+        this.facetsInfo = str;
+    }
+
+    public void setFavoriteType(String str) {
+        this.favoriteType = str;
+    }
+
+    public void setFormattedDistance(String str) {
+        this.formattedDistance = str;
+    }
+
+    public void setGeoLatitude(double d) {
+        this.geoLatitude = d;
+    }
+
+    public void setGeoLongitude(double d) {
+        this.geoLongitude = d;
+    }
+
+    public void setNavLatitude(double d) {
+        this.navLatitude = d;
+    }
+
+    public void setNavLongitude(double d) {
+        this.navLongitude = d;
+    }
+
+    public void setNavPoints(List<LatLonData> list) {
+        this.navPoints = list;
+    }
+
+    public void setPhone(String str) {
+        this.phone = str;
+    }
+
+    public void setPlaceDisplayLabel(String str) {
+        this.placeDisplayLabel = str;
+    }
+
+    public void setPlaceId(String str) {
+        this.placeId = str;
+    }
+
+    public void setPlaceName(String str) {
+        this.placeName = str;
+    }
+
+    public void setPlaceType(String str) {
+        this.placeType = str;
+    }
+
+    public void setPoiExtraInfo(PoiExtraInfo poiExtraInfo) {
+        this.poiExtraInfo = poiExtraInfo;
+    }
+
+    public void setSearchSourceType(String str) {
+        this.searchSourceType = str;
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(this.placeId);
+        parcel.writeString(this.placeName);
+        parcel.writeParcelable(this.address, i);
+        parcel.writeFloat(this.distanceInMeter);
+        parcel.writeTypedList(this.categories);
+        parcel.writeTypedList(this.brands);
+        parcel.writeString(this.favoriteType);
+        parcel.writeBundle(this.extraInfo);
+        parcel.writeDouble(this.geoLatitude);
+        parcel.writeDouble(this.geoLongitude);
+        parcel.writeDouble(this.navLatitude);
+        parcel.writeDouble(this.navLongitude);
+        parcel.writeString(this.phone);
+        parcel.writeParcelable(this.poiExtraInfo, i);
+        parcel.writeString(this.formattedDistance);
+        parcel.writeString(this.placeDisplayLabel);
+        parcel.writeString(this.placeType);
+        parcel.writeString(this.searchSourceType);
+        parcel.writeString(this.facetsInfo);
+        parcel.writeTypedList(this.navPoints);
+    }
+
+    public Place(Parcel parcel) {
+        this.placeId = parcel.readString();
+        this.placeName = parcel.readString();
+        this.address = (Address) parcel.readParcelable(Address.class.getClassLoader());
+        this.distanceInMeter = parcel.readFloat();
+        this.categories = parcel.createTypedArrayList(Category.CREATOR);
+        this.brands = parcel.createTypedArrayList(Brand.CREATOR);
+        this.favoriteType = parcel.readString();
+        this.extraInfo = parcel.readBundle();
+        this.geoLatitude = parcel.readDouble();
+        this.geoLongitude = parcel.readDouble();
+        this.navLatitude = parcel.readDouble();
+        this.navLongitude = parcel.readDouble();
+        this.phone = parcel.readString();
+        this.poiExtraInfo = (PoiExtraInfo) parcel.readParcelable(PoiExtraInfo.class.getClassLoader());
+        this.formattedDistance = parcel.readString();
+        this.placeDisplayLabel = parcel.readString();
+        this.placeType = parcel.readString();
+        this.searchSourceType = parcel.readString();
+        this.facetsInfo = parcel.readString();
+        this.navPoints = parcel.createTypedArrayList(LatLonData.CREATOR);
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/placeextrainfo/ChargeInfo.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/placeextrainfo/ChargeInfo.java
@@ -1,0 +1,102 @@
+package com.telenav.app.external.model.search.placeextrainfo;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class ChargeInfo implements Parcelable {
+    public static final Parcelable.Creator<ChargeInfo> CREATOR = new Parcelable.Creator<ChargeInfo>() { // from class: com.telenav.app.external.model.search.placeextrainfo.ChargeInfo.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public ChargeInfo createFromParcel(Parcel parcel) {
+            return new ChargeInfo(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public ChargeInfo[] newArray(int i) {
+            return new ChargeInfo[i];
+        }
+    };
+    private int available;
+    private String power;
+    private int total;
+
+    public ChargeInfo() {
+    }
+
+    public static ChargeInfo fromJson(String str) {
+        ChargeInfo chargeInfo = new ChargeInfo();
+        try {
+            JSONObject jSONObject = new JSONObject(str);
+            if (jSONObject.has("total")) {
+                chargeInfo.total = jSONObject.optInt("total");
+            }
+            if (jSONObject.has("available")) {
+                chargeInfo.available = jSONObject.optInt("available");
+            }
+            if (jSONObject.has("power")) {
+                chargeInfo.power = jSONObject.optString("power");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return chargeInfo;
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public int getAvailable() {
+        return this.available;
+    }
+
+    public String getPower() {
+        return this.power;
+    }
+
+    public int getTotal() {
+        return this.total;
+    }
+
+    public void setAvailable(int i) {
+        this.available = i;
+    }
+
+    public void setPower(String str) {
+        this.power = str;
+    }
+
+    public void setTotal(int i) {
+        this.total = i;
+    }
+
+    public JSONObject toJson() throws JSONException {
+        JSONObject jSONObject = new JSONObject();
+        jSONObject.put("total", this.total);
+        jSONObject.put("available", this.available);
+        jSONObject.put("power", this.power);
+        return jSONObject;
+    }
+
+    public String toString() {
+        return "ChargeInfo{total=" + this.total + ", available=" + this.available + ", power=" + this.power + '}';
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeInt(this.total);
+        parcel.writeInt(this.available);
+        parcel.writeString(this.power);
+    }
+
+    public ChargeInfo(Parcel parcel) {
+        this.total = parcel.readInt();
+        this.available = parcel.readInt();
+        this.power = parcel.readString();
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/search/placeextrainfo/PoiExtraInfo.java
+++ b/app/src/main/java/com/telenav/app/external/model/search/placeextrainfo/PoiExtraInfo.java
@@ -1,0 +1,85 @@
+package com.telenav.app.external.model.search.placeextrainfo;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class PoiExtraInfo implements Parcelable {
+    public static final Parcelable.Creator<PoiExtraInfo> CREATOR = new Parcelable.Creator<PoiExtraInfo>() { // from class: com.telenav.app.external.model.search.placeextrainfo.PoiExtraInfo.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public PoiExtraInfo createFromParcel(Parcel parcel) {
+            return new PoiExtraInfo(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public PoiExtraInfo[] newArray(int i) {
+            return new PoiExtraInfo[i];
+        }
+    };
+    private boolean busiState;
+    private String busiTime;
+    private List<ChargeInfo> content;
+    private String payment;
+
+    public PoiExtraInfo() {
+    }
+
+    @Override // android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public boolean getBusiState() {
+        return this.busiState;
+    }
+
+    public String getBusiTime() {
+        return this.busiTime;
+    }
+
+    public List<ChargeInfo> getContent() {
+        return this.content;
+    }
+
+    public String getPayment() {
+        return this.payment;
+    }
+
+    public void setBusiState(boolean z) {
+        this.busiState = z;
+    }
+
+    public void setBusiTime(String str) {
+        this.busiTime = str;
+    }
+
+    public void setContent(List<ChargeInfo> list) {
+        this.content = list;
+    }
+
+    public void setPayment(String str) {
+        this.payment = str;
+    }
+
+    public String toString() {
+        return "PoiExtraInfo{busiState='" + this.busiState + "', busiTime=" + this.busiTime + ", payment='" + this.payment + "', content='" + this.content + '}';
+    }
+
+    @Override // android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeByte(this.busiState ? (byte) 1 : (byte) 0);
+        parcel.writeString(this.busiTime);
+        parcel.writeString(this.payment);
+        parcel.writeTypedList(this.content);
+    }
+
+    public PoiExtraInfo(Parcel parcel) {
+        this.busiState = parcel.readByte() != 0;
+        this.busiTime = parcel.readString();
+        this.payment = parcel.readString();
+        this.content = parcel.createTypedArrayList(ChargeInfo.CREATOR);
+    }
+}

--- a/app/src/main/java/com/telenav/app/external/model/userservice/UserDataResult.java
+++ b/app/src/main/java/com/telenav/app/external/model/userservice/UserDataResult.java
@@ -1,0 +1,74 @@
+package com.telenav.app.external.model.userservice;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import com.telenav.app.external.model.InteractionResult;
+import com.telenav.app.external.model.search.Place;
+import java.util.List;
+
+/* JADX INFO: loaded from: /tmp/claude-1338850283/-home-pal-kristensen-geodata-no/cc05901e-c414-4c8c-8231-cd74795cb1da/scratchpad/dex/classes21.dex */
+public class UserDataResult extends InteractionResult {
+    public static final Parcelable.Creator<UserDataResult> CREATOR = new Parcelable.Creator<UserDataResult>() { // from class: com.telenav.app.external.model.userservice.UserDataResult.1
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public UserDataResult createFromParcel(Parcel parcel) {
+            return new UserDataResult(parcel);
+        }
+
+        /* JADX WARN: Can't rename method to resolve collision */
+        @Override // android.os.Parcelable.Creator
+        public UserDataResult[] newArray(int i) {
+            return new UserDataResult[i];
+        }
+    };
+    private List<Place> data;
+    private int maxCount;
+    private String type;
+
+    public UserDataResult() {
+    }
+
+    @Override // com.telenav.app.external.model.InteractionResult, android.os.Parcelable
+    public int describeContents() {
+        return 0;
+    }
+
+    public List<Place> getData() {
+        return this.data;
+    }
+
+    public int getMaxCount() {
+        return this.maxCount;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setData(List<Place> list) {
+        this.data = list;
+    }
+
+    public void setMaxCount(int i) {
+        this.maxCount = i;
+    }
+
+    public void setType(String str) {
+        this.type = str;
+    }
+
+    @Override // com.telenav.app.external.model.InteractionResult, android.os.Parcelable
+    public void writeToParcel(Parcel parcel, int i) {
+        super.writeToParcel(parcel, i);
+        parcel.writeTypedList(this.data);
+        parcel.writeInt(this.maxCount);
+        parcel.writeString(this.type);
+    }
+
+    public UserDataResult(Parcel parcel) {
+        super(parcel);
+        this.data = parcel.createTypedArrayList(Place.CREATOR);
+        this.maxCount = parcel.readInt();
+        this.type = parcel.readString();
+    }
+}

--- a/app/src/main/res/layout/activity_roadsense_map.xml
+++ b/app/src/main/res/layout/activity_roadsense_map.xml
@@ -536,39 +536,61 @@
                     app:tint="?attr/colorOnSurfaceVariant" />
             </LinearLayout>
 
-            <!-- TRIP STOPS — the ordered itinerary (origin → intermediate stops →
-                 destination) plus an "Add stop" affordance. Rebuilt in code by
-                 RoadSenseMapActivity.rebuildStopsUi() into this LinearLayout: an
-                 origin row ("Your location"), one row per entry in routeStops
-                 (each with a remove X + up/down reorder controls), and an
-                 "Add stop" row at the end. Kept as a code-populated container
-                 (not a RecyclerView) since the list is tiny (≤ MAX_STOPS). -->
-            <LinearLayout
-                android:id="@+id/routeStopsContainer"
+            <!-- Scrollable middle: itinerary + route candidates. Header (above) and
+                 the Start button (below) stay pinned; only this region scrolls when
+                 there are many routes, so the header car icon never scrolls off-screen.
+                 Its height is capped in code (RoadSenseMapActivity.showRouteOptionsSheet)
+                 so the whole sheet fits the short landscape screen; short content keeps
+                 the sheet compact (wrap_content). -->
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/routeSheetScroll"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:orientation="vertical" />
+                android:fillViewport="true"
+                android:overScrollMode="ifContentScrolls">
 
-            <!-- Thin divider between the itinerary and the route candidates. -->
-            <View
-                android:id="@+id/routeStopsDivider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginVertical="8dp"
-                android:background="?attr/colorOutlineVariant" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/routeOptionsList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:clipToPadding="false"
-                android:overScrollMode="ifContentScrolls"
-                android:paddingVertical="2dp"
-                tools:itemCount="2"
-                tools:listitem="@layout/item_nav_route_option" />
+                    <!-- TRIP STOPS — the ordered itinerary (origin → intermediate stops →
+                         destination) plus an "Add stop" affordance. Rebuilt in code by
+                         RoadSenseMapActivity.rebuildStopsUi() into this LinearLayout: an
+                         origin row ("Your location"), one row per entry in routeStops
+                         (each with a remove X + up/down reorder controls), and an
+                         "Add stop" row at the end. Kept as a code-populated container
+                         (not a RecyclerView) since the list is tiny (≤ MAX_STOPS). -->
+                    <LinearLayout
+                        android:id="@+id/routeStopsContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:orientation="vertical" />
+
+                    <!-- Thin divider between the itinerary and the route candidates. -->
+                    <View
+                        android:id="@+id/routeStopsDivider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginVertical="8dp"
+                        android:background="?attr/colorOutlineVariant" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/routeOptionsList"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:clipToPadding="false"
+                        android:nestedScrollingEnabled="false"
+                        android:overScrollMode="never"
+                        android:paddingVertical="2dp"
+                        tools:itemCount="2"
+                        tools:listitem="@layout/item_nav_route_option" />
+
+                </LinearLayout>
+            </androidx.core.widget.NestedScrollView>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnRouteStart"

--- a/app/src/main/res/layout/activity_roadsense_map.xml
+++ b/app/src/main/res/layout/activity_roadsense_map.xml
@@ -501,6 +501,18 @@
                     tools:text="Routes to Changi Airport" />
 
                 <ImageButton
+                    android:id="@+id/btnRouteCarNav"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="4dp"
+                    android:background="@drawable/bg_nav_leading_icon"
+                    android:contentDescription="@string/carnav_section_header"
+                    android:padding="8dp"
+                    android:scaleType="fitCenter"
+                    android:src="@drawable/ic_directions_car"
+                    app:tint="?attr/colorOnSurfaceVariant" />
+
+                <ImageButton
                     android:id="@+id/btnRouteSheetSave"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
@@ -573,44 +585,8 @@
                 app:iconGravity="textStart"
                 app:iconPadding="10dp" />
 
-            <!-- Hand this destination to the car's built-in navigation instead -->
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginBottom="6dp"
-                android:text="@string/carnav_section_header"
-                android:textAppearance="?attr/textAppearanceLabelMedium"
-                android:alpha="0.7" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginBottom="6dp"
-                android:baselineAligned="false"
-                android:orientation="horizontal">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnRouteCarNavNavigate"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:layout_marginEnd="5dp"
-                    android:paddingVertical="14dp"
-                    android:text="@string/carnav_navigate" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnRouteCarNavSave"
-                    style="@style/Widget.Material3.Button.TonalButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:layout_marginStart="5dp"
-                    android:paddingVertical="14dp"
-                    android:text="@string/carnav_save_favourite" />
-            </LinearLayout>
+            <!-- "Send to car navigation" lives as a header icon (btnRouteCarNav) so it
+                 stays visible; the old bottom buttons scrolled off the short screen. -->
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/activity_roadsense_map.xml
+++ b/app/src/main/res/layout/activity_roadsense_map.xml
@@ -572,6 +572,45 @@
                 app:icon="@drawable/ic_directions_car"
                 app:iconGravity="textStart"
                 app:iconPadding="10dp" />
+
+            <!-- Hand this destination to the car's built-in navigation instead -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="6dp"
+                android:text="@string/carnav_section_header"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                android:alpha="0.7" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginBottom="6dp"
+                android:baselineAligned="false"
+                android:orientation="horizontal">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRouteCarNavNavigate"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="5dp"
+                    android:paddingVertical="14dp"
+                    android:text="@string/carnav_navigate" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRouteCarNavSave"
+                    style="@style/Widget.Material3.Button.TonalButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="5dp"
+                    android:paddingVertical="14dp"
+                    android:text="@string/carnav_save_favourite" />
+            </LinearLayout>
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/sheet_place_action.xml
+++ b/app/src/main/res/layout/sheet_place_action.xml
@@ -126,4 +126,40 @@
             app:iconGravity="textStart" />
     </LinearLayout>
 
+    <!-- Hand the place to the car's built-in navigation (factory nav) -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:layout_marginBottom="6dp"
+        android:text="@string/carnav_section_header"
+        android:textAppearance="?attr/textAppearanceLabelMedium"
+        android:alpha="0.7" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCarNavNavigate"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="5dp"
+            android:paddingVertical="14dp"
+            android:text="@string/carnav_navigate" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCarNavSave"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="5dp"
+            android:paddingVertical="14dp"
+            android:text="@string/carnav_save_favourite" />
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/sheet_poi_action.xml
+++ b/app/src/main/res/layout/sheet_poi_action.xml
@@ -87,4 +87,40 @@
         app:icon="@drawable/ic_directions"
         app:iconGravity="textStart" />
 
+    <!-- Hand the POI to the car's built-in navigation -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:layout_marginBottom="6dp"
+        android:text="@string/carnav_section_header"
+        android:textAppearance="?attr/textAppearanceLabelMedium"
+        android:alpha="0.7" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnPoiCarNavNavigate"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="5dp"
+            android:paddingVertical="14dp"
+            android:text="@string/carnav_navigate" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnPoiCarNavSave"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="5dp"
+            android:paddingVertical="14dp"
+            android:text="@string/carnav_save_favourite" />
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1630,6 +1630,8 @@
     <string name="roadsense_map_navigate_here">Navigate here</string>
     <string name="carnav_section_header">Send to car navigation</string>
     <string name="carnav_navigate">Navigate</string>
+    <string name="carnav_menu_navigate_here">Navigate here (replace route)</string>
+    <string name="carnav_menu_add_stop">Add as stop</string>
     <string name="carnav_save_favourite">Save to Favourites</string>
     <string name="carnav_sending">Sending to car navigation…</string>
     <string name="carnav_navigate_ok">Navigation started</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1632,6 +1632,9 @@
     <string name="carnav_navigate">Navigate</string>
     <string name="carnav_menu_navigate_here">Navigate here (replace route)</string>
     <string name="carnav_menu_add_stop">Add as stop</string>
+    <string name="carnav_deferred_prompt_title">Navigation offered</string>
+    <string name="carnav_deferred_yes">Accept</string>
+    <string name="carnav_deferred_cancel">Decline</string>
     <string name="carnav_save_favourite">Save to Favourites</string>
     <string name="carnav_sending">Sending to car navigation…</string>
     <string name="carnav_navigate_ok">Navigation started</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1628,6 +1628,14 @@
     <!-- Place-action sheet (long-press the map or a search result to save/navigate) -->
     <string name="roadsense_map_dropped_pin">Dropped pin</string>
     <string name="roadsense_map_navigate_here">Navigate here</string>
+    <string name="carnav_section_header">Send to car navigation</string>
+    <string name="carnav_navigate">Navigate</string>
+    <string name="carnav_save_favourite">Save to Favourites</string>
+    <string name="carnav_sending">Sending to car navigation…</string>
+    <string name="carnav_navigate_ok">Navigation started</string>
+    <string name="carnav_navigate_fail">Car navigation declined the request</string>
+    <string name="carnav_saved_ok">Saved to favourites</string>
+    <string name="carnav_failed">Couldn\'t reach car navigation: %1$s</string>
     <!-- Shown after tapping an unset Home/Work chip: search picks the place to save. -->
     <string name="roadsense_map_search_to_save">Search a place to set as %1$s</string>
     <!-- Shown when re-entering the map with a previously-set trip restored. -->


### PR DESCRIPTION
My Audi could take a location shared from my phone and drop it straight into the car's navigation. The BYD Seal's factory nav, Telenav, has no such path: nothing outside the head unit can hand it a place. But Telenav ships an external AIDL service, `TnNaviService` (`com.telenav.app.external.service.NAVI`), that is exported and gated by nothing, so a normal `bindService` reaches it. Through it OverDrive can read and write Telenav's favourites and start navigation, which is enough to rebuild that "send to car" flow on the Seal.

This is a bridge to the **factory** Telenav nav. It adds new files and endpoints, a send-to-car control on the map's place, POI and route sheets, and one guarded line in `CameraDaemon`. It adds alongside existing behaviour and changes none of it. The bind runs in the app process: the daemon can't `bindService` (AMS rejects it, "Unable to find app for caller"), so a small localhost IPC hands Telenav work from the daemon's HTTP server to the app.

## What this delivers

**A `/api/telenav/*` bridge to the factory nav.** Read the favourite buckets and recents, add a favourite, start navigation, read and stop the current nav state, all over Telenav's OEM AIDL. This is the endpoint the companion phone app talks to, and it stands on its own.

**"Send to car navigation" in the RoadSense map.** A car icon on the place, POI and route sheets opens Navigate here, Add as stop, or Save to favourites. A place found in OverDrive's own map can be handed to the factory nav without retyping it.

**Foreground handling, because guidance needs it.** Telenav accepts `startNavigation` and returns success while backgrounded, but only engages guidance once it is the foreground app. So a navigate brings Telenav to the front first: `startActivity` from the on-car map (a foreground caller), or `am start` from the daemon for a request that arrives while OverDrive is backgrounded.

**Add-a-stop vs replace-the-route.** Telenav's external `startNavigation` takes only a place, no mode: called while a route is active it adds the place as a waypoint, called idle it starts fresh. To force a fresh single-destination route it stops the active nav first, then starts. Both are offered, Navigate here (replace) and Add as stop.

**Deferred navigate for a car that's off.** A Navigate that arrives while the car is off would be a silent no-op, screen off and nothing to foreground. Instead it is queued, and on the next ACC-on OverDrive offers it as a floating prompt, Accept or Decline, themed to match the app and the head unit's day/night. The prompt holds while the car is in reverse so it never covers the rear camera, and a target older than four hours is dropped.

**A companion phone app as one client.** Send to BYD registers as a share target: share a Google Maps place, it resolves to coordinates and posts to `/api/telenav/*`. It is a separate, MIT-licensed repo, and the on-car pieces above work without it. Get the APK from the [latest release](https://github.com/paalkr/byd-share/releases/latest); source at [paalkr/byd-share](https://github.com/paalkr/byd-share).

## How you use it

1. In OverDrive's map, tap a search result or POI and pick **Send to car navigation** → Navigate here, Add as stop, or Save to favourites.
2. Or from your phone, share a place to **Send to BYD**; it lands in the car.
3. If the car is off when you send a Navigate, start the car and Accept the prompt.

## Notes for review

**Only the `Normal` bucket is a writable favourite.** Home and Work are real but set through Telenav's own UI (they carry Google place ids); School/Gym/Daycare/Custom accept an `addFavorite` and return success but persist nothing. So the clients only ever write `Normal`, the heart list.

**Navigate is a no-op unless Telenav is foregrounded**, verified live: the call returns success and the nav-state stays idle while Telenav is backgrounded. The foreground step above is load-bearing, not defensive.

**The bind must be app-process.** The daemon's synthetic `ActivityThread` isn't an AMS-registered app, so `bindService` fails with "Unable to find app for caller". The app process binds Telenav and the daemon reaches it over `127.0.0.1`.

**Deferred-nav is isolated from the surveillance ACC state machine.** It runs its own `AccMonitorController` on the same `sys.accanim.status` signal rather than threading into `CameraDaemon`'s ACC handling, and its one boot line is wrapped so it can never take the daemon down. Gear for the reverse hold comes from the existing `GearMonitor`.

## Testing

Verified on a 2024 BYD Seal, DiLink 3.0 (build `eng.build.20260204.025317`): favourites add and read back over the AIDL; navigate starts guidance, a second navigate adds a waypoint, and a replace produces a fresh route; the on-car sheets hand a place to Telenav; and a Navigate sent with the car off is offered as the prompt on the next start, starting guidance on Accept. `assembleDebug` passes on this branch; the native surveillance target needs OpenCV configured in the build environment, unchanged here.

## Screenshots

<img width="504" height="735" alt="Screenshot_2026-08-24_14-56-44" src="https://github.com/user-attachments/assets/5a76dbed-2d35-42ce-bc18-fad9524de0ae" />
<img width="501" height="1113" alt="Screenshot_2026-08-24_14-57-06" src="https://github.com/user-attachments/assets/88cdabba-14b5-438f-90a7-1b38a2b3ee83" />
<img width="501" height="709" alt="Screenshot_2026-08-24_14-57-51" src="https://github.com/user-attachments/assets/81f2304f-f7fc-4226-8995-3a554cb52ec5" />
<img width="1828" height="1031" alt="Screenshot_2026-08-24_14-56-06" src="https://github.com/user-attachments/assets/9c406fde-37ee-4566-88a0-c12b9ee9a7e1" />
<img width="1826" height="1022" alt="Screenshot_2026-08-24_14-55-29" src="https://github.com/user-attachments/assets/0d9f89c0-f727-45e7-90e1-95de7e1dc857" />

