### PR TITLE
add overlink support

### DIFF
--- a/app/src/main/java/com/overdrive/app/notifications/NotificationStore.java
+++ b/app/src/main/java/com/overdrive/app/notifications/NotificationStore.java
@@ -107,6 +107,21 @@ public final class NotificationStore {
         return instance;
     }
 
+    /**
+     * The store only if it exists and has opened its database — never
+     * constructing one as a side effect of asking.
+     *
+     * <p>{@link #getInstance()} always hands back an object, so a caller that
+     * only wants to read (the Overlink event feed) cannot tell "log is running"
+     * from "log never started" without this. Returning null lets that caller
+     * answer 503 instead of silently serving an empty event list, which the
+     * phone would cache as "nothing happened".
+     */
+    public static NotificationStore getInstanceOrNull() {
+        NotificationStore s = instance;
+        return (s != null && s.isInitialized) ? s : null;
+    }
+
     // ==================== LIFECYCLE ====================
 
     public void init() {
@@ -388,6 +403,41 @@ public final class NotificationStore {
             }
         }
         return new Page(out, total);
+    }
+
+    /**
+     * Ascending-by-id page of rows newer than {@code sinceId} — the cursor read
+     * behind the Overlink event feed.
+     *
+     * <p>Deliberately ordered by {@code id} and not by {@code ts}: the caller
+     * keeps a cursor and asks for everything newer on foreground, so the ordering
+     * key has to be the same monotonic value it stores. Ordering by timestamp
+     * would silently skip a row inserted with an out-of-order clock, which is
+     * exactly the case a head unit with a drifting RTC produces.
+     *
+     * @param sinceId exclusive lower bound; 0 for "from the beginning"
+     */
+    public JSONArray listSince(long sinceId, int limit) {
+        JSONArray out = new JSONArray();
+        if (limit < 1) limit = 1;
+        if (limit > MAX_PAGE_SIZE) limit = MAX_PAGE_SIZE;
+        synchronized (lock) {
+            if (!isInitialized || connection == null) return out;
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT " + COLS + " FROM " + TABLE
+                            + " WHERE id > ? ORDER BY id ASC LIMIT ?;")) {
+                ps.setLong(1, sinceId);
+                ps.setInt(2, limit);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) out.put(rowToJson(rs));
+                }
+            } catch (Exception e) {
+                logger.error("NotificationStore.listSince failed: " + e.getMessage(), e);
+                reconnect();
+                return new JSONArray();
+            }
+        }
+        return out;
     }
 
     private JSONObject rowToJson(ResultSet rs) throws Exception {

--- a/app/src/main/java/com/overdrive/app/overlink/CarIdentity.java
+++ b/app/src/main/java/com/overdrive/app/overlink/CarIdentity.java
@@ -1,0 +1,188 @@
+package com.overdrive.app.overlink;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The car's own tailnet identity, read from {@code tailscale status --json} (§4.3).
+ *
+ * <p>No API call is needed for any of this — the CLI is already on disk and the
+ * daemon runs as the shell UID that owns it, so this execs the binary directly
+ * rather than going the long way round through
+ * {@link com.overdrive.app.launcher.TailscaleLauncher}'s ADB executor (which
+ * needs an Android {@code Context} the daemon JVM does not have).
+ *
+ * <p>Paths and the CLI socket mirror {@code TailscaleLauncher}'s constants; if
+ * those move, these must move with them.
+ */
+public final class CarIdentity {
+
+    private static final String TAILSCALE_HOME = "/data/local/tmp/.tailscale";
+    private static final String TAILSCALE_BIN = TAILSCALE_HOME + "/tailscale";
+    private static final String CLI_SOCKET = "127.0.0.1:8532";
+
+    private static final long EXEC_TIMEOUT_SEC = 10;
+
+    /** Tailscale's CGNAT v4 range and its ULA v6 prefix (§4.4 validation). */
+    private static final String TS_V6_PREFIX = "fd7a:115c:a1e0";
+
+    public final String nodeId;
+    public final String tailscaleIp;
+    /** MagicDNS name with the trailing dot stripped — the phone tolerates it, display does not. */
+    public final String fqdn;
+    public final String backendState;
+    public final boolean tagged;
+    public final JSONArray tags;
+
+    private CarIdentity(String nodeId, String tailscaleIp, String fqdn,
+                        String backendState, boolean tagged, JSONArray tags) {
+        this.nodeId = nodeId;
+        this.tailscaleIp = tailscaleIp;
+        this.fqdn = fqdn;
+        this.backendState = backendState;
+        this.tagged = tagged;
+        this.tags = tags;
+    }
+
+    /** True when the node has joined a tailnet and pairing may be offered. */
+    public boolean isRunning() {
+        return "Running".equals(backendState);
+    }
+
+    /** True when every field the QR requires is present and well-formed. */
+    public boolean isComplete() {
+        return isRunning()
+                && nodeId != null && !nodeId.isEmpty()
+                && tailscaleIp != null && isTailscaleAddress(tailscaleIp)
+                && fqdn != null && !fqdn.isEmpty();
+    }
+
+    public JSONObject toJson() {
+        JSONObject j = new JSONObject();
+        try {
+            j.put("node_id", nodeId == null ? JSONObject.NULL : nodeId);
+            j.put("ts_ip", tailscaleIp == null ? JSONObject.NULL : tailscaleIp);
+            j.put("fqdn", fqdn == null ? JSONObject.NULL : fqdn);
+            j.put("backend_state", backendState == null ? "Unknown" : backendState);
+            j.put("running", isRunning());
+            j.put("complete", isComplete());
+            // The most common first-run stumble: an untagged car cannot be named
+            // as a grant destination, so pairing "works" and then nothing routes.
+            j.put("tagged", tagged);
+            j.put("tags", tags != null ? tags : new JSONArray());
+        } catch (Exception ignored) {
+            // JSONObject.put only throws on a null key; nothing to recover.
+        }
+        return j;
+    }
+
+    // ==================== READ ====================
+
+    /** Runs the CLI and parses {@code Self}. Never returns null; check {@link #isRunning()}. */
+    public static CarIdentity read() {
+        String out = exec(TAILSCALE_BIN + " --socket " + CLI_SOCKET + " status --json");
+        if (out == null || out.isEmpty()) {
+            return new CarIdentity(null, null, null, "Unreachable", false, new JSONArray());
+        }
+        try {
+            JSONObject root = new JSONObject(out);
+            String backendState = root.optString("BackendState", "Unknown");
+            JSONObject self = root.optJSONObject("Self");
+            if (self == null) {
+                return new CarIdentity(null, null, null, backendState, false, new JSONArray());
+            }
+
+            String nodeId = emptyToNull(self.optString("ID", ""));
+
+            String ip = null;
+            JSONArray ips = self.optJSONArray("TailscaleIPs");
+            if (ips != null) {
+                // Prefer the v4 CGNAT address; the phone accepts either.
+                for (int i = 0; i < ips.length(); i++) {
+                    String candidate = ips.optString(i, "");
+                    if (isTailscaleAddress(candidate)) {
+                        ip = candidate;
+                        if (candidate.indexOf(':') < 0) break;
+                    }
+                }
+            }
+
+            // DNSName is fully qualified with a trailing dot.
+            String fqdn = self.optString("DNSName", "");
+            if (fqdn.endsWith(".")) fqdn = fqdn.substring(0, fqdn.length() - 1);
+            fqdn = emptyToNull(fqdn);
+
+            JSONArray tags = self.optJSONArray("Tags");
+            if (tags == null) tags = new JSONArray();
+
+            return new CarIdentity(nodeId, ip, fqdn, backendState, tags.length() > 0, tags);
+        } catch (Exception e) {
+            OverlinkConfig.log("status --json parse failed: " + e.getMessage());
+            return new CarIdentity(null, null, null, "Unparseable", false, new JSONArray());
+        }
+    }
+
+    /** The car's short MagicDNS label, used as a display name fallback. */
+    public String shortName() {
+        if (fqdn == null || fqdn.isEmpty()) return "OverDrive";
+        int dot = fqdn.indexOf('.');
+        return dot > 0 ? fqdn.substring(0, dot) : fqdn;
+    }
+
+    // ==================== VALIDATION ====================
+
+    /** Must be inside {@code 100.64.0.0/10} or {@code fd7a:115c:a1e0::/48} (§4.4). */
+    public static boolean isTailscaleAddress(String addr) {
+        if (addr == null || addr.isEmpty()) return false;
+        if (addr.indexOf(':') >= 0) {
+            return addr.toLowerCase(java.util.Locale.US).startsWith(TS_V6_PREFIX);
+        }
+        String[] parts = addr.split("\\.");
+        if (parts.length != 4) return false;
+        try {
+            int a = Integer.parseInt(parts[0]);
+            int b = Integer.parseInt(parts[1]);
+            for (int i = 2; i < 4; i++) {
+                int v = Integer.parseInt(parts[i]);
+                if (v < 0 || v > 255) return false;
+            }
+            // 100.64.0.0/10 → first octet 100, second octet 64..127.
+            return a == 100 && b >= 64 && b <= 127;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    // ==================== PLUMBING ====================
+
+    private static String exec(String cmd) {
+        Process p = null;
+        try {
+            p = new ProcessBuilder("sh", "-c", cmd).redirectErrorStream(false).start();
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                String line;
+                while ((line = r.readLine()) != null) sb.append(line).append('\n');
+            }
+            if (!p.waitFor(EXEC_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+                OverlinkConfig.log("status --json timed out");
+                return null;
+            }
+            return sb.toString().trim();
+        } catch (Exception e) {
+            OverlinkConfig.log("status --json exec failed: " + e.getMessage());
+            return null;
+        } finally {
+            if (p != null) p.destroy();
+        }
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/overlink/DeviceRegistry.java
+++ b/app/src/main/java/com/overdrive/app/overlink/DeviceRegistry.java
@@ -1,0 +1,277 @@
+package com.overdrive.app.overlink;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * The paired-phone registry (§5.2), stored in the {@code overlink} config section.
+ *
+ * <p>Rows are keyed on the client-generated, install-stable {@code device_id}, so
+ * re-pairing the same phone updates its row rather than leaving a ghost behind.
+ * {@code first_paired} is preserved across updates.
+ *
+ * <p>{@code node_id} is the phone's own StableNodeID, supplied directly in the
+ * registration payload rather than inferred from the connection's source address
+ * — inference works on the first registration and stops working the moment the
+ * phone's address changes. It is what makes {@link #revoke one-action revocation}
+ * possible at all: without it, revoking can only set a flag while the phone keeps
+ * its tailnet access.
+ */
+public final class DeviceRegistry {
+
+    /** Guards the read-modify-write cycle against two concurrent registrations. */
+    private static final Object LOCK = new Object();
+
+    /**
+     * Cap on stored rows. Far above any plausible household; keeps a hostile or
+     * looping client from growing the config file without bound.
+     */
+    private static final int MAX_DEVICES = 64;
+
+    public static final int MAX_FIELD_LEN = 128;
+
+    private DeviceRegistry() {}
+
+    // ==================== READ ====================
+
+    /** All rows, newest activity first. Never null. */
+    public static JSONArray list() {
+        JSONArray devices = OverlinkConfig.devices();
+        JSONArray sorted = new JSONArray();
+        java.util.List<JSONObject> rows = new java.util.ArrayList<>();
+        for (int i = 0; i < devices.length(); i++) {
+            JSONObject d = devices.optJSONObject(i);
+            if (d != null) rows.add(d);
+        }
+        rows.sort((a, b) -> Long.compare(b.optLong("last_seen", 0), a.optLong("last_seen", 0)));
+        for (JSONObject r : rows) sorted.put(r);
+        return sorted;
+    }
+
+    public static JSONObject find(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) return null;
+        JSONArray devices = OverlinkConfig.devices();
+        for (int i = 0; i < devices.length(); i++) {
+            JSONObject d = devices.optJSONObject(i);
+            if (d != null && deviceId.equals(d.optString("device_id", null))) return d;
+        }
+        return null;
+    }
+
+    public static int activeCount() {
+        JSONArray devices = OverlinkConfig.devices();
+        int n = 0;
+        for (int i = 0; i < devices.length(); i++) {
+            JSONObject d = devices.optJSONObject(i);
+            if (d != null && !d.optBoolean("revoked", false)) n++;
+        }
+        return n;
+    }
+
+    // ==================== WRITE ====================
+
+    /**
+     * Insert or update a row from a registration payload (§5.1).
+     *
+     * @return the stored row, or null when the write failed.
+     */
+    public static JSONObject upsert(String deviceId, String label, String platform,
+                                    String osVersion, String appVersion, String nodeId,
+                                    String nodeIp, JSONObject pushRoute) {
+        if (deviceId == null || deviceId.isEmpty()) return null;
+        long now = System.currentTimeMillis() / 1000L;
+
+        synchronized (LOCK) {
+            JSONArray devices = OverlinkConfig.devicesFresh();
+            JSONArray next = new JSONArray();
+            JSONObject stored = null;
+
+            for (int i = 0; i < devices.length(); i++) {
+                JSONObject d = devices.optJSONObject(i);
+                if (d == null) continue;
+                if (deviceId.equals(d.optString("device_id", null))) {
+                    stored = d;               // keep the original first_paired
+                } else {
+                    next.put(d);
+                }
+            }
+
+            try {
+                JSONObject row = stored != null ? stored : new JSONObject();
+                if (stored == null) row.put("first_paired", now);
+                row.put("device_id", deviceId);
+                row.put("label", clamp(label));
+                row.put("platform", clamp(platform));
+                row.put("os_version", clamp(osVersion));
+                row.put("app_version", clamp(appVersion));
+                row.put("node_id", clamp(nodeId));
+                row.put("node_ip", clamp(nodeIp));
+                row.put("last_seen", now);
+                // Re-registering an explicitly revoked phone un-revokes it: the
+                // owner had to display a fresh QR for that to be possible.
+                row.put("revoked", false);
+                // Always null in v1. Stored anyway so notifications can be turned
+                // on later without asking every existing user to re-scan (§5.1).
+                row.put("push_route", pushRoute != null ? pushRoute : JSONObject.NULL);
+
+                next.put(row);
+                trim(next);
+
+                if (!OverlinkConfig.writeDevices(next)) {
+                    OverlinkConfig.log("registry write failed for " + deviceId);
+                    return null;
+                }
+                return row;
+            } catch (Exception e) {
+                OverlinkConfig.log("registry upsert failed: " + e.getMessage());
+                return null;
+            }
+        }
+    }
+
+    /** Bump {@code last_seen} without touching anything else. Best-effort. */
+    public static void touch(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) return;
+        synchronized (LOCK) {
+            JSONArray devices = OverlinkConfig.devicesFresh();
+            boolean changed = false;
+            for (int i = 0; i < devices.length(); i++) {
+                JSONObject d = devices.optJSONObject(i);
+                if (d != null && deviceId.equals(d.optString("device_id", null))) {
+                    try {
+                        d.put("last_seen", System.currentTimeMillis() / 1000L);
+                        changed = true;
+                    } catch (Exception ignored) {
+                        // Non-fatal: last_seen is cosmetic.
+                    }
+                    break;
+                }
+            }
+            if (changed) OverlinkConfig.writeDevices(devices);
+        }
+    }
+
+    // ==================== REVOCATION (§5.3) ====================
+
+    /** Outcome of a revoke attempt, so the UI can report exactly what happened. */
+    public static final class RevokeResult {
+        public final boolean ok;
+        public final String error;
+        /** True when the row existed but carried no node ID to delete. */
+        public final boolean missingNodeId;
+
+        RevokeResult(boolean ok, String error, boolean missingNodeId) {
+            this.ok = ok;
+            this.error = error;
+            this.missingNodeId = missingNodeId;
+        }
+    }
+
+    /**
+     * Revoke a phone: mark the registry row <em>and</em> delete the tailnet node.
+     * One action, both halves, always.
+     *
+     * <p>Registry-only revocation leaves a phone with working tailnet access;
+     * tailnet-only deletion leaves a stale row that silently re-registers on the
+     * next pair. So if the Tailscale call fails, the row is <em>not</em> marked
+     * either — better a visible error than a half-applied revocation the UI
+     * claims succeeded.
+     *
+     * <p>Note for the UI: revoking the OAuth client does not deauthorize
+     * already-paired phones. It only stops new ones being paired.
+     */
+    public static RevokeResult revoke(String deviceId) {
+        JSONObject row = find(deviceId);
+        if (row == null) {
+            return new RevokeResult(false, "No such paired device", false);
+        }
+        String nodeId = row.optString("node_id", "");
+
+        TailscaleApiClient api = TailscaleApiClient.fromConfig();
+        if (api == null) {
+            return new RevokeResult(false,
+                    "Phone pairing is not set up, so the tailnet node cannot be removed. "
+                    + "Delete it in the Tailscale admin console, or add the OAuth client first.",
+                    nodeId.isEmpty());
+        }
+        if (nodeId.isEmpty()) {
+            return new RevokeResult(false,
+                    "This device registered without a node ID, so its tailnet access cannot be "
+                    + "removed from here. Delete it in the Tailscale admin console.",
+                    true);
+        }
+
+        try {
+            api.deleteDevice(nodeId);
+        } catch (TailscaleApiClient.ApiException e) {
+            OverlinkConfig.log("revoke failed for " + deviceId + ": " + e.getMessage());
+            return new RevokeResult(false, e.getMessage(), false);
+        }
+
+        // The tailnet half succeeded — now, and only now, mark the row.
+        synchronized (LOCK) {
+            JSONArray devices = OverlinkConfig.devicesFresh();
+            for (int i = 0; i < devices.length(); i++) {
+                JSONObject d = devices.optJSONObject(i);
+                if (d != null && deviceId.equals(d.optString("device_id", null))) {
+                    try {
+                        d.put("revoked", true);
+                        d.put("revoked_at", System.currentTimeMillis() / 1000L);
+                    } catch (Exception ignored) {
+                        // Non-fatal: the tailnet node is already gone.
+                    }
+                    break;
+                }
+            }
+            OverlinkConfig.writeDevices(devices);
+        }
+        return new RevokeResult(true, null, false);
+    }
+
+    /** Drop a revoked row entirely. Does not touch the tailnet — see {@link #revoke}. */
+    public static boolean forget(String deviceId) {
+        if (deviceId == null || deviceId.isEmpty()) return false;
+        synchronized (LOCK) {
+            JSONArray devices = OverlinkConfig.devicesFresh();
+            JSONArray next = new JSONArray();
+            boolean removed = false;
+            for (int i = 0; i < devices.length(); i++) {
+                JSONObject d = devices.optJSONObject(i);
+                if (d == null) continue;
+                if (deviceId.equals(d.optString("device_id", null))) {
+                    removed = true;
+                } else {
+                    next.put(d);
+                }
+            }
+            return removed && OverlinkConfig.writeDevices(next);
+        }
+    }
+
+    // ==================== PLUMBING ====================
+
+    /** Drop the least recently seen revoked rows, then the oldest, down to the cap. */
+    private static void trim(JSONArray devices) {
+        if (devices.length() <= MAX_DEVICES) return;
+        java.util.List<JSONObject> rows = new java.util.ArrayList<>();
+        for (int i = 0; i < devices.length(); i++) {
+            JSONObject d = devices.optJSONObject(i);
+            if (d != null) rows.add(d);
+        }
+        rows.sort((a, b) -> {
+            boolean ra = a.optBoolean("revoked", false);
+            boolean rb = b.optBoolean("revoked", false);
+            if (ra != rb) return ra ? 1 : -1;   // revoked rows go last
+            return Long.compare(b.optLong("last_seen", 0), a.optLong("last_seen", 0));
+        });
+        while (devices.length() > 0) devices.remove(devices.length() - 1);
+        for (int i = 0; i < Math.min(rows.size(), MAX_DEVICES); i++) devices.put(rows.get(i));
+    }
+
+    /** Bound every stored string so a hostile payload can't bloat the config. */
+    private static String clamp(String s) {
+        if (s == null) return "";
+        String t = s.trim();
+        return t.length() > MAX_FIELD_LEN ? t.substring(0, MAX_FIELD_LEN) : t;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/overlink/LanAddress.java
+++ b/app/src/main/java/com/overdrive/app/overlink/LanAddress.java
@@ -1,0 +1,160 @@
+package com.overdrive.app.overlink;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.Enumeration;
+
+/**
+ * Local-network address classification.
+ *
+ * <p>Two jobs, both of which the phone's parser also does independently:
+ *
+ * <ul>
+ *   <li>Find the car's own private LAN address for the optional {@code lan_ip}
+ *       hint and the §4.6 claim QR. A routable value is rejected — the phone
+ *       refuses one, so emitting it would only produce a pairing that fails
+ *       later rather than here.</li>
+ *   <li>Decide whether an inbound request arrived over the tailnet, which is the
+ *       authenticated channel §11.2 requires for registration and events. The
+ *       LAN is not authenticated, and only the claim endpoint is served there.</li>
+ * </ul>
+ */
+public final class LanAddress {
+
+    private LanAddress() {}
+
+    // ==================== OUR OWN ADDRESS ====================
+
+    /**
+     * The car's private IPv4 LAN address, or null when it only has routable or
+     * Tailscale addresses. Tailscale's own CGNAT range is deliberately excluded:
+     * {@code lan_ip} is a hint for reaching the car <em>before</em> the tunnel
+     * exists, so a tailnet address there would be useless.
+     */
+    public static String privateAddress() {
+        try {
+            Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+            if (ifaces == null) return null;
+            String fallback = null;
+            for (NetworkInterface ni : Collections.list(ifaces)) {
+                if (!ni.isUp() || ni.isLoopback()) continue;
+                String name = ni.getName();
+                // tailscale0 / tun* carry tailnet addresses, not LAN ones.
+                if (name != null && (name.startsWith("tailscale") || name.startsWith("tun"))) continue;
+
+                for (InetAddress addr : Collections.list(ni.getInetAddresses())) {
+                    if (!(addr instanceof Inet4Address)) continue;
+                    String ip = addr.getHostAddress();
+                    if (ip == null || CarIdentity.isTailscaleAddress(ip)) continue;
+                    if (!isPrivateOrLocal(ip)) continue;
+                    // Prefer a real Wi-Fi/Ethernet address over link-local.
+                    if (addr.isLinkLocalAddress()) {
+                        if (fallback == null) fallback = ip;
+                    } else {
+                        return ip;
+                    }
+                }
+            }
+            return fallback;
+        } catch (Exception e) {
+            OverlinkConfig.log("LAN address lookup failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ==================== CLASSIFYING INBOUND REQUESTS ====================
+
+    /**
+     * True when the request came from a Tailscale peer — i.e. over the tunnel.
+     * §11.2 requires registration and the event stream to refuse anything else.
+     */
+    public static boolean isTailnetPeer(SocketAddress clientAddress) {
+        String ip = extractIp(clientAddress);
+        return ip != null && CarIdentity.isTailscaleAddress(ip);
+    }
+
+    /** True for loopback, so the settings UI's own calls are recognised. */
+    public static boolean isLoopback(SocketAddress clientAddress) {
+        String ip = extractIp(clientAddress);
+        if (ip == null) return false;
+        return ip.equals("127.0.0.1") || ip.startsWith("127.") || ip.equals("::1")
+                || ip.equals("0:0:0:0:0:0:0:1");
+    }
+
+    /**
+     * True for a private, link-local or loopback source — the set the §4.6 claim
+     * endpoint is willing to answer, since it must be reachable before the
+     * tailnet is up.
+     */
+    public static boolean isLocalNetwork(SocketAddress clientAddress) {
+        String ip = extractIp(clientAddress);
+        return ip != null && isPrivateOrLocal(ip);
+    }
+
+    /**
+     * RFC 1918, CGNAT-excluding, plus link-local, loopback and IPv6 ULA. Used
+     * both for the address we advertise and for the sources we answer, so the
+     * two can never drift apart.
+     */
+    public static boolean isPrivateOrLocal(String ip) {
+        if (ip == null || ip.isEmpty()) return false;
+        if (ip.indexOf(':') >= 0) {
+            String v6 = ip.toLowerCase(java.util.Locale.US);
+            int pct = v6.indexOf('%');            // strip a zone id
+            if (pct > 0) v6 = v6.substring(0, pct);
+            return v6.equals("::1")
+                    || v6.equals("0:0:0:0:0:0:0:1")
+                    || v6.startsWith("fe80:")     // link-local
+                    || v6.startsWith("fc") || v6.startsWith("fd"); // unique local
+        }
+        String[] parts = ip.split("\\.");
+        if (parts.length != 4) return false;
+        int a, b;
+        try {
+            a = Integer.parseInt(parts[0]);
+            b = Integer.parseInt(parts[1]);
+            for (int i = 2; i < 4; i++) {
+                int v = Integer.parseInt(parts[i]);
+                if (v < 0 || v > 255) return false;
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        if (a < 0 || a > 255 || b < 0 || b > 255) return false;
+        if (a == 10) return true;                              // 10/8
+        if (a == 172 && b >= 16 && b <= 31) return true;       // 172.16/12
+        if (a == 192 && b == 168) return true;                 // 192.168/16
+        if (a == 169 && b == 254) return true;                 // 169.254/16 link-local
+        if (a == 127) return true;                             // loopback
+        return false;
+    }
+
+    /**
+     * Pull the bare IP out of a {@link SocketAddress}. Java renders these as
+     * {@code /10.0.0.5:41234} or {@code host/10.0.0.5:41234}, and IPv6 as
+     * {@code /fd7a:…:1234}, so the port is split from the right.
+     */
+    public static String extractIp(SocketAddress addr) {
+        if (addr == null) return null;
+        if (addr instanceof java.net.InetSocketAddress) {
+            InetAddress ia = ((java.net.InetSocketAddress) addr).getAddress();
+            if (ia != null) {
+                String host = ia.getHostAddress();
+                if (host == null) return null;
+                int pct = host.indexOf('%');
+                return pct > 0 ? host.substring(0, pct) : host;
+            }
+        }
+        String s = addr.toString();
+        int slash = s.indexOf('/');
+        if (slash >= 0) s = s.substring(slash + 1);
+        int colon = s.lastIndexOf(':');
+        if (colon > 0) s = s.substring(0, colon);
+        int pct = s.indexOf('%');
+        if (pct > 0) s = s.substring(0, pct);
+        return s.isEmpty() ? null : s;
+    }
+}

--- a/app/src/main/java/com/overdrive/app/overlink/OverlinkClient.kt
+++ b/app/src/main/java/com/overdrive/app/overlink/OverlinkClient.kt
@@ -1,0 +1,182 @@
+package com.overdrive.app.overlink
+
+import com.overdrive.app.util.DaemonHttpClient
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+/**
+ * App-side client for the daemon's `/api/overlink/v1` endpoints.
+ *
+ * The pairing state machine, the Tailscale API credentials and the device
+ * registry all live in the daemon JVM ([OverlinkPairingManager] explains why),
+ * so the settings screen reaches them the same way every other cross-UID read in
+ * this app does: authenticated loopback HTTP via [DaemonHttpClient].
+ *
+ * Every method here is **blocking** and must be called off the UI thread. A key
+ * mint is up to three round trips to `api.tailscale.com` over what may be a car
+ * SIM; a settings screen frozen for four seconds reads as a crash and gets
+ * reported as one.
+ *
+ * Nothing throws. Failures come back as [Result.failure] with a message the
+ * pairing screen can show verbatim, because each of the daemon's failure
+ * reasons already maps to its own user-facing action.
+ */
+object OverlinkClient {
+
+    private const val BASE = "/api/overlink/v1"
+
+    /** Generous: a mint is three sequential calls to Tailscale over a car SIM. */
+    private const val PAIR_READ_TIMEOUT_MS = 45_000
+
+    private const val DEFAULT_READ_TIMEOUT_MS = 10_000
+
+    /**
+     * A parsed daemon response.
+     *
+     * @param reason the daemon's machine-readable failure code (`not_configured`,
+     *   `tag_not_owned`, `clock_skew`, …) — this is what the screen switches on to
+     *   pick a message and a next action, never the human text.
+     */
+    data class Failure(val status: Int, val reason: String, val message: String)
+
+    // ==================== SETUP ====================
+
+    /** Owner-facing setup state, car identity, capabilities and the ACL grant. */
+    fun status(): Result<JSONObject> = get("$BASE/status")
+
+    /**
+     * Save the OAuth client and pairing preferences.
+     *
+     * Pass a null [clientSecret] to leave the stored secret untouched — the
+     * screen never reads it back, so re-saving a tag or a toggle must not
+     * clear it.
+     */
+    fun saveConfig(
+        clientId: String? = null,
+        clientSecret: String? = null,
+        phoneTag: String? = null,
+        carTag: String? = null,
+        shareDeviceToken: Boolean? = null,
+        lanPairing: Boolean? = null,
+        carName: String? = null,
+        carModel: String? = null,
+    ): Result<JSONObject> {
+        val body = JSONObject()
+        clientId?.let { body.put("oauth_client_id", it) }
+        clientSecret?.let { body.put("oauth_client_secret", it) }
+        phoneTag?.let { body.put("phone_tag", it) }
+        carTag?.let { body.put("car_tag", it) }
+        shareDeviceToken?.let { body.put("share_device_token", it) }
+        lanPairing?.let { body.put("lan_pairing", it) }
+        carName?.let { body.put("car_name", it) }
+        carModel?.let { body.put("car_model", it) }
+        return send("POST", "$BASE/config", body)
+    }
+
+    /**
+     * Forget the OAuth client. Does **not** deauthorize already-paired phones —
+     * it only stops new ones being paired. The screen must say so.
+     */
+    fun clearConfig(): Result<JSONObject> = send("DELETE", "$BASE/config", null)
+
+    // ==================== PAIRING ====================
+
+    /**
+     * Mint a key and issue a pairing session. The response carries `uri` (the QR
+     * payload) and `expires_at`; on failure, `reason` selects the screen's error
+     * state.
+     */
+    fun startPairing(): Result<JSONObject> =
+        send("POST", "$BASE/pair/start", null, readTimeoutMs = PAIR_READ_TIMEOUT_MS)
+
+    /** Poll for the countdown and for the ISSUED → CONSUMED transition. */
+    fun pairingSession(): Result<JSONObject> = get("$BASE/pair/session")
+
+    /**
+     * Clear the QR and delete the key. Called on expiry, on navigating away and
+     * on screen sleep — both halves, every time.
+     */
+    fun cancelPairing(reason: String): Result<JSONObject> =
+        send("POST", "$BASE/pair/cancel", JSONObject().put("reason", reason))
+
+    // ==================== DEVICES ====================
+
+    fun devices(): Result<JSONObject> = get("$BASE/devices")
+
+    /**
+     * Revoke a phone: registry row *and* tailnet node, in one action. Fails
+     * without marking the row if the tailnet half fails, so the two halves can
+     * never disagree.
+     */
+    fun revoke(deviceId: String): Result<JSONObject> =
+        send("POST", "$BASE/devices/${enc(deviceId)}/revoke", null, readTimeoutMs = 20_000)
+
+    /** Drop an already-revoked row. Refused by the daemon for a live device. */
+    fun forget(deviceId: String): Result<JSONObject> =
+        send("POST", "$BASE/devices/${enc(deviceId)}/forget", null)
+
+    // ==================== PLUMBING ====================
+
+    private fun get(path: String): Result<JSONObject> = send("GET", path, null)
+
+    private fun send(
+        method: String,
+        path: String,
+        body: JSONObject?,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT_MS,
+    ): Result<JSONObject> {
+        var conn: java.net.HttpURLConnection? = null
+        return try {
+            conn = DaemonHttpClient.open(path, method, connectTimeoutMs = 3000, readTimeoutMs = readTimeoutMs)
+            if (body != null) {
+                conn.doOutput = true
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.outputStream.use { it.write(body.toString().toByteArray(Charsets.UTF_8)) }
+            }
+            val status = conn.responseCode
+            // A 4xx/5xx puts the body on the error stream, and that body is where
+            // the daemon's `reason` lives — so read whichever stream is populated.
+            val stream = if (status in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.let {
+                BufferedReader(InputStreamReader(it, Charsets.UTF_8)).use(BufferedReader::readText)
+            }.orEmpty()
+
+            val json = if (text.isBlank()) JSONObject() else runCatching { JSONObject(text) }.getOrNull()
+            if (status in 200..299) {
+                Result.success(json ?: JSONObject())
+            } else {
+                Result.failure(
+                    OverlinkException(
+                        Failure(
+                            status,
+                            json?.optString("reason").orEmpty().ifEmpty { "http_$status" },
+                            json?.optString("error").orEmpty().ifEmpty { "Request failed (HTTP $status)" },
+                        )
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            // The daemon being down is the common case here, not a bug — the
+            // pairing screen is reachable before it has booted.
+            Result.failure(
+                OverlinkException(
+                    Failure(0, "daemon_unreachable",
+                        "OverDrive's background service is not responding. Start the daemon and try again.")
+                )
+            )
+        } finally {
+            conn?.disconnect()
+        }
+    }
+
+    private fun enc(s: String): String =
+        java.net.URLEncoder.encode(s, "UTF-8").replace("+", "%20")
+
+    /** Carries [Failure] so callers can switch on `reason` rather than on text. */
+    class OverlinkException(val failure: Failure) : Exception(failure.message)
+}
+
+/** Convenience for `Result.failure` payloads produced by [OverlinkClient]. */
+val Throwable.overlinkFailure: OverlinkClient.Failure?
+    get() = (this as? OverlinkClient.OverlinkException)?.failure

--- a/app/src/main/java/com/overdrive/app/overlink/OverlinkConfig.java
+++ b/app/src/main/java/com/overdrive/app/overlink/OverlinkConfig.java
@@ -1,0 +1,260 @@
+package com.overdrive.app.overlink;
+
+import com.overdrive.app.config.UnifiedConfigManager;
+import com.overdrive.app.daemon.CameraDaemon;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Persistent state for the Overlink companion-app integration.
+ *
+ * <p>Everything lives in the {@code "overlink"} section of the unified config
+ * ({@code /data/local/tmp/overdrive_config.json}), alongside {@code automation},
+ * {@code camera}, {@code recording}, {@code surveillance} and {@code telegram}.
+ *
+ * <h3>Why the unified config and not Android Keystore</h3>
+ * The Overlink spec (§4.1) asks for the OAuth client secret in
+ * AndroidKeyStore-backed storage, "following {@code auth/PinManager.java}".
+ * PinManager does not do that, and neither can this: {@link CameraDaemon} is a
+ * standalone {@code app_process} JVM running as the shell UID (2000), while the
+ * settings UI runs as the app UID. AndroidKeyStore and EncryptedSharedPreferences
+ * are both per-UID, so a secret written by the UI would be unreadable by the
+ * daemon that has to use it — §4.5's device lookup and §5.3's revocation are
+ * both served from the daemon. The unified config is this codebase's established
+ * cross-UID credential store for exactly that reason; it already holds
+ * {@link com.overdrive.app.auth.AuthManager}'s device secret (full dashboard
+ * access), PinManager's PIN hash and the Telegram bot token.
+ *
+ * <p>What the spec's concern buys instead is applied at the blast-radius level:
+ * the client secret never leaves this process boundary (never returned by an
+ * API, never placed in a QR, never logged), and every key it mints is
+ * single-use, tagged, 300s-lived and deleted on consumption (§4.2).
+ *
+ * <h3>Survives reinstall and OTA (§5.4)</h3>
+ * The unified config is outside app-private storage, so the device registry
+ * survives an OverDrive uninstall/reinstall and a userdata-preserving OTA. Only
+ * a factory reset clears it — and even then nothing needs re-scanning, because
+ * the phone's tailnet identity is independent of the car and it re-registers on
+ * next start.
+ */
+public final class OverlinkConfig {
+
+    public static final String SECTION = "overlink";
+
+    /** Bump only for a breaking shape change; readers tolerate unknown keys. */
+    public static final int SCHEMA = 1;
+
+    public static final String DEFAULT_PHONE_TAG = "tag:overdrive-phone";
+    public static final String DEFAULT_CAR_TAG = "tag:overdrive-car";
+
+    private static final String KEY_SCHEMA = "schema";
+    private static final String KEY_CLIENT_ID = "oauthClientId";
+    private static final String KEY_CLIENT_SECRET = "oauthClientSecret";
+    private static final String KEY_PHONE_TAG = "phoneTag";
+    private static final String KEY_CAR_TAG = "carTag";
+    private static final String KEY_SHARE_TOKEN = "shareDeviceToken";
+    private static final String KEY_LAN_PAIRING = "lanPairing";
+    private static final String KEY_CAR_NAME = "carName";
+    private static final String KEY_CAR_MODEL = "carModel";
+    private static final String KEY_DEVICES = "devices";
+
+    private OverlinkConfig() {}
+
+    // ==================== SECTION ACCESS ====================
+
+    public static JSONObject section() {
+        try {
+            JSONObject s = UnifiedConfigManager.loadConfig().optJSONObject(SECTION);
+            return s != null ? s : new JSONObject();
+        } catch (Exception e) {
+            log("section read failed: " + e.getMessage());
+            return new JSONObject();
+        }
+    }
+
+    /** Re-read from disk, bypassing the cache. Used before a read-modify-write. */
+    public static JSONObject sectionFresh() {
+        try {
+            JSONObject s = UnifiedConfigManager.forceReload().optJSONObject(SECTION);
+            return s != null ? s : new JSONObject();
+        } catch (Exception e) {
+            log("section reload failed: " + e.getMessage());
+            return section();
+        }
+    }
+
+    /**
+     * Merge {@code delta} into the section. UnifiedConfigManager merges per key,
+     * so a caller may write a single field without reading the rest first — but
+     * a whole-array key like {@code devices} is replaced wholesale.
+     */
+    private static boolean write(JSONObject delta) {
+        try {
+            delta.put(KEY_SCHEMA, SCHEMA);
+            return UnifiedConfigManager.updateSection(SECTION, delta);
+        } catch (Exception e) {
+            log("section write failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+    // ==================== OAUTH CREDENTIALS (§4.1) ====================
+
+    public static String clientId() {
+        return section().optString(KEY_CLIENT_ID, "").trim();
+    }
+
+    /**
+     * The OAuth client secret. Callers must treat the return value as
+     * write-only: never echo it into an HTTP response, a QR payload or a log line.
+     */
+    public static String clientSecret() {
+        return section().optString(KEY_CLIENT_SECRET, "").trim();
+    }
+
+    public static boolean isConfigured() {
+        return !clientId().isEmpty() && !clientSecret().isEmpty();
+    }
+
+    /**
+     * Persist owner-supplied credentials. A null {@code clientSecret} leaves the
+     * stored secret untouched, so the settings screen can re-save the other
+     * fields without ever reading the secret back out.
+     */
+    public static boolean setCredentials(String clientId, String clientSecret) {
+        JSONObject delta = new JSONObject();
+        try {
+            if (clientId != null) delta.put(KEY_CLIENT_ID, clientId.trim());
+            if (clientSecret != null) delta.put(KEY_CLIENT_SECRET, clientSecret.trim());
+        } catch (Exception e) {
+            return false;
+        }
+        return write(delta);
+    }
+
+    public static boolean clearCredentials() {
+        JSONObject delta = new JSONObject();
+        try {
+            delta.put(KEY_CLIENT_ID, "");
+            delta.put(KEY_CLIENT_SECRET, "");
+        } catch (Exception e) {
+            return false;
+        }
+        return write(delta);
+    }
+
+    // ==================== PAIRING PREFERENCES ====================
+
+    /** Tag applied to phone nodes. Must satisfy the phone's own regex (§4.4). */
+    public static String phoneTag() {
+        String t = section().optString(KEY_PHONE_TAG, "").trim();
+        return isValidTag(t) ? t : DEFAULT_PHONE_TAG;
+    }
+
+    /** Tag the car's node is expected to carry — used to render the ACL grant (§9.4). */
+    public static String carTag() {
+        String t = section().optString(KEY_CAR_TAG, "").trim();
+        return isValidTag(t) ? t : DEFAULT_CAR_TAG;
+    }
+
+    /**
+     * Whether the pairing QR carries OverDrive's device token (§6). Defaults on:
+     * without it the user meets a PIN prompt on first load and every 30 days
+     * after, which is the friction Overlink exists to remove.
+     */
+    public static boolean shareDeviceToken() {
+        return section().optBoolean(KEY_SHARE_TOKEN, true);
+    }
+
+    /** Whether the §4.6 local-network claim endpoint is offered. Off by default. */
+    public static boolean lanPairingEnabled() {
+        return section().optBoolean(KEY_LAN_PAIRING, false);
+    }
+
+    /** Display name shown on the phone; falls back to the car's MagicDNS label. */
+    public static String carName() {
+        return section().optString(KEY_CAR_NAME, "").trim();
+    }
+
+    /** One of atto3/seal/dolphin/tang — selects the phone's accent colour (§4.4). */
+    public static String carModel() {
+        return section().optString(KEY_CAR_MODEL, "").trim();
+    }
+
+    public static boolean setPreferences(String phoneTag, String carTag,
+                                         Boolean shareDeviceToken, Boolean lanPairing,
+                                         String carName, String carModel) {
+        JSONObject delta = new JSONObject();
+        try {
+            if (phoneTag != null && isValidTag(phoneTag.trim())) delta.put(KEY_PHONE_TAG, phoneTag.trim());
+            if (carTag != null && isValidTag(carTag.trim())) delta.put(KEY_CAR_TAG, carTag.trim());
+            if (shareDeviceToken != null) delta.put(KEY_SHARE_TOKEN, shareDeviceToken.booleanValue());
+            if (lanPairing != null) delta.put(KEY_LAN_PAIRING, lanPairing.booleanValue());
+            if (carName != null) delta.put(KEY_CAR_NAME, carName.trim());
+            if (carModel != null) delta.put(KEY_CAR_MODEL, carModel.trim());
+        } catch (Exception e) {
+            return false;
+        }
+        return delta.length() == 0 || write(delta);
+    }
+
+    /** {@code ^tag:[a-z0-9][a-z0-9-]{0,62}$} — the phone rejects anything else (§4.4). */
+    public static boolean isValidTag(String tag) {
+        return tag != null && tag.matches("^tag:[a-z0-9][a-z0-9-]{0,62}$");
+    }
+
+    // ==================== DEVICE REGISTRY (§5.2) ====================
+
+    public static JSONArray devices() {
+        JSONArray a = section().optJSONArray(KEY_DEVICES);
+        return a != null ? a : new JSONArray();
+    }
+
+    /** Replaces the whole {@code devices} array. Callers hold {@link DeviceRegistry}'s lock. */
+    static boolean writeDevices(JSONArray devices) {
+        JSONObject delta = new JSONObject();
+        try {
+            delta.put(KEY_DEVICES, devices);
+        } catch (Exception e) {
+            return false;
+        }
+        return write(delta);
+    }
+
+    /** Fresh read of the devices array, for the read-modify-write path. */
+    static JSONArray devicesFresh() {
+        JSONArray a = sectionFresh().optJSONArray(KEY_DEVICES);
+        return a != null ? a : new JSONArray();
+    }
+
+    // ==================== ACL GRANT (§9.4) ====================
+
+    /**
+     * The tailnet policy block the owner pastes into the Tailscale admin console,
+     * with the configured tags substituted so it can be copied verbatim. This
+     * grant is the real security boundary — note what it does <em>not</em> give
+     * phones: no exit-node use, no subnet routes, no access to any other host.
+     */
+    public static String aclGrant(int dashboardPort) {
+        String phone = phoneTag();
+        String car = carTag();
+        return "{\n"
+             + "  \"tagOwners\": {\n"
+             + "    \"" + phone + "\": [\"autogroup:admin\"],\n"
+             + "    \"" + car + "\": [\"autogroup:admin\"]\n"
+             + "  },\n"
+             + "  \"grants\": [\n"
+             + "    {\n"
+             + "      \"src\": [\"" + phone + "\"],\n"
+             + "      \"dst\": [\"" + car + "\"],\n"
+             + "      \"ip\": [\"tcp:" + dashboardPort + "\"]\n"
+             + "    }\n"
+             + "  ]\n"
+             + "}";
+    }
+
+    static void log(String message) {
+        CameraDaemon.log("OVERLINK: " + message);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/overlink/OverlinkPairingManager.java
+++ b/app/src/main/java/com/overdrive/app/overlink/OverlinkPairingManager.java
@@ -1,0 +1,548 @@
+package com.overdrive.app.overlink;
+
+import android.util.Base64;
+
+import com.overdrive.app.auth.AuthManager;
+import com.overdrive.app.daemon.CameraDaemon;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.security.SecureRandom;
+import java.util.Locale;
+
+/**
+ * The pairing nonce lifecycle and QR payload builder (spec §4.2–§4.4, §11.4).
+ *
+ * <h3>Why this lives in the daemon</h3>
+ * §11.1 sketches this as a Kotlin class in the settings UI. It is Java here, and
+ * runs inside {@link CameraDaemon}, because the app and the daemon are separate
+ * JVMs: the settings screen runs as the app UID, while the registration endpoint
+ * that consumes the nonce is served by the daemon. Splitting the state machine
+ * across two processes would mean persisting the nonce — and the minted auth key
+ * — through the world-readable config file and inventing a cross-process
+ * compare-and-set for §11.4's atomic consumption. Keeping the whole machine in
+ * the daemon makes consumption a plain {@code synchronized} block, and means the
+ * auth key never touches disk. The UI drives it over authenticated loopback via
+ * {@link com.overdrive.app.util.DaemonHttpClient}.
+ *
+ * <h3>State machine (§11.4)</h3>
+ * <pre>
+ * ISSUED ──(register with matching nonce)──▶ CONSUMED ──▶ clear QR, delete key
+ *    │
+ *    ├──(300s elapsed)──────────▶ EXPIRED ──▶ clear QR, delete key
+ *    ├──(screen sleep)──────────▶ EXPIRED ──▶ clear QR, delete key
+ *    └──(owner navigates away)──▶ EXPIRED ──▶ clear QR, delete key
+ * </pre>
+ * At most one ISSUED session exists at a time — starting a new pairing expires
+ * the previous one. A second registration carrying an already-consumed nonce is
+ * rejected, which is what makes the replay test meaningful.
+ */
+public final class OverlinkPairingManager {
+
+    /** Payload version the phone's parser expects. */
+    public static final int PAYLOAD_VERSION = 1;
+
+    /** Key lifetime and nonce lifetime, in seconds (§4.2). */
+    public static final int PAIRING_TTL_SECONDS = 300;
+
+    /**
+     * Soft ceiling on the plain URI form. The phone accepts up to 2048 bytes, but
+     * QR legibility collapses long before that and pairing has to work on a real
+     * head unit, in sunlight, at arm's length. Past this we switch to the compact
+     * base64 form, which {@code core/pairing.go} also decodes.
+     */
+    private static final int URI_SIZE_BUDGET = 800;
+
+    /**
+     * Reject a clock this far off Tailscale's before minting (§11.5). Key expiry
+     * is enforced against real time, so past roughly a minute of skew the QR is
+     * born dead and the user gets a mysterious rejection instead of an answer.
+     */
+    private static final long MAX_CLOCK_SKEW_MS = 60_000L;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public enum State { IDLE, ISSUED, CONSUMED, EXPIRED }
+
+    // ==================== SESSION ====================
+
+    /** One pairing attempt. Immutable except for {@link #state} and consumption. */
+    public static final class Session {
+        public final String nonce;
+        /** Single-use token for the §4.6 LAN claim; null when LAN pairing is off. */
+        public final String claimToken;
+        public final String keyId;
+        public final String authKey;
+        public final String tag;
+        public final CarIdentity car;
+        public final long issuedAt;
+        public final long expiresAt;
+        /** The full §4.4 payload as JSON — also what the LAN claim endpoint serves. */
+        public final JSONObject payload;
+        public final String uri;
+
+        State state = State.ISSUED;
+        String consumedBy;
+        boolean claimTokenUsed;
+
+        Session(String nonce, String claimToken, String keyId, String authKey, String tag,
+                CarIdentity car, long issuedAt, long expiresAt, JSONObject payload, String uri) {
+            this.nonce = nonce;
+            this.claimToken = claimToken;
+            this.keyId = keyId;
+            this.authKey = authKey;
+            this.tag = tag;
+            this.car = car;
+            this.issuedAt = issuedAt;
+            this.expiresAt = expiresAt;
+            this.payload = payload;
+            this.uri = uri;
+        }
+
+        public boolean isExpired(long now) {
+            return now >= expiresAt;
+        }
+
+        public State state() {
+            return state;
+        }
+
+        public String consumedBy() {
+            return consumedBy;
+        }
+    }
+
+    /** A pairing attempt that could not start, mapped to §11.6's failure states. */
+    public static final class PairingException extends Exception {
+        /** Stable machine-readable reason, e.g. {@code not_configured}, {@code tag_not_owned}. */
+        public final String reason;
+
+        PairingException(String reason, String message) {
+            super(message);
+            this.reason = reason;
+        }
+    }
+
+    private static final Object LOCK = new Object();
+    private static Session current;
+
+    private OverlinkPairingManager() {}
+
+    // ==================== START ====================
+
+    /**
+     * Mint a key and issue a fresh pairing session. Blocking — up to three round
+     * trips to {@code api.tailscale.com} over what may be a car SIM, so callers
+     * must be off the UI thread and show visible progress (§11.3).
+     *
+     * <p>Starting a new session expires any previous one, key deletion included.
+     */
+    public static Session start() throws PairingException {
+        if (!OverlinkConfig.isConfigured()) {
+            throw new PairingException("not_configured",
+                    "Set up phone pairing first — OverDrive needs a Tailscale OAuth client "
+                    + "to mint pairing keys.");
+        }
+
+        CarIdentity car = CarIdentity.read();
+        if (!car.isRunning()) {
+            throw new PairingException("car_not_on_tailnet",
+                    "This car has not joined a tailnet yet.");
+        }
+        if (!car.isComplete()) {
+            throw new PairingException("car_identity_incomplete",
+                    "Tailscale is running but has not reported this car's address yet. "
+                    + "Try again in a moment.");
+        }
+
+        TailscaleApiClient api = TailscaleApiClient.fromConfig();
+        String tag = OverlinkConfig.phoneTag();
+        String carName = displayName(car);
+
+        TailscaleApiClient.MintedKey key;
+        try {
+            // The token exchange also gives us Tailscale's clock, so the skew
+            // check below costs nothing extra.
+            api.accessToken();
+            if (api.isClockSkewKnown() && Math.abs(api.clockSkewMs()) > MAX_CLOCK_SKEW_MS) {
+                long offBy = Math.abs(api.clockSkewMs()) / 1000L;
+                throw new PairingException("clock_skew",
+                        "The car's clock is off by about " + offBy + " seconds, so pairing codes "
+                        + "will not work. Fix the time first.");
+            }
+            key = api.mintPairingKey(tag, PAIRING_TTL_SECONDS, describe(carName));
+        } catch (TailscaleApiClient.ApiException e) {
+            throw toPairingException(e, tag);
+        }
+
+        long now = System.currentTimeMillis();
+        String nonce = randomToken();
+        boolean lan = OverlinkConfig.lanPairingEnabled();
+        String claimToken = lan ? randomToken() : null;
+
+        JSONObject payload = buildPayload(nonce, key.secret, tag, car, carName);
+        String uri = buildUri(payload);
+
+        Session session = new Session(nonce, claimToken, key.id, key.secret, tag, car,
+                now, now + (PAIRING_TTL_SECONDS * 1000L), payload, uri);
+
+        Session previous;
+        synchronized (LOCK) {
+            previous = current;
+            current = session;
+        }
+        // Expire the displaced session outside the lock — deleting its key is a
+        // network call and must not block a concurrent registration.
+        if (previous != null && previous.state == State.ISSUED) {
+            retire(previous, State.EXPIRED, "superseded by a new pairing");
+        }
+
+        log("pairing issued, nonce=" + shortId(nonce) + " key=" + key.id
+                + " tag=" + tag + " ttl=" + PAIRING_TTL_SECONDS + "s");
+        return session;
+    }
+
+    // ==================== INSPECT ====================
+
+    /**
+     * The most recent session, or null. A session whose timer ran out while
+     * nobody was looking is expired and its key deleted on the way past, so the
+     * countdown reaching zero is enough to guarantee cleanup even if the UI
+     * never comes back to cancel it.
+     */
+    public static Session active() {
+        Session expiring = null;
+        Session s;
+        synchronized (LOCK) {
+            s = current;
+            if (s == null) return null;
+            if (s.state == State.ISSUED && s.isExpired(System.currentTimeMillis())) {
+                s.state = State.EXPIRED;
+                expiring = s;
+            }
+        }
+        if (expiring != null) retire(expiring, State.EXPIRED, "expired");
+        return s;
+    }
+
+    /** Seconds left on the visible countdown, floored at 0. */
+    public static int remainingSeconds(Session s) {
+        if (s == null || s.state != State.ISSUED) return 0;
+        long ms = s.expiresAt - System.currentTimeMillis();
+        return ms <= 0 ? 0 : (int) Math.ceil(ms / 1000.0);
+    }
+
+    // ==================== CONSUME (§11.4) ====================
+
+    /**
+     * Atomically consume a nonce presented at registration.
+     *
+     * <p>Rejects a nonce that was never issued, has expired, or was already
+     * consumed by a different device. A repeat from the <em>same</em> device is
+     * accepted so a retried registration (dropped response, app restart during
+     * the handshake) is not treated as an attack.
+     *
+     * @return true when the nonce was accepted.
+     */
+    public static boolean consumeNonce(String nonce, String deviceId) {
+        if (nonce == null || nonce.isEmpty()) return false;
+        Session toRetire = null;
+        boolean accepted = false;
+
+        synchronized (LOCK) {
+            Session s = current;
+            if (s == null || !constantTimeEquals(s.nonce, nonce)) return false;
+
+            if (s.state == State.CONSUMED) {
+                // Idempotent retry from the same install only.
+                return deviceId != null && deviceId.equals(s.consumedBy);
+            }
+            if (s.state != State.ISSUED) return false;
+            if (s.isExpired(System.currentTimeMillis())) {
+                s.state = State.EXPIRED;
+                toRetire = s;
+            } else {
+                s.state = State.CONSUMED;
+                s.consumedBy = deviceId;
+                toRetire = s;
+                accepted = true;
+            }
+        }
+
+        // §4.2 step 5 / §6.3: on consumption do not wait for the timer — clear
+        // the QR and delete the key immediately. Off the lock; it is a network call.
+        if (toRetire != null) {
+            final Session s = toRetire;
+            final boolean ok = accepted;
+            new Thread(() -> retire(s, s.state, ok ? "consumed" : "expired"),
+                    "OverlinkKeyCleanup").start();
+        }
+        return accepted;
+    }
+
+    /**
+     * Consume the §4.6 LAN claim token. Single-use, atomic, and the nonce must
+     * match the one in the same request — a mismatch is a crossed pairing attempt.
+     *
+     * @return the payload to serve, or null when the token is wrong, used or expired.
+     */
+    public static JSONObject claim(String token, String nonce) {
+        synchronized (LOCK) {
+            Session s = current;
+            if (s == null || s.state != State.ISSUED) return null;
+            if (s.claimToken == null || s.claimTokenUsed) return null;
+            if (s.isExpired(System.currentTimeMillis())) return null;
+            if (!constantTimeEquals(s.claimToken, token)) return null;
+            if (!constantTimeEquals(s.nonce, nonce)) return null;
+            s.claimTokenUsed = true;
+            return s.payload;
+        }
+    }
+
+    // ==================== CANCEL / EXPIRE ====================
+
+    /**
+     * End the active session — the owner navigated away, the screen slept, or the
+     * countdown ran out. Clears the QR and deletes the key: both halves, every
+     * time. Clearing without deleting leaves a live credential; deleting without
+     * clearing leaves a dead QR that users keep scanning and reporting as broken.
+     */
+    public static void cancel(String why) {
+        Session s;
+        synchronized (LOCK) {
+            s = current;
+            if (s == null) return;
+            if (s.state == State.ISSUED) s.state = State.EXPIRED;
+            current = null;
+        }
+        retire(s, s.state, why != null ? why : "cancelled");
+    }
+
+    /**
+     * Delete the minted key and drop the session from view. Idempotent and
+     * best-effort: this runs from cleanup paths where failing loudly would
+     * strand the UI, so a failed delete is logged and the key is left to its own
+     * 300-second expiry.
+     *
+     * <p>A CONSUMED session stays addressable so the pairing screen can show
+     * "Paired: Pixel 8" — its key is deleted either way.
+     */
+    private static void retire(Session s, State finalState, String why) {
+        if (s == null) return;
+        synchronized (LOCK) {
+            if (current == s && finalState == State.EXPIRED) current = null;
+        }
+        TailscaleApiClient api = TailscaleApiClient.fromConfig();
+        boolean deleted = api != null && api.deleteKey(s.keyId);
+        log("pairing " + why + ", nonce=" + shortId(s.nonce)
+                + " key=" + s.keyId + " deleted=" + deleted);
+    }
+
+    // ==================== PAYLOAD (§4.4) ====================
+
+    /**
+     * Build the pairing payload. Field names match the QR query parameters
+     * exactly, because the §4.6 claim endpoint serves this same object as JSON.
+     */
+    private static JSONObject buildPayload(String nonce, String authKey, String tag,
+                                           CarIdentity car, String carName) {
+        JSONObject p = new JSONObject();
+        try {
+            p.put("v", PAYLOAD_VERSION);
+            p.put("nonce", nonce);
+            p.put("ak", authKey);
+            p.put("tag", tag);
+            p.put("node_id", car.nodeId);
+            p.put("ts_ip", car.tailscaleIp);
+            p.put("fqdn", car.fqdn);
+            // Read from the running server — never hardcode 8080.
+            p.put("port", CameraDaemon.HTTP_PORT);
+            p.put("caps", new JSONArray(capabilities()));
+
+            if (!carName.isEmpty()) p.put("car_name", carName);
+            String model = OverlinkConfig.carModel();
+            if (!model.isEmpty()) p.put("car_model", model);
+
+            String lanIp = LanAddress.privateAddress();
+            if (lanIp != null) p.put("lan_ip", lanIp);
+
+            // §6: the device token, so the phone can log itself in and the user
+            // never meets OverDrive's PIN prompt. Optional, defaulted on.
+            if (OverlinkConfig.shareDeviceToken()) {
+                String dt = deviceToken();
+                if (dt != null && !dt.isEmpty()) p.put("dt", dt);
+            }
+            // `notify` is reserved and stays empty in v1.
+        } catch (Exception e) {
+            log("payload build failed: " + e.getMessage());
+        }
+        return p;
+    }
+
+    /**
+     * Render the payload as the {@code overdrive://pair?…} URI, falling back to
+     * the compact {@code ?b=<base64url(json)>} form when the query-string version
+     * would push the QR past what a head-unit screen renders legibly.
+     */
+    static String buildUri(JSONObject payload) {
+        StringBuilder sb = new StringBuilder("overdrive://pair?");
+        // Deterministic order so the QR is stable for a given payload; `v` first
+        // so a version mismatch is the first thing a parser sees.
+        String[] order = {"v", "nonce", "ak", "tag", "node_id", "ts_ip", "fqdn", "port",
+                          "lan_ip", "lan_hint", "car_name", "car_model", "caps", "dt"};
+        boolean first = true;
+        for (String key : order) {
+            if (!payload.has(key)) continue;
+            Object v = payload.opt(key);
+            if (v == null || v == JSONObject.NULL) continue;
+            String value;
+            if (v instanceof JSONArray) {
+                JSONArray a = (JSONArray) v;
+                if (a.length() == 0) continue;
+                StringBuilder joined = new StringBuilder();
+                for (int i = 0; i < a.length(); i++) {
+                    if (i > 0) joined.append(',');
+                    joined.append(a.optString(i, ""));
+                }
+                value = joined.toString();
+            } else {
+                value = String.valueOf(v);
+            }
+            if (!first) sb.append('&');
+            first = false;
+            sb.append(key).append('=').append(urlEncode(value));
+        }
+
+        String uri = sb.toString();
+        if (uri.getBytes(java.nio.charset.StandardCharsets.UTF_8).length <= URI_SIZE_BUDGET) {
+            return uri;
+        }
+        return "overdrive://pair?b=" + base64Url(payload.toString());
+    }
+
+    /** The §4.6 LAN-pairing QR: an address and a single-use token, no key. */
+    public static String buildLanUri(Session s) {
+        String lan = LanAddress.privateAddress();
+        if (lan == null || s.claimToken == null) return null;
+        return "overdrive://pair?v=" + PAYLOAD_VERSION
+                + "&src=lan"
+                + "&addr=" + urlEncode(lan + ":" + CameraDaemon.HTTP_PORT)
+                + "&t=" + urlEncode(s.claimToken)
+                + "&nonce=" + urlEncode(s.nonce);
+    }
+
+    // ==================== CAPABILITIES (§7) ====================
+
+    /**
+     * What this build supports. The registration response is authoritative — the
+     * QR is a snapshot from pairing time and the car may have been updated since,
+     * so the phone overwrites its stored copy from the response.
+     *
+     * <p>Flags are additive and must never be removed once shipped: the phone
+     * treats an absent flag as "not supported" and degrades, so removing one
+     * silently disables a working feature.
+     */
+    public static java.util.List<String> capabilities() {
+        java.util.List<String> caps = new java.util.ArrayList<>();
+        caps.add("registry");
+        caps.add("events");
+        if (OverlinkConfig.shareDeviceToken() && deviceToken() != null) caps.add("auth_token");
+        if (OverlinkConfig.lanPairingEnabled()) caps.add("lan_pairing");
+        // `cloud` is v2 — not advertised until the car can proxy BYD Cloud calls.
+        return caps;
+    }
+
+    // ==================== HELPERS ====================
+
+    /**
+     * OverDrive's stable device token (§6). A real credential: it grants full
+     * dashboard access, and belongs in the QR only because the QR is a
+     * five-minute one-off displayed on a screen the owner physically controls.
+     * Never log it.
+     */
+    static String deviceToken() {
+        try {
+            AuthManager.AuthState state = AuthManager.getState();
+            if (state == null) return null;
+            String t = state.getDeviceToken();
+            return (t == null || t.isEmpty()) ? null : t;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String displayName(CarIdentity car) {
+        String configured = OverlinkConfig.carName();
+        return !configured.isEmpty() ? configured : car.shortName();
+    }
+
+    private static String describe(String carName) {
+        return "Overlink pairing — " + carName + " — " + iso8601Now();
+    }
+
+    private static String iso8601Now() {
+        java.text.SimpleDateFormat f =
+                new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        f.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        return f.format(new java.util.Date());
+    }
+
+    /** 128 bits, URL-safe, matching the phone's {@code ^[A-Za-z0-9._~-]{8,128}$}. */
+    static String randomToken() {
+        byte[] bytes = new byte[16];
+        RANDOM.nextBytes(bytes);
+        return Base64.encodeToString(bytes, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+    }
+
+    private static String base64Url(String json) {
+        return Base64.encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return java.net.URLEncoder.encode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    /** Length-independent comparison so a token cannot be recovered by timing. */
+    private static boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) return false;
+        byte[] x = a.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] y = b.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        int diff = x.length ^ y.length;
+        for (int i = 0; i < x.length && i < y.length; i++) diff |= x[i] ^ y[i];
+        return diff == 0;
+    }
+
+    private static PairingException toPairingException(TailscaleApiClient.ApiException e, String tag) {
+        if (e.isOffline()) {
+            return new PairingException("offline", "The car is offline — Tailscale could not be reached.");
+        }
+        if (e.isTagOwnershipError()) {
+            // The common first-run failure. A generic "mint failed" here is close
+            // to undiagnosable, so name the tag and point at the ACL grant.
+            return new PairingException("tag_not_owned",
+                    tag + " is not listed in tagOwners. Add the grant block from this screen "
+                    + "to your tailnet policy, then try again.");
+        }
+        if (e.isCredentialError()) {
+            return new PairingException("bad_credentials",
+                    "Tailscale rejected these credentials. Check the OAuth client ID and secret.");
+        }
+        return new PairingException("mint_failed", e.getMessage());
+    }
+
+    /** Nonces are secrets; log a prefix so sessions stay traceable without leaking. */
+    private static String shortId(String s) {
+        if (s == null) return "?";
+        return s.length() <= 6 ? "…" : s.substring(0, 6) + "…";
+    }
+
+    private static void log(String message) {
+        OverlinkConfig.log(message);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/overlink/TailscaleApiClient.java
+++ b/app/src/main/java/com/overdrive/app/overlink/TailscaleApiClient.java
@@ -1,0 +1,459 @@
+package com.overdrive.app.overlink;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * Minimal OkHttp client for {@code api.tailscale.com} (spec §4.2, §4.5, §5.3).
+ *
+ * <p>This is the one genuinely new piece of machinery Overlink needs. OverDrive
+ * authenticates to Tailscale interactively today — {@code tailscale login
+ * --hostname overdrive}, with {@link com.overdrive.app.launcher.TailscaleLauncher}
+ * scraping {@code Log in at:} out of {@code tailscale status}. There is no OAuth
+ * client, no API token and no key minting anywhere else in the tree.
+ *
+ * <p>Everything here is blocking. Callers must be off the UI thread; the
+ * pairing flow can be three round trips over a car SIM (§11.3).
+ *
+ * <p>Errors are surfaced as {@link ApiException} carrying the HTTP status and,
+ * where Tailscale supplied one, its message — {@link OverlinkPairingManager}
+ * maps those to the distinct failure states in §11.6 (the "tag not in tagOwners"
+ * case in particular, which is the common first-run failure and close to
+ * undiagnosable behind a generic "mint failed").
+ */
+public final class TailscaleApiClient {
+
+    private static final String BASE = "https://api.tailscale.com/api/v2";
+    private static final String TOKEN_URL = BASE + "/oauth/token";
+
+    /** {@code -} resolves to the tailnet the credential belongs to. */
+    private static final String TAILNET = "-";
+
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    /**
+     * Refresh a little before the token actually dies so a mint that starts
+     * just under the wire doesn't fail mid-flight.
+     */
+    private static final long TOKEN_SKEW_MS = 30_000L;
+
+    private static final OkHttpClient HTTP = new OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .build();
+
+    /**
+     * Tighter budget for the §4.5 device lookup, which runs <em>inside</em> a
+     * phone's registration request rather than on a settings screen. The facts
+     * it fetches are advisory — the phone treats them as "unknown" when absent —
+     * so a slow control plane must cost the registration a few seconds at most,
+     * never the whole HTTP response window. Shares {@link #HTTP}'s connection
+     * pool and dispatcher via {@code newBuilder()}.
+     */
+    private static final OkHttpClient LOOKUP_HTTP = HTTP.newBuilder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(8, TimeUnit.SECONDS)
+            .build();
+
+    private final String clientId;
+    private final String clientSecret;
+
+    private String accessToken;
+    private long accessTokenExpiresAt;
+
+    /**
+     * Signed difference between this head unit's clock and Tailscale's, measured
+     * from the {@code Date} response header on the token exchange. Key expiry is
+     * enforced against real time, so a badly wrong clock renders a QR that is
+     * already dead — see {@link #clockSkewMs()}.
+     */
+    private volatile long clockSkewMs;
+    private volatile boolean clockSkewKnown;
+
+    public TailscaleApiClient(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    /** Build a client from stored credentials, or null when pairing isn't set up. */
+    public static TailscaleApiClient fromConfig() {
+        if (!OverlinkConfig.isConfigured()) return null;
+        return new TailscaleApiClient(OverlinkConfig.clientId(), OverlinkConfig.clientSecret());
+    }
+
+    // ==================== ERRORS ====================
+
+    /** A failed Tailscale API call. {@link #status} is 0 for transport failures. */
+    public static class ApiException extends Exception {
+        public final int status;
+        /** Tailscale's own error text when it supplied one, else null. */
+        public final String apiMessage;
+
+        ApiException(int status, String apiMessage, String message) {
+            super(message);
+            this.status = status;
+            this.apiMessage = apiMessage;
+        }
+
+        /** True when the failure is the tag missing from {@code tagOwners} (§11.6). */
+        public boolean isTagOwnershipError() {
+            String m = apiMessage != null ? apiMessage.toLowerCase(java.util.Locale.US) : "";
+            return m.contains("tagowner") || m.contains("tag owner")
+                    || (m.contains("tag") && (m.contains("not permitted")
+                        || m.contains("invalid") || m.contains("unauthorized")));
+        }
+
+        /** True when the OAuth credentials themselves were rejected. */
+        public boolean isCredentialError() {
+            return status == 401 || status == 403;
+        }
+
+        /** True when nothing reached Tailscale at all — the car has no internet. */
+        public boolean isOffline() {
+            return status == 0;
+        }
+    }
+
+    // ==================== STEP 1 — ACCESS TOKEN ====================
+
+    /**
+     * Exchange the OAuth client credentials for a bearer token, reusing a
+     * still-valid one. Tailscale tokens are short-lived (typically an hour), and
+     * a pairing session can outlive one, so this refreshes on demand rather than
+     * caching for the process lifetime.
+     */
+    public synchronized String accessToken() throws ApiException {
+        long now = System.currentTimeMillis();
+        if (accessToken != null && now < accessTokenExpiresAt - TOKEN_SKEW_MS) {
+            return accessToken;
+        }
+        RequestBody form = new FormBody.Builder()
+                .add("grant_type", "client_credentials")
+                .add("client_id", clientId)
+                .add("client_secret", clientSecret)
+                .build();
+        Request req = new Request.Builder()
+                .url(TOKEN_URL)
+                .post(form)
+                .build();
+
+        JSONObject json = execute(req, "oauth/token", this);
+        String token = json.optString("access_token", "");
+        if (token.isEmpty()) {
+            throw new ApiException(200, null, "Tailscale returned no access_token");
+        }
+        // expires_in is seconds; default to 30 min if absent so we still refresh.
+        long expiresIn = json.optLong("expires_in", 1800L);
+        this.accessToken = token;
+        this.accessTokenExpiresAt = now + (expiresIn * 1000L);
+        return token;
+    }
+
+    /** Drop the cached token so the next call re-authenticates. */
+    public synchronized void invalidateToken() {
+        accessToken = null;
+        accessTokenExpiresAt = 0;
+    }
+
+    /**
+     * Local clock minus Tailscale's clock, in milliseconds, or 0 when unknown.
+     * Positive means this head unit is running fast.
+     */
+    public long clockSkewMs() {
+        return clockSkewKnown ? clockSkewMs : 0L;
+    }
+
+    public boolean isClockSkewKnown() {
+        return clockSkewKnown;
+    }
+
+    private void recordClockSkew(Response resp) {
+        try {
+            java.util.Date serverDate = resp.headers().getDate("Date");
+            if (serverDate == null) return;
+            clockSkewMs = System.currentTimeMillis() - serverDate.getTime();
+            clockSkewKnown = true;
+        } catch (Exception ignored) {
+            // A missing or unparseable Date header just leaves skew unknown.
+        }
+    }
+
+    // ==================== STEP 2 — MINT A PAIRING KEY ====================
+
+    /** A freshly minted auth key. {@link #secret} is shown exactly once. */
+    public static final class MintedKey {
+        /** Key ID, needed for the §4.2 step-5 delete. */
+        public final String id;
+        /** The {@code tskey-auth-…} secret that goes in the QR. */
+        public final String secret;
+
+        MintedKey(String id, String secret) {
+            this.id = id;
+            this.secret = secret;
+        }
+    }
+
+    /**
+     * Mint a one-off, pre-authorized, tagged auth key.
+     *
+     * <p><strong>{@code ephemeral} is hard-coded false, and this is settled, not
+     * a preference.</strong> Tailscale marks nodes ephemeral based on their
+     * registration method, not on client choice — there is no way for the phone
+     * to register non-ephemeral using an ephemeral key. Ephemeral devices are
+     * auto-removed 30–60 minutes after their last activity and get a new IP when
+     * recreated. A phone is offline constantly, so an ephemeral phone node works
+     * for a week and then silently stops: the worst failure shape there is,
+     * because it looks like the app broke rather than like a misconfiguration.
+     *
+     * <p>Containment does not need ephemerality. {@code reusable: false} bounds
+     * the key to one device, {@code expirySeconds} bounds it to five minutes, and
+     * {@link #deleteKey} removes it on use.
+     */
+    public MintedKey mintPairingKey(String tag, int expirySeconds, String description)
+            throws ApiException {
+        JSONObject create = new JSONObject();
+        JSONObject devices = new JSONObject();
+        JSONObject caps = new JSONObject();
+        JSONObject body = new JSONObject();
+        try {
+            create.put("reusable", false);
+            create.put("ephemeral", false);
+            create.put("preauthorized", true);
+            create.put("tags", new JSONArray().put(tag));
+            devices.put("create", create);
+            caps.put("devices", devices);
+            body.put("capabilities", caps);
+            body.put("expirySeconds", expirySeconds);
+            body.put("description", description);
+        } catch (Exception e) {
+            throw new ApiException(0, null, "Failed to build key request: " + e.getMessage());
+        }
+
+        Request req = new Request.Builder()
+                .url(BASE + "/tailnet/" + TAILNET + "/keys")
+                .addHeader("Authorization", "Bearer " + accessToken())
+                .post(RequestBody.create(body.toString(), JSON))
+                .build();
+
+        JSONObject json = execute(req, "mint key");
+        String id = json.optString("id", "");
+        String secret = json.optString("key", "");
+        if (secret.isEmpty()) {
+            throw new ApiException(200, null, "Tailscale returned no key material");
+        }
+        return new MintedKey(id, secret);
+    }
+
+    /**
+     * Delete a minted key (§4.2 step 5). Best-effort by design: called from the
+     * nonce-lifecycle cleanup path, where failing loudly would strand the UI.
+     * Returns true when Tailscale confirmed the delete.
+     */
+    public boolean deleteKey(String keyId) {
+        if (keyId == null || keyId.isEmpty()) return false;
+        try {
+            Request req = new Request.Builder()
+                    .url(BASE + "/tailnet/" + TAILNET + "/keys/" + urlSegment(keyId))
+                    .addHeader("Authorization", "Bearer " + accessToken())
+                    .delete()
+                    .build();
+            try (Response resp = HTTP.newCall(req).execute()) {
+                // 404 means it is already gone, which satisfies the intent.
+                return resp.isSuccessful() || resp.code() == 404;
+            }
+        } catch (Exception e) {
+            OverlinkConfig.log("key delete failed for " + keyId + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    // ==================== §4.5 — VERIFYING WHAT REGISTERED ====================
+
+    /**
+     * What control actually applied to a node — which is not necessarily what
+     * was asked for. All three fields feed the phone's user-visible warnings,
+     * which name the <em>car</em> as the place to fix it so the user is not sent
+     * round a re-pair loop for something they cannot fix on the phone.
+     */
+    public static final class DeviceFacts {
+        public final String nodeId;
+        public final boolean ephemeral;
+        /** ISO-8601 key expiry, or null when expiry is disabled (the tagged case). */
+        public final String keyExpiry;
+        public final List<String> tags;
+
+        DeviceFacts(String nodeId, boolean ephemeral, String keyExpiry, List<String> tags) {
+            this.nodeId = nodeId;
+            this.ephemeral = ephemeral;
+            this.keyExpiry = keyExpiry;
+            this.tags = tags;
+        }
+    }
+
+    /**
+     * Look a device up by StableNodeID, falling back to a tailnet-IP match.
+     *
+     * <p>The phone cannot see its own ephemerality — {@code tsnet} does not
+     * expose it. The car can, because it holds the API credentials. Matching on
+     * the {@code node_id} the phone supplied at registration is a direct lookup;
+     * {@code nodeIp} is carried as a fallback for a control plane that indexes
+     * differently, and as a sanity check that the registering phone is the node
+     * it claims to be.
+     *
+     * @return the facts, or null when no device matched.
+     */
+    public DeviceFacts findDevice(String nodeId, String nodeIp) throws ApiException {
+        Request req = new Request.Builder()
+                .url(BASE + "/tailnet/" + TAILNET + "/devices")
+                .addHeader("Authorization", "Bearer " + accessToken())
+                .get()
+                .build();
+
+        JSONObject json = execute(LOOKUP_HTTP, req, "list devices", null);
+        JSONArray devices = json.optJSONArray("devices");
+        if (devices == null) return null;
+
+        DeviceFacts ipMatch = null;
+        for (int i = 0; i < devices.length(); i++) {
+            JSONObject d = devices.optJSONObject(i);
+            if (d == null) continue;
+
+            String id = d.optString("nodeId", "");
+            if (nodeId != null && !nodeId.isEmpty() && nodeId.equals(id)) {
+                return toFacts(d, id);
+            }
+            if (ipMatch == null && nodeIp != null && !nodeIp.isEmpty()) {
+                JSONArray addrs = d.optJSONArray("addresses");
+                if (addrs != null) {
+                    for (int j = 0; j < addrs.length(); j++) {
+                        if (nodeIp.equals(addrs.optString(j, null))) {
+                            ipMatch = toFacts(d, id);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return ipMatch;
+    }
+
+    private static DeviceFacts toFacts(JSONObject d, String id) {
+        // Tailscale omits `expires` or sends the zero time when key expiry is
+        // disabled, which is what a correctly tagged device looks like.
+        String expires = d.optString("expires", "");
+        if (expires.isEmpty() || expires.startsWith("0001-01-01")) expires = null;
+
+        List<String> tags = new ArrayList<>();
+        JSONArray t = d.optJSONArray("tags");
+        if (t != null) {
+            for (int i = 0; i < t.length(); i++) {
+                String v = t.optString(i, null);
+                if (v != null && !v.isEmpty()) tags.add(v);
+            }
+        }
+        return new DeviceFacts(id, d.optBoolean("isEphemeral", false), expires, tags);
+    }
+
+    // ==================== §5.3 — REVOCATION ====================
+
+    /**
+     * Remove a node from the tailnet. This is the half of revocation that
+     * actually cuts access; {@link DeviceRegistry} owns the other half and the
+     * two are only ever surfaced as one action.
+     *
+     * @return true when the node is gone (including "was already gone")
+     */
+    public boolean deleteDevice(String nodeId) throws ApiException {
+        if (nodeId == null || nodeId.isEmpty()) {
+            throw new ApiException(0, null, "No node ID recorded for this device");
+        }
+        Request req = new Request.Builder()
+                .url(BASE + "/device/" + urlSegment(nodeId))
+                .addHeader("Authorization", "Bearer " + accessToken())
+                .delete()
+                .build();
+        try (Response resp = HTTP.newCall(req).execute()) {
+            if (resp.isSuccessful() || resp.code() == 404) return true;
+            throw new ApiException(resp.code(), readError(resp),
+                    "Tailscale refused to delete the device (HTTP " + resp.code() + ")");
+        } catch (IOException e) {
+            throw new ApiException(0, null, "Could not reach Tailscale: " + e.getMessage());
+        }
+    }
+
+    // ==================== PLUMBING ====================
+
+    private static JSONObject execute(Request req, String what) throws ApiException {
+        return execute(HTTP, req, what, null);
+    }
+
+    private static JSONObject execute(Request req, String what, TailscaleApiClient skewSink)
+            throws ApiException {
+        return execute(HTTP, req, what, skewSink);
+    }
+
+    private static JSONObject execute(OkHttpClient http, Request req, String what,
+                                      TailscaleApiClient skewSink) throws ApiException {
+        try (Response resp = http.newCall(req).execute()) {
+            if (skewSink != null) skewSink.recordClockSkew(resp);
+            ResponseBody rb = resp.body();
+            String text = rb != null ? rb.string() : "";
+            if (!resp.isSuccessful()) {
+                throw new ApiException(resp.code(), extractError(text),
+                        "Tailscale " + what + " failed (HTTP " + resp.code() + ")");
+            }
+            if (text.isEmpty()) return new JSONObject();
+            return new JSONObject(text);
+        } catch (ApiException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new ApiException(0, null, "Could not reach Tailscale: " + e.getMessage());
+        } catch (Exception e) {
+            throw new ApiException(0, null, "Unreadable Tailscale response: " + e.getMessage());
+        }
+    }
+
+    private static String readError(Response resp) {
+        try {
+            ResponseBody rb = resp.body();
+            return rb != null ? extractError(rb.string()) : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Tailscale errors arrive as {@code {"message": "..."}}, occasionally as plain text. */
+    private static String extractError(String text) {
+        if (text == null || text.isEmpty()) return null;
+        try {
+            JSONObject j = new JSONObject(text);
+            String m = j.optString("message", "");
+            if (!m.isEmpty()) return m;
+        } catch (Exception ignored) {
+            // Not JSON — fall through and use the raw text.
+        }
+        return text.length() > 400 ? text.substring(0, 400) : text;
+    }
+
+    private static String urlSegment(String s) {
+        try {
+            return java.net.URLEncoder.encode(s, "UTF-8").replace("+", "%20");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+}

--- a/app/src/main/java/com/overdrive/app/server/AuthApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/AuthApiHandler.java
@@ -94,6 +94,28 @@ public class AuthApiHandler {
     }
 
     /**
+     * Share this limiter with other unauthenticated endpoints.
+     *
+     * <p>Used by {@link OverlinkApiHandler}'s local-network pairing claim, which
+     * is guarded only by a single-use token: a guessable token on an
+     * unauthenticated LAN endpoint deserves the same protection as the login
+     * endpoint. Callers must namespace their identity (e.g.
+     * {@code "overlink-claim:" + ip}) so they get their own bucket rather than
+     * sharing the login bucket for the same address — but they still inherit
+     * this map's opportunistic GC and its hard bucket cap.
+     *
+     * @return null if the request may proceed, an error string if rate limited.
+     */
+    public static String checkRateLimitFor(String identity) {
+        return checkRateLimit(identity != null && !identity.isEmpty() ? identity : "unknown");
+    }
+
+    /** Reset a shared-limiter bucket after a successful use. */
+    public static void clearRateLimitFor(String identity) {
+        clearRateLimit(identity);
+    }
+
+    /**
      * @return null if request may proceed, error string if rate limited.
      */
     private static String checkRateLimit(String identity) {

--- a/app/src/main/java/com/overdrive/app/server/AuthMiddleware.java
+++ b/app/src/main/java/com/overdrive/app/server/AuthMiddleware.java
@@ -29,6 +29,8 @@ import java.util.Set;
  * - /login            - Login alias
  * - /shared/*         - Static assets (CSS, JS, fonts, models)
  * - /favicon.ico      - Browser favicon
+ * - /api/overlink/v1/pair/claim      - Overlink LAN pairing (single-use token)
+ * - /api/overlink/v1/devices/register - Overlink registration (JWT or single-use nonce)
  *
  * Notably NOT public anymore:
  * - /status           - leaks ACC/charging/recording state, requires auth
@@ -48,7 +50,19 @@ public class AuthMiddleware {
         // worker registration and manifest discovery, with no Bearer header
         // (browser-internal fetch, not auth.js-wrapped).
         "/manifest.json",
-        "/sw.js"
+        "/sw.js",
+        // Overlink companion-app pairing. Neither of these can rely on a JWT:
+        // the claim endpoint runs before the tunnel exists, and registration
+        // runs before the phone has a session whenever the car omits the
+        // device token from the pairing payload. Each carries its own
+        // single-use credential — a claim token and a pairing nonce — which
+        // OverlinkApiHandler checks, along with the source address. Everything
+        // else under /api/overlink/ stays behind normal auth.
+        //
+        // Note these cannot lean on the Tier-2 loopback net either: Overlink's
+        // traffic reaches the car over its tailnet interface, not 127.0.0.1.
+        "/api/overlink/v1/pair/claim",
+        "/api/overlink/v1/devices/register"
     ));
 
     // Path prefixes that don't require authentication

--- a/app/src/main/java/com/overdrive/app/server/HttpResponse.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpResponse.java
@@ -57,14 +57,18 @@ public class HttpResponse {
         byte[] body = json.getBytes("UTF-8");
         String reason;
         switch (status) {
+            case 201: reason = "Created"; break;
             case 400: reason = "Bad Request"; break;
             case 401: reason = "Unauthorized"; break;
             case 403: reason = "Forbidden"; break;
             case 404: reason = "Not Found"; break;
+            case 405: reason = "Method Not Allowed"; break;
             case 409: reason = "Conflict"; break;
             case 410: reason = "Gone"; break;
             case 429: reason = "Too Many Requests"; break;
             case 500: reason = "Internal Server Error"; break;
+            case 501: reason = "Not Implemented"; break;
+            case 502: reason = "Bad Gateway"; break;
             case 503: reason = "Service Unavailable"; break;
             default:  reason = "OK";
         }

--- a/app/src/main/java/com/overdrive/app/server/HttpServer.java
+++ b/app/src/main/java/com/overdrive/app/server/HttpServer.java
@@ -400,8 +400,18 @@ public class HttpServer {
             String path = parts[1];
             
             // Extend timeout for slow BYD cloud API calls (login + verify can take 10-15s)
-            if (path.startsWith("/api/bydcloud") || path.startsWith("/api/vehicle/lock") || 
+            if (path.startsWith("/api/bydcloud") || path.startsWith("/api/vehicle/lock") ||
                 path.startsWith("/api/vehicle/unlock") || path.startsWith("/api/vehicle/flash")) {
+                client.setSoTimeout(60000);
+            }
+
+            // Overlink pairing endpoints call api.tailscale.com while the request
+            // is open — minting a key on /pair/start, and looking the registering
+            // node up on /devices/register so the response can tell the phone
+            // whether it actually landed non-ephemeral and tagged. Over a car SIM
+            // that comfortably exceeds the default 15s socket window.
+            if (path.startsWith("/api/overlink/v1/pair/start")
+                    || path.startsWith("/api/overlink/v1/devices/register")) {
                 client.setSoTimeout(60000);
             }
             
@@ -479,6 +489,20 @@ public class HttpServer {
             // Check authentication for all other paths
             if (!AuthMiddleware.checkAuth(path, cookieHeader, authHeader, out,
                     client.getRemoteSocketAddress(), hasTunnelHeaders)) {
+                client.close();
+                return;
+            }
+
+            // Overlink companion-app API. Dispatched here rather than in
+            // routeToHandlers because it needs three things that layer doesn't
+            // carry: the client address (the LAN pairing claim must be served
+            // off-tailnet while registration and events must not be), and the
+            // cookie/authorization headers (registration accepts a session JWT
+            // *or* a single-use pairing nonce, and has to check the former
+            // itself because its path is public). See OverlinkApiHandler.
+            if (path.startsWith("/api/overlink/")) {
+                OverlinkApiHandler.handle(method, path, body, out,
+                        client.getRemoteSocketAddress(), cookieHeader, authHeader);
                 client.close();
                 return;
             }

--- a/app/src/main/java/com/overdrive/app/server/OverlinkApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/OverlinkApiHandler.java
@@ -1,0 +1,779 @@
+package com.overdrive.app.server;
+
+import com.overdrive.app.auth.AuthManager;
+import com.overdrive.app.daemon.CameraDaemon;
+import com.overdrive.app.notifications.NotificationStore;
+import com.overdrive.app.overlink.CarIdentity;
+import com.overdrive.app.overlink.DeviceRegistry;
+import com.overdrive.app.overlink.LanAddress;
+import com.overdrive.app.overlink.OverlinkConfig;
+import com.overdrive.app.overlink.OverlinkPairingManager;
+import com.overdrive.app.overlink.TailscaleApiClient;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.OutputStream;
+import java.net.SocketAddress;
+import java.util.Map;
+
+/**
+ * The Overlink companion-app API — everything under {@code /api/overlink/v1/*}.
+ *
+ * <h3>Endpoints</h3>
+ * <table>
+ *   <tr><td>{@code GET  /status}</td><td>owner-facing setup state, car identity, ACL grant</td></tr>
+ *   <tr><td>{@code POST /config}</td><td>store OAuth client + pairing preferences</td></tr>
+ *   <tr><td>{@code DELETE /config}</td><td>forget the OAuth client</td></tr>
+ *   <tr><td>{@code POST /pair/start}</td><td>mint a key, issue a nonce, return the QR payload</td></tr>
+ *   <tr><td>{@code GET  /pair/session}</td><td>countdown + state, for the pairing screen</td></tr>
+ *   <tr><td>{@code POST /pair/cancel}</td><td>clear the QR and delete the key</td></tr>
+ *   <tr><td>{@code GET  /pair/claim}</td><td><b>public</b> — §4.6 local-network pairing</td></tr>
+ *   <tr><td>{@code POST /devices/register}</td><td><b>public path</b> — §5.1, guarded by JWT or nonce</td></tr>
+ *   <tr><td>{@code GET  /devices}</td><td>paired-device list</td></tr>
+ *   <tr><td>{@code POST /devices/{id}/revoke}</td><td>§5.3 — registry and tailnet, one action</td></tr>
+ *   <tr><td>{@code POST /devices/{id}/forget}</td><td>drop a revoked row</td></tr>
+ *   <tr><td>{@code GET  /events}</td><td>§8 — canonical event schema over the notification log</td></tr>
+ * </table>
+ *
+ * <h3>Which channel each endpoint trusts</h3>
+ * Two endpoints are listed in {@link AuthMiddleware}'s {@code PUBLIC_PATHS}
+ * because neither can rely on a JWT: {@code /pair/claim} runs before the tunnel
+ * exists, and {@code /devices/register} runs before the phone has a session
+ * whenever the car omits {@code dt}. Each carries its own credential instead —
+ * a single-use claim token and a single-use nonce respectively — and each is
+ * additionally restricted by source address here. Everything else under
+ * {@code /api/overlink/} stays behind normal auth.
+ *
+ * <p><b>Source-address note.</b> §11.2 asks for registration to be tailnet-only.
+ * OverDrive runs {@code tailscaled --tun userspace-networking} (no root, so no
+ * TUN device), which means inbound tailnet connections are terminated by
+ * tailscaled's netstack and re-originated into loopback rather than arriving
+ * from the peer's 100.64/10 address. So {@link #isTrustedTunnelSource} accepts
+ * either a Tailscale peer address or loopback, and refuses a routable or
+ * ordinary-LAN source. The nonce and the JWT remain the real guards; this is
+ * defence in depth, not the primary check.
+ */
+public final class OverlinkApiHandler {
+
+    private static final String PREFIX = "/api/overlink/v1";
+
+    /** §4.6: the phone reads at most 64 KB, so keep the claim response small. */
+    private static final int MAX_CLAIM_BYTES = 8 * 1024;
+
+    /** §8: page size for the event feed. */
+    private static final int DEFAULT_EVENT_LIMIT = 50;
+    private static final int MAX_EVENT_LIMIT = 200;
+
+    /** Signed-thumbnail TTL, matching the surveillance and proximity call sites. */
+    private static final long THUMB_TOKEN_TTL_SEC = 600L;
+
+    private OverlinkApiHandler() {}
+
+    // ==================== DISPATCH ====================
+
+    /**
+     * @param clientAddress the peer socket address — load-bearing: the claim
+     *                      endpoint must be served on the LAN while registration
+     *                      and events must not be.
+     * @return true when this handler produced a response.
+     */
+    public static boolean handle(String method, String path, String body, OutputStream out,
+                                 SocketAddress clientAddress, String cookieHeader,
+                                 String authHeader) throws Exception {
+        String pathOnly = stripQuery(path);
+        if (!pathOnly.startsWith("/api/overlink/")) return false;
+
+        // Anything not on the v1 surface is a version the phone should not have
+        // called. 404 rather than a redirect, so its degradation path fires.
+        if (!pathOnly.startsWith(PREFIX + "/")) {
+            sendError(out, 404, "unknown_endpoint", "No such Overlink endpoint");
+            return true;
+        }
+        String route = pathOnly.substring(PREFIX.length());
+
+        try {
+            switch (route) {
+                case "/status":
+                    if (!method.equals("GET")) return methodNotAllowed(out);
+                    return status(out);
+
+                case "/config":
+                    if (method.equals("POST")) return saveConfig(body, out);
+                    if (method.equals("DELETE")) return clearConfig(out);
+                    return methodNotAllowed(out);
+
+                case "/pair/start":
+                    if (!method.equals("POST")) return methodNotAllowed(out);
+                    return pairStart(out);
+
+                case "/pair/session":
+                    if (!method.equals("GET")) return methodNotAllowed(out);
+                    return pairSession(out);
+
+                case "/pair/cancel":
+                    if (!method.equals("POST")) return methodNotAllowed(out);
+                    return pairCancel(body, out);
+
+                case "/pair/claim":
+                    if (!method.equals("GET")) return methodNotAllowed(out);
+                    return pairClaim(path, out, clientAddress);
+
+                case "/devices":
+                    if (!method.equals("GET")) return methodNotAllowed(out);
+                    return listDevices(out);
+
+                case "/devices/register":
+                    if (!method.equals("POST")) return methodNotAllowed(out);
+                    return register(body, out, clientAddress, cookieHeader, authHeader);
+
+                case "/events":
+                    if (!method.equals("GET")) return methodNotAllowed(out);
+                    return events(path, out, clientAddress);
+
+                case "/events/stream":
+                    // SSE is explicitly optional in §8. Say so distinctly rather
+                    // than 404ing, so the phone can tell "not built" from "wrong
+                    // URL" and fall back to the cursor feed above.
+                    sendError(out, 501, "not_implemented",
+                            "This build serves /events only; there is no SSE stream yet");
+                    return true;
+
+                default:
+                    break;
+            }
+
+            // /devices/{deviceId}/revoke | /forget
+            if (route.startsWith("/devices/")) {
+                String rest = route.substring("/devices/".length());
+                int slash = rest.lastIndexOf('/');
+                if (slash > 0) {
+                    String deviceId = urlDecode(rest.substring(0, slash));
+                    String action = rest.substring(slash + 1);
+                    if (action.equals("revoke") && method.equals("POST")) {
+                        return revokeDevice(deviceId, out);
+                    }
+                    if (action.equals("forget") && method.equals("POST")) {
+                        return forgetDevice(deviceId, out);
+                    }
+                }
+            }
+
+            sendError(out, 404, "unknown_endpoint", "No such Overlink endpoint");
+            return true;
+        } catch (Exception e) {
+            log("unhandled error on " + route + ": " + e);
+            sendError(out, 500, "internal_error", "Overlink request failed");
+            return true;
+        }
+    }
+
+    // ==================== OWNER-FACING SETUP (§4.1) ====================
+
+    /**
+     * Everything the pairing settings screen needs in one call. Deliberately
+     * never returns the client secret — only whether one is stored.
+     */
+    private static boolean status(OutputStream out) throws Exception {
+        CarIdentity car = CarIdentity.read();
+        JSONObject resp = new JSONObject();
+
+        resp.put("success", true);
+        resp.put("schema", OverlinkConfig.SCHEMA);
+        resp.put("car_version", appVersion());
+        resp.put("port", CameraDaemon.HTTP_PORT);
+        resp.put("configured", OverlinkConfig.isConfigured());
+        resp.put("oauth_client_id", OverlinkConfig.clientId());
+        resp.put("has_client_secret", !OverlinkConfig.clientSecret().isEmpty());
+        resp.put("phone_tag", OverlinkConfig.phoneTag());
+        resp.put("car_tag", OverlinkConfig.carTag());
+        resp.put("share_device_token", OverlinkConfig.shareDeviceToken());
+        resp.put("lan_pairing", OverlinkConfig.lanPairingEnabled());
+        resp.put("car_name", OverlinkConfig.carName());
+        resp.put("car_model", OverlinkConfig.carModel());
+        resp.put("caps", new JSONArray(OverlinkPairingManager.capabilities()));
+        resp.put("car", car.toJson());
+        // Nobody wants to transcribe JSON off a car's screen — the screen offers
+        // this as copy-to-clipboard and as its own QR.
+        resp.put("acl_grant", OverlinkConfig.aclGrant(CameraDaemon.HTTP_PORT));
+        resp.put("device_count", DeviceRegistry.activeCount());
+        resp.put("lan_ip", nullable(LanAddress.privateAddress()));
+
+        // An untagged car cannot be named as a grant destination, and that is the
+        // most common first-run stumble — surface it before pairing, not after.
+        if (car.isRunning() && !car.tagged) {
+            resp.put("warning", "car_untagged");
+        }
+
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    private static boolean saveConfig(String body, OutputStream out) throws Exception {
+        JSONObject req = parseBody(body);
+        if (req == null) {
+            sendError(out, 400, "bad_request", "Expected a JSON body");
+            return true;
+        }
+
+        String clientId = req.has("oauth_client_id") ? req.optString("oauth_client_id", "") : null;
+        // A null secret leaves the stored one alone, so the screen can re-save
+        // preferences without ever reading the secret back out.
+        String clientSecret = req.has("oauth_client_secret")
+                ? req.optString("oauth_client_secret", "") : null;
+        if (clientSecret != null && clientSecret.isEmpty()) clientSecret = null;
+
+        String phoneTag = req.has("phone_tag") ? req.optString("phone_tag", "") : null;
+        if (phoneTag != null && !OverlinkConfig.isValidTag(phoneTag.trim())) {
+            sendError(out, 400, "bad_tag",
+                    "Tags must look like tag:overdrive-phone (lowercase letters, digits, hyphens)");
+            return true;
+        }
+        String carTag = req.has("car_tag") ? req.optString("car_tag", "") : null;
+        if (carTag != null && !OverlinkConfig.isValidTag(carTag.trim())) {
+            sendError(out, 400, "bad_tag",
+                    "Tags must look like tag:overdrive-car (lowercase letters, digits, hyphens)");
+            return true;
+        }
+
+        boolean ok = true;
+        if (clientId != null || clientSecret != null) {
+            ok = OverlinkConfig.setCredentials(clientId, clientSecret);
+        }
+        ok = OverlinkConfig.setPreferences(
+                phoneTag,
+                carTag,
+                req.has("share_device_token") ? Boolean.valueOf(req.optBoolean("share_device_token", true)) : null,
+                req.has("lan_pairing") ? Boolean.valueOf(req.optBoolean("lan_pairing", false)) : null,
+                req.has("car_name") ? req.optString("car_name", "") : null,
+                req.has("car_model") ? req.optString("car_model", "") : null) && ok;
+
+        if (!ok) {
+            sendError(out, 500, "persist_failed", "Could not save pairing settings");
+            return true;
+        }
+        return status(out);
+    }
+
+    private static boolean clearConfig(OutputStream out) throws Exception {
+        // Worth restating in the UI, because it genuinely surprises people:
+        // forgetting the OAuth client does NOT deauthorize already-paired
+        // phones. It only stops new ones being paired.
+        OverlinkPairingManager.cancel("OAuth client removed");
+        boolean ok = OverlinkConfig.clearCredentials();
+        JSONObject resp = new JSONObject();
+        resp.put("success", ok);
+        resp.put("note", "Already-paired phones keep their tailnet access. "
+                + "Revoke them individually to cut it.");
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    // ==================== PAIRING (§4.2–§4.4) ====================
+
+    private static boolean pairStart(OutputStream out) throws Exception {
+        OverlinkPairingManager.Session s;
+        try {
+            s = OverlinkPairingManager.start();
+        } catch (OverlinkPairingManager.PairingException e) {
+            // §11.6: each failure distinct, each with its own action. The reason
+            // code is what the screen switches on.
+            int code = "not_configured".equals(e.reason) ? 409
+                     : "bad_credentials".equals(e.reason) ? 502
+                     : "offline".equals(e.reason) ? 503
+                     : "car_not_on_tailnet".equals(e.reason) ? 409
+                     : "clock_skew".equals(e.reason) ? 409
+                     : 502;
+            sendError(out, code, e.reason, e.getMessage());
+            return true;
+        }
+        HttpResponse.sendJson(out, sessionJson(s, true).toString());
+        return true;
+    }
+
+    private static boolean pairSession(OutputStream out) throws Exception {
+        OverlinkPairingManager.Session s = OverlinkPairingManager.active();
+        if (s == null) {
+            JSONObject resp = new JSONObject();
+            resp.put("success", true);
+            resp.put("state", "idle");
+            HttpResponse.sendJson(out, resp.toString());
+            return true;
+        }
+        HttpResponse.sendJson(out, sessionJson(s, false).toString());
+        return true;
+    }
+
+    private static boolean pairCancel(String body, OutputStream out) throws Exception {
+        JSONObject req = parseBody(body);
+        String why = req != null ? req.optString("reason", "cancelled") : "cancelled";
+        OverlinkPairingManager.cancel(why);
+        JSONObject resp = new JSONObject();
+        resp.put("success", true);
+        resp.put("state", "idle");
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    /**
+     * Serialise a session for the pairing screen.
+     *
+     * @param includeSecrets true only on the response to {@code /pair/start},
+     *                       which is the one place the QR URI has to cross a
+     *                       process boundary. Polls get the countdown and state
+     *                       but never re-send the key.
+     */
+    private static JSONObject sessionJson(OverlinkPairingManager.Session s, boolean includeSecrets)
+            throws Exception {
+        JSONObject resp = new JSONObject();
+        resp.put("success", true);
+        resp.put("state", s.state().name().toLowerCase(java.util.Locale.US));
+        resp.put("nonce_hint", s.nonce.length() > 6 ? s.nonce.substring(0, 6) : "");
+        resp.put("issued_at", s.issuedAt);
+        resp.put("expires_at", s.expiresAt);
+        resp.put("remaining_seconds", OverlinkPairingManager.remainingSeconds(s));
+        resp.put("ttl_seconds", OverlinkPairingManager.PAIRING_TTL_SECONDS);
+        resp.put("tag", s.tag);
+        resp.put("lan_pairing", s.claimToken != null);
+
+        if (includeSecrets) {
+            resp.put("uri", s.uri);
+            String lanUri = OverlinkPairingManager.buildLanUri(s);
+            if (lanUri != null) resp.put("lan_uri", lanUri);
+        }
+        if (s.state() == OverlinkPairingManager.State.CONSUMED) {
+            JSONObject row = DeviceRegistry.find(s.consumedBy());
+            if (row != null) resp.put("paired_device", row);
+        }
+        return resp;
+    }
+
+    // ==================== LOCAL-NETWORK PAIRING (§4.6) ====================
+
+    /**
+     * {@code GET /pair/claim?t=<token>&nonce=<nonce>}
+     *
+     * <p>The one endpoint that must be reachable off-tailnet, because the tunnel
+     * is not up yet. Guarded by a single-use token, rate-limited on the same
+     * limiter as {@code /auth/token}, and restricted to private sources.
+     */
+    private static boolean pairClaim(String path, OutputStream out, SocketAddress clientAddress)
+            throws Exception {
+        if (!OverlinkConfig.lanPairingEnabled()) {
+            sendError(out, 404, "not_enabled", "Local-network pairing is turned off on this car");
+            return true;
+        }
+        // Serve the LAN and loopback only; a routable source has no business here.
+        if (!LanAddress.isLocalNetwork(clientAddress) && !LanAddress.isTailnetPeer(clientAddress)) {
+            sendError(out, 403, "not_local", "This endpoint is only served on the local network");
+            return true;
+        }
+
+        // A guessable token on an unauthenticated LAN endpoint deserves the same
+        // protection as the login endpoint, so it shares that bucket namespace.
+        String identity = "overlink-claim:" + String.valueOf(LanAddress.extractIp(clientAddress));
+        String limited = AuthApiHandler.checkRateLimitFor(identity);
+        if (limited != null) {
+            sendError(out, 429, "rate_limited", limited);
+            return true;
+        }
+
+        Map<String, String> q = parseQuery(path);
+        String token = q.get("t");
+        String nonce = q.get("nonce");
+        if (isBlank(token) || isBlank(nonce)) {
+            sendError(out, 400, "bad_request", "Missing t or nonce");
+            return true;
+        }
+
+        JSONObject payload = OverlinkPairingManager.claim(token, nonce);
+        if (payload == null) {
+            // 410 covers wrong / already used / expired as one indistinguishable
+            // case, which is also what the phone shows the user.
+            sendError(out, 410, "claim_unavailable",
+                    "That code has already been used or has expired");
+            return true;
+        }
+        AuthApiHandler.clearRateLimitFor(identity);
+
+        String json = payload.toString();
+        if (json.length() > MAX_CLAIM_BYTES) {
+            log("claim payload unexpectedly large (" + json.length() + " bytes)");
+            sendError(out, 500, "payload_too_large", "Pairing payload is too large to serve");
+            return true;
+        }
+        HttpResponse.sendJson(out, json);
+        return true;
+    }
+
+    // ==================== REGISTRATION (§5.1) ====================
+
+    /**
+     * {@code POST /devices/register} — called by the phone over the tunnel, once,
+     * as soon as its node reaches {@code Running}.
+     *
+     * <p>Accepts <b>either</b> a valid {@code byd_session} JWT <b>or</b> a valid,
+     * unconsumed, unexpired nonce. Both are sufficient on their own: the nonce is
+     * single-use, expires in 300 seconds and only travels over the tunnel, so it
+     * is a real credential in its own right — and it has to be, because a car that
+     * omits {@code dt} leaves the phone with no session at registration time.
+     * Requiring the JWT alone would make the registry unavailable to exactly the
+     * setups that need it most.
+     */
+    private static boolean register(String body, OutputStream out, SocketAddress clientAddress,
+                                    String cookieHeader, String authHeader) throws Exception {
+        if (!isTrustedTunnelSource(clientAddress)) {
+            sendError(out, 403, "not_tunnel",
+                    "Registration is only accepted over the tunnel");
+            return true;
+        }
+
+        JSONObject req = parseBody(body);
+        if (req == null) {
+            sendError(out, 400, "bad_request", "Expected a JSON body");
+            return true;
+        }
+
+        String deviceId = req.optString("device_id", "").trim();
+        if (deviceId.isEmpty() || deviceId.length() > DeviceRegistry.MAX_FIELD_LEN) {
+            sendError(out, 400, "bad_device_id", "device_id is required");
+            return true;
+        }
+        String nonce = req.optString("nonce", "").trim();
+
+        boolean hasJwt = hasValidJwt(cookieHeader, authHeader);
+        boolean nonceOk = !nonce.isEmpty() && OverlinkPairingManager.consumeNonce(nonce, deviceId);
+        if (!hasJwt && !nonceOk) {
+            // A nonce that was never issued, already consumed by a different
+            // device, or expired lands here — which is what makes the replay
+            // test meaningful.
+            sendError(out, 401, "unauthorized",
+                    "Registration needs a valid session or an unused pairing code");
+            return true;
+        }
+
+        String nodeId = req.optString("node_id", "").trim();
+        String nodeIp = req.optString("node_ip", "").trim();
+        JSONObject pushRoute = req.optJSONObject("push_route");   // always null in v1
+
+        JSONObject row = DeviceRegistry.upsert(
+                deviceId,
+                req.optString("label", ""),
+                req.optString("platform", ""),
+                req.optString("os_version", ""),
+                req.optString("app_version", ""),
+                nodeId,
+                nodeIp,
+                pushRoute);
+
+        if (row == null) {
+            sendError(out, 500, "persist_failed", "Could not record this device");
+            return true;
+        }
+
+        JSONObject resp = new JSONObject();
+        resp.put("car_version", appVersion());
+        // Authoritative: the QR is a snapshot from pairing time and the car may
+        // have been updated since, so the phone overwrites its stored copy.
+        resp.put("caps", new JSONArray(OverlinkPairingManager.capabilities()));
+
+        attachNodeFacts(resp, nodeId, nodeIp);
+
+        log("registered " + deviceId + " (" + row.optString("label", "?") + ")"
+                + " node=" + (nodeId.isEmpty() ? "?" : nodeId)
+                + " via=" + (nonceOk ? "nonce" : "jwt"));
+        HttpResponse.sendJson(out, 201, resp.toString());
+        return true;
+    }
+
+    /**
+     * §4.5 — report what actually registered.
+     *
+     * <p>This is the highest-value part of registration: it converts a silent,
+     * delayed-onset failure into a message at pair time. The phone cannot see its
+     * own ephemerality ({@code tsnet} does not expose it); the car can, because
+     * it holds the API credentials.
+     *
+     * <p>If the lookup fails the fields are simply omitted — the device still
+     * registered, and the phone treats missing fields as "unknown" rather than as
+     * a problem.
+     */
+    private static void attachNodeFacts(JSONObject resp, String nodeId, String nodeIp) {
+        if (nodeId.isEmpty() && nodeIp.isEmpty()) return;
+        TailscaleApiClient api = TailscaleApiClient.fromConfig();
+        if (api == null) return;
+        try {
+            TailscaleApiClient.DeviceFacts facts = api.findDevice(nodeId, nodeIp);
+            if (facts == null) {
+                log("registered node " + nodeId + " not found in the tailnet device list");
+                return;
+            }
+            // Phone will be evicted after ~30-60 min offline; pairing dies days later.
+            resp.put("node_ephemeral", facts.ephemeral);
+            // Tagged devices should not expire — an expiry means the tag did not apply.
+            resp.put("node_key_expiry", facts.keyExpiry == null
+                    ? JSONObject.NULL : facts.keyExpiry);
+            // What control actually applied, which is not necessarily what was asked for.
+            resp.put("node_tags", new JSONArray(facts.tags));
+        } catch (Exception e) {
+            log("node fact lookup failed (non-fatal): " + e.getMessage());
+        }
+    }
+
+    // ==================== DEVICE LIST + REVOCATION (§5.3) ====================
+
+    private static boolean listDevices(OutputStream out) throws Exception {
+        JSONObject resp = new JSONObject();
+        resp.put("success", true);
+        resp.put("devices", DeviceRegistry.list());
+        resp.put("configured", OverlinkConfig.isConfigured());
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    private static boolean revokeDevice(String deviceId, OutputStream out) throws Exception {
+        DeviceRegistry.RevokeResult r = DeviceRegistry.revoke(deviceId);
+        JSONObject resp = new JSONObject();
+        resp.put("success", r.ok);
+        if (!r.ok) {
+            // Both halves stay consistent on failure: the row is not marked
+            // either. A half-applied revocation the UI claims succeeded is worse
+            // than a visible error.
+            resp.put("error", r.error);
+            resp.put("missing_node_id", r.missingNodeId);
+            HttpResponse.sendJson(out, 502, resp.toString());
+            return true;
+        }
+        resp.put("devices", DeviceRegistry.list());
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    private static boolean forgetDevice(String deviceId, OutputStream out) throws Exception {
+        JSONObject row = DeviceRegistry.find(deviceId);
+        if (row != null && !row.optBoolean("revoked", false)) {
+            // Dropping a live row without deleting the node is precisely the
+            // half-revocation §5.3 forbids: the phone keeps tailnet access and
+            // silently re-registers on the next pair.
+            sendError(out, 409, "not_revoked",
+                    "Revoke this device before forgetting it, or it keeps its tailnet access");
+            return true;
+        }
+        boolean ok = DeviceRegistry.forget(deviceId);
+        JSONObject resp = new JSONObject();
+        resp.put("success", ok);
+        resp.put("devices", DeviceRegistry.list());
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    // ==================== EVENT STREAM (§8) ====================
+
+    /**
+     * {@code GET /events?since=<id>&limit=<n>} — the canonical event schema,
+     * layered over the existing notification log rather than built beside it.
+     *
+     * <p>{@code id} is stable and monotonic per car (an H2 {@code IDENTITY}
+     * column), which is what makes it usable as the deduplication and backfill
+     * key: the phone keeps a cursor and asks for everything newer on foreground,
+     * so the event list is correct regardless of whether push ever worked.
+     */
+    private static boolean events(String path, OutputStream out, SocketAddress clientAddress)
+            throws Exception {
+        if (!isTrustedTunnelSource(clientAddress)) {
+            sendError(out, 403, "not_tunnel", "The event stream is only served over the tunnel");
+            return true;
+        }
+        NotificationStore store = NotificationStore.getInstanceOrNull();
+        if (store == null) {
+            sendError(out, 503, "log_unavailable", "The notification log is not running");
+            return true;
+        }
+
+        Map<String, String> q = parseQuery(path);
+        long since = parseLong(q.get("since"), 0L);
+        int limit = (int) parseLong(q.get("limit"), DEFAULT_EVENT_LIMIT);
+        limit = Math.max(1, Math.min(limit, MAX_EVENT_LIMIT));
+
+        JSONArray rows = store.listSince(since, limit);
+        JSONArray events = new JSONArray();
+        long cursor = since;
+        for (int i = 0; i < rows.length(); i++) {
+            JSONObject row = rows.optJSONObject(i);
+            if (row == null) continue;
+            events.put(toEvent(row));
+            cursor = Math.max(cursor, row.optLong("id", cursor));
+        }
+
+        JSONObject resp = new JSONObject();
+        resp.put("success", true);
+        resp.put("events", events);
+        resp.put("cursor", cursor);
+        // The phone pages until this goes false rather than guessing from length.
+        resp.put("has_more", rows.length() == limit);
+        HttpResponse.sendJson(out, resp.toString());
+        return true;
+    }
+
+    /** Map one notification-log row onto the canonical event schema. */
+    private static JSONObject toEvent(JSONObject row) throws Exception {
+        JSONObject e = new JSONObject();
+        long id = row.optLong("id", 0);
+        e.put("id", id);
+        // The log stores epoch-ms; the canonical schema is epoch-seconds.
+        e.put("ts", row.optLong("ts", 0) / 1000L);
+        e.put("type", row.optString("category", "unknown"));
+        e.put("severity", row.optString("severity", "info"));
+
+        JSONObject data = row.optJSONObject("data");
+        String camera = data != null ? data.optString("camera", "") : "";
+        if (!camera.isEmpty()) e.put("camera", camera);
+
+        // Thumbnails are a PATH, fetched over the tunnel on demand — never
+        // embedded, and never carried in a push payload. The signed-token
+        // mechanism this reuses was built for exactly this.
+        String filename = data != null ? data.optString("filename", "") : "";
+        if (!filename.isEmpty()) {
+            String token = AuthManager.signThumbToken(filename, THUMB_TOKEN_TTL_SEC);
+            if (token != null) {
+                e.put("thumbnail_path", "/thumb/" + urlEncode(filename) + "?t=" + token);
+            }
+        }
+
+        String title = row.optString("title", "");
+        String bodyText = row.optString("body", "");
+        e.put("summary", bodyText.isEmpty() ? title : title + " — " + bodyText);
+        e.put("deep_link", "overdrive://event/" + id);
+        return e;
+    }
+
+    // ==================== SOURCE CLASSIFICATION ====================
+
+    /**
+     * True when a request may be treated as arriving over the tunnel.
+     *
+     * <p>Accepts a Tailscale peer address, and also loopback because
+     * {@code --tun userspace-networking} re-originates inbound tailnet
+     * connections into loopback (see the class comment). Refuses an ordinary LAN
+     * or routable source, which is the distinction §11.2 actually cares about:
+     * the tailnet is the authenticated channel, the LAN is not.
+     */
+    private static boolean isTrustedTunnelSource(SocketAddress clientAddress) {
+        if (clientAddress == null) return false;
+        return LanAddress.isTailnetPeer(clientAddress) || LanAddress.isLoopback(clientAddress);
+    }
+
+    private static boolean hasValidJwt(String cookieHeader, String authHeader) {
+        String jwt = null;
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            jwt = authHeader.substring(7).trim();
+        }
+        if ((jwt == null || jwt.isEmpty()) && cookieHeader != null) {
+            for (String cookie : cookieHeader.split(";")) {
+                String[] parts = cookie.trim().split("=", 2);
+                if (parts.length == 2 && parts[0].trim().equals("byd_session")) {
+                    jwt = parts[1].trim();
+                    break;
+                }
+            }
+        }
+        if (jwt == null || jwt.isEmpty()) return false;
+        try {
+            AuthManager.JwtValidation v = AuthManager.validateJwt(jwt);
+            return v != null && v.valid;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // ==================== PLUMBING ====================
+
+    private static boolean methodNotAllowed(OutputStream out) throws Exception {
+        sendError(out, 405, "method_not_allowed", "Method not allowed");
+        return true;
+    }
+
+    private static void sendError(OutputStream out, int status, String reason, String message)
+            throws Exception {
+        JSONObject j = new JSONObject();
+        try {
+            j.put("success", false);
+            j.put("reason", reason);
+            j.put("error", message);
+        } catch (Exception ignored) {
+            // JSONObject.put only throws on a null key.
+        }
+        HttpResponse.sendJson(out, status, j.toString());
+    }
+
+    private static JSONObject parseBody(String body) {
+        if (body == null || body.trim().isEmpty()) return null;
+        try {
+            return new JSONObject(body);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String appVersion() {
+        try {
+            return com.overdrive.app.BuildConfig.VERSION_NAME;
+        } catch (Throwable t) {
+            return "unknown";
+        }
+    }
+
+    private static Object nullable(String s) {
+        return (s == null || s.isEmpty()) ? JSONObject.NULL : s;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    private static String stripQuery(String path) {
+        int q = path.indexOf('?');
+        return q < 0 ? path : path.substring(0, q);
+    }
+
+    private static Map<String, String> parseQuery(String path) {
+        Map<String, String> map = new java.util.HashMap<>();
+        int q = path.indexOf('?');
+        if (q < 0 || q == path.length() - 1) return map;
+        for (String pair : path.substring(q + 1).split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq <= 0) continue;
+            map.put(urlDecode(pair.substring(0, eq)), urlDecode(pair.substring(eq + 1)));
+        }
+        return map;
+    }
+
+    private static long parseLong(String s, long fallback) {
+        if (s == null || s.isEmpty()) return fallback;
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static String urlDecode(String s) {
+        try {
+            return java.net.URLDecoder.decode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    private static String urlEncode(String s) {
+        try {
+            return java.net.URLEncoder.encode(s, "UTF-8");
+        } catch (Exception e) {
+            return s;
+        }
+    }
+
+    private static void log(String message) {
+        CameraDaemon.log("OVERLINK: " + message);
+    }
+}

--- a/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/DaemonsFragment.kt
@@ -26,6 +26,8 @@ import com.overdrive.app.R
 import com.overdrive.app.config.UnifiedConfigManager
 import com.overdrive.app.ui.model.DaemonStatus
 import com.overdrive.app.ui.util.QrCodeGenerator
+import androidx.navigation.fragment.findNavController
+import com.overdrive.app.ui.util.navigateDrillDown
 
 /**
  * Fragment for managing background daemons.
@@ -234,6 +236,9 @@ class DaemonsFragment : Fragment() {
             val proxySwitch = dialogView.findViewById<SwitchMaterial>(R.id.switchTailscaleProxy)
             val adbSwitch = dialogView.findViewById<SwitchMaterial>(R.id.switchTailscaleAdb)
             val adbEndpoint = dialogView.findViewById<TextView>(R.id.tailscaleAdbEndpoint)
+            val phonePairingBtn = dialogView.findViewById<com.google.android.material.button.MaterialButton>(
+                R.id.btnPhonePairing
+            )
 
             daemonsViewModel.tailscaleController.isProxyEnabled { isEnabled ->
                 activity?.runOnUiThread {
@@ -347,6 +352,15 @@ class DaemonsFragment : Fragment() {
                     confirmResetTailscaleEnvironment()
                 }
                 .create()
+
+            // Pairing needs the whole screen (a large QR, a countdown and the
+            // paired-device list), so it drills down rather than nesting inside
+            // this dialog. Dismiss first so the dialog isn't left behind the
+            // pushed fragment.
+            phonePairingBtn?.setOnClickListener {
+                dialog.dismiss()
+                findNavController().navigateDrillDown(R.id.phonePairingFragment)
+            }
 
             dialog.show()
         }

--- a/app/src/main/java/com/overdrive/app/ui/fragment/settings/PhonePairingFragment.kt
+++ b/app/src/main/java/com/overdrive/app/ui/fragment/settings/PhonePairingFragment.kt
@@ -1,0 +1,578 @@
+package com.overdrive.app.ui.fragment.settings
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.textfield.TextInputEditText
+import com.overdrive.app.R
+import com.overdrive.app.overlink.OverlinkClient
+import com.overdrive.app.overlink.overlinkFailure
+import com.overdrive.app.ui.util.QrCodeGenerator
+import org.json.JSONObject
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Settings → Tailscale → Phone pairing.
+ *
+ * Owns the *presentation* of pairing only. The nonce lifecycle, the Tailscale
+ * API credentials and the device registry all live in the daemon (see
+ * `OverlinkPairingManager`); this screen drives them through [OverlinkClient]
+ * over authenticated loopback and polls for the countdown.
+ *
+ * Two behaviours here are load-bearing rather than cosmetic:
+ *
+ * * **Every exit path cancels the session.** Navigating away, the screen
+ *   sleeping, or the countdown running out all clear the QR *and* delete the
+ *   minted key. Clearing without deleting leaves a live credential; deleting
+ *   without clearing leaves a dead QR that users keep scanning and reporting as
+ *   broken.
+ * * **Failures are distinct.** Each cause gets its own message and its own next
+ *   action — the tag-not-in-tagOwners case in particular, which is the common
+ *   first-run failure and close to undiagnosable behind a generic "mint failed".
+ */
+class PhonePairingFragment : Fragment() {
+
+    /** Countdown tick. One second, because the countdown is displayed in seconds. */
+    private val pollIntervalMs = 1_000L
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var io: ExecutorService? = null
+
+    private lateinit var tvCarState: TextView
+    private lateinit var tvCarIdentity: TextView
+    private lateinit var warnUntagged: View
+    private lateinit var btnPairPhone: MaterialButton
+    private lateinit var pairProgress: View
+    private lateinit var pairError: View
+    private lateinit var tvPairError: TextView
+    private lateinit var btnPairErrorAction: MaterialButton
+    private lateinit var qrContainer: View
+    private lateinit var ivPairQr: ImageView
+    private lateinit var tvCountdown: TextView
+    private lateinit var btnCancelPairing: MaterialButton
+    private lateinit var pairSuccess: View
+    private lateinit var tvPairSuccess: TextView
+    private lateinit var rowShareToken: View
+    private lateinit var swShareToken: MaterialSwitch
+    private lateinit var rowLanPairing: View
+    private lateinit var swLanPairing: MaterialSwitch
+    private lateinit var etClientId: TextInputEditText
+    private lateinit var etClientSecret: TextInputEditText
+    private lateinit var etPhoneTag: TextInputEditText
+    private lateinit var btnSaveSetup: MaterialButton
+    private lateinit var btnForgetClient: MaterialButton
+    private lateinit var tvAclGrant: TextView
+    private lateinit var btnCopyGrant: MaterialButton
+    private lateinit var tvNoDevices: TextView
+    private lateinit var devicesContainer: LinearLayout
+
+    /** True while a pairing session is on screen, so exit paths know to cancel. */
+    private var sessionActive = false
+
+    /** Guards the switch listeners while a failed write reverts the control. */
+    private var applyingOptions = false
+
+    private var aclGrant: String = ""
+
+    private val poll = object : Runnable {
+        override fun run() {
+            refreshSession()
+            if (sessionActive) mainHandler.postDelayed(this, pollIntervalMs)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = inflater.inflate(R.layout.fragment_phone_pairing, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        io = Executors.newSingleThreadExecutor()
+        bindViews(view)
+        wireActions()
+        loadStatus()
+        loadDevices()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // Screen sleep and navigating away are the same thing from the key's
+        // point of view: the QR is no longer in front of anyone, so it must not
+        // stay live. onPause covers both, plus the app being backgrounded.
+        if (sessionActive) cancelSession("screen left the pairing page")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        mainHandler.removeCallbacksAndMessages(null)
+        io?.shutdownNow()
+        io = null
+    }
+
+    // ==================== BINDING ====================
+
+    private fun bindViews(v: View) {
+        tvCarState = v.findViewById(R.id.tvCarState)
+        tvCarIdentity = v.findViewById(R.id.tvCarIdentity)
+        warnUntagged = v.findViewById(R.id.warnUntagged)
+        btnPairPhone = v.findViewById(R.id.btnPairPhone)
+        pairProgress = v.findViewById(R.id.pairProgress)
+        pairError = v.findViewById(R.id.pairError)
+        tvPairError = v.findViewById(R.id.tvPairError)
+        btnPairErrorAction = v.findViewById(R.id.btnPairErrorAction)
+        qrContainer = v.findViewById(R.id.qrContainer)
+        ivPairQr = v.findViewById(R.id.ivPairQr)
+        tvCountdown = v.findViewById(R.id.tvCountdown)
+        btnCancelPairing = v.findViewById(R.id.btnCancelPairing)
+        pairSuccess = v.findViewById(R.id.pairSuccess)
+        tvPairSuccess = v.findViewById(R.id.tvPairSuccess)
+        rowShareToken = v.findViewById(R.id.rowShareToken)
+        swShareToken = v.findViewById(R.id.swShareToken)
+        rowLanPairing = v.findViewById(R.id.rowLanPairing)
+        swLanPairing = v.findViewById(R.id.swLanPairing)
+        etClientId = v.findViewById(R.id.etClientId)
+        etClientSecret = v.findViewById(R.id.etClientSecret)
+        etPhoneTag = v.findViewById(R.id.etPhoneTag)
+        btnSaveSetup = v.findViewById(R.id.btnSaveSetup)
+        btnForgetClient = v.findViewById(R.id.btnForgetClient)
+        tvAclGrant = v.findViewById(R.id.tvAclGrant)
+        btnCopyGrant = v.findViewById(R.id.btnCopyGrant)
+        tvNoDevices = v.findViewById(R.id.tvNoDevices)
+        devicesContainer = v.findViewById(R.id.devicesContainer)
+    }
+
+    private fun wireActions() {
+        btnPairPhone.setOnClickListener { startPairing() }
+        btnCancelPairing.setOnClickListener { cancelSession("owner cancelled") }
+        btnSaveSetup.setOnClickListener { saveSetup() }
+        btnForgetClient.setOnClickListener { confirmForgetClient() }
+        btnCopyGrant.setOnClickListener { copyToClipboard("tailnet policy", aclGrant, R.string.pairing_grant_copied) }
+        rowShareToken.setOnClickListener { if (!applyingOptions) toggleShareToken() }
+        rowLanPairing.setOnClickListener { if (!applyingOptions) toggleLanPairing() }
+    }
+
+    // ==================== STATUS ====================
+
+    private fun loadStatus() {
+        runIo {
+            val result = OverlinkClient.status()
+            onMain {
+                result.onSuccess { renderStatus(it) }
+                    .onFailure { showError(it.overlinkFailure?.message ?: it.message.orEmpty(), null) }
+            }
+        }
+    }
+
+    private fun renderStatus(status: JSONObject) {
+        val car = status.optJSONObject("car") ?: JSONObject()
+        val running = car.optBoolean("running", false)
+
+        tvCarState.text = when {
+            !running && car.optString("backend_state") == "Unreachable" ->
+                getString(R.string.pairing_car_unreachable)
+            !running -> getString(R.string.pairing_car_not_joined)
+            else -> getString(R.string.pairing_car_ready, car.optString("fqdn", "?"))
+        }
+
+        // Node ID and address stay visible whenever we know them: they are the
+        // manual-pairing fallback, so the owner never has to leave this screen
+        // to read them off another surface.
+        val nodeId = car.optString("node_id", "")
+        val tsIp = car.optString("ts_ip", "")
+        if (nodeId.isNotEmpty() && tsIp.isNotEmpty()) {
+            tvCarIdentity.text = getString(R.string.pairing_car_identity_fmt, nodeId, tsIp)
+            tvCarIdentity.visibility = View.VISIBLE
+        } else {
+            tvCarIdentity.visibility = View.GONE
+        }
+
+        warnUntagged.visibility =
+            if (running && !car.optBoolean("tagged", false)) View.VISIBLE else View.GONE
+
+        // Pairing is only offered when the car can actually be reached.
+        btnPairPhone.isEnabled = car.optBoolean("complete", false) && status.optBoolean("configured", false)
+
+        applyingOptions = true
+        swShareToken.isChecked = status.optBoolean("share_device_token", true)
+        swLanPairing.isChecked = status.optBoolean("lan_pairing", false)
+        applyingOptions = false
+
+        // Never populate the secret field — the daemon does not return it, and a
+        // blank field is what tells the save path to leave the stored one alone.
+        etClientId.setText(status.optString("oauth_client_id", ""))
+        etPhoneTag.setText(status.optString("phone_tag", ""))
+
+        aclGrant = status.optString("acl_grant", "")
+        tvAclGrant.text = aclGrant
+    }
+
+    private fun saveSetup() {
+        val clientId = etClientId.text?.toString()?.trim().orEmpty()
+        val secret = etClientSecret.text?.toString()?.trim().orEmpty()
+        val tag = etPhoneTag.text?.toString()?.trim().orEmpty()
+
+        btnSaveSetup.isEnabled = false
+        runIo {
+            val result = OverlinkClient.saveConfig(
+                clientId = clientId,
+                clientSecret = secret.ifEmpty { null },
+                phoneTag = tag.ifEmpty { null },
+            )
+            onMain {
+                btnSaveSetup.isEnabled = true
+                result.onSuccess {
+                    // Wipe the secret field once it is stored, so it is never
+                    // sitting in a view for the next person at the head unit.
+                    etClientSecret.setText("")
+                    renderStatus(it)
+                    toast(getString(R.string.pairing_saved))
+                }.onFailure { e ->
+                    val f = e.overlinkFailure
+                    toast(
+                        if (f?.reason == "bad_tag") getString(R.string.pairing_bad_tag)
+                        else f?.message ?: e.message.orEmpty()
+                    )
+                }
+            }
+        }
+    }
+
+    private fun confirmForgetClient() {
+        val ctx = context ?: return
+        MaterialAlertDialogBuilder(ctx, R.style.Theme_Overdrive_M3_Dialog)
+            .setIcon(R.drawable.ic_warning)
+            .setTitle(R.string.pairing_forget_client_title)
+            // Worth restating, because it genuinely surprises people: removing
+            // the OAuth client does not deauthorize already-paired phones.
+            .setMessage(R.string.pairing_forget_client_message)
+            .setPositiveButton(R.string.pairing_action_forget_client) { _, _ ->
+                runIo {
+                    OverlinkClient.clearConfig()
+                    onMain {
+                        etClientId.setText("")
+                        etClientSecret.setText("")
+                        loadStatus()
+                    }
+                }
+            }
+            .setNegativeButton(R.string.action_cancel, null)
+            .show()
+    }
+
+    private fun toggleShareToken() {
+        val next = !swShareToken.isChecked
+        applyingOptions = true
+        swShareToken.isChecked = next
+        runIo {
+            val result = OverlinkClient.saveConfig(shareDeviceToken = next)
+            onMain {
+                applyingOptions = true
+                result.onFailure { swShareToken.isChecked = !next }
+                applyingOptions = false
+            }
+        }
+        applyingOptions = false
+    }
+
+    private fun toggleLanPairing() {
+        val next = !swLanPairing.isChecked
+        applyingOptions = true
+        swLanPairing.isChecked = next
+        runIo {
+            val result = OverlinkClient.saveConfig(lanPairing = next)
+            onMain {
+                applyingOptions = true
+                result.onFailure { swLanPairing.isChecked = !next }
+                applyingOptions = false
+            }
+        }
+        applyingOptions = false
+    }
+
+    // ==================== PAIRING ====================
+
+    private fun startPairing() {
+        pairError.visibility = View.GONE
+        pairSuccess.visibility = View.GONE
+        qrContainer.visibility = View.GONE
+        pairProgress.visibility = View.VISIBLE
+        btnPairPhone.isEnabled = false
+
+        runIo {
+            val result = OverlinkClient.startPairing()
+            onMain {
+                pairProgress.visibility = View.GONE
+                btnPairPhone.isEnabled = true
+                result.onSuccess { showQr(it) }.onFailure { renderPairFailure(it) }
+            }
+        }
+    }
+
+    private fun showQr(session: JSONObject) {
+        // Prefer the LAN form when the owner asked for it: the code then carries
+        // an address and a single-use token instead of the key itself.
+        val uri = session.optString("lan_uri", "").ifEmpty { session.optString("uri", "") }
+        if (uri.isEmpty()) {
+            showError(getString(R.string.pairing_expired), null)
+            return
+        }
+        val px = resources.getDimensionPixelSize(R.dimen.pairing_qr_size)
+        val bitmap = QrCodeGenerator.generateDarkTheme(uri, px)
+        if (bitmap == null) {
+            showError(getString(R.string.pairing_expired), null)
+            return
+        }
+
+        ivPairQr.setImageBitmap(bitmap)
+        qrContainer.visibility = View.VISIBLE
+        btnPairPhone.setText(R.string.pairing_action_pair_again)
+        renderCountdown(session.optInt("remaining_seconds", 0))
+
+        sessionActive = true
+        mainHandler.removeCallbacks(poll)
+        mainHandler.postDelayed(poll, pollIntervalMs)
+    }
+
+    /** Poll the daemon for the countdown and the ISSUED → CONSUMED transition. */
+    private fun refreshSession() {
+        runIo {
+            val result = OverlinkClient.pairingSession()
+            onMain {
+                result.onSuccess { s ->
+                    when (s.optString("state", "idle")) {
+                        "issued" -> renderCountdown(s.optInt("remaining_seconds", 0))
+                        "consumed" -> onPaired(s)
+                        else -> onSessionEnded()
+                    }
+                }.onFailure { onSessionEnded() }
+            }
+        }
+    }
+
+    private fun renderCountdown(remaining: Int) {
+        tvCountdown.text = getString(R.string.pairing_countdown_fmt, remaining / 60, remaining % 60)
+    }
+
+    private fun onPaired(session: JSONObject) {
+        sessionActive = false
+        mainHandler.removeCallbacks(poll)
+        clearQr()
+
+        val label = session.optJSONObject("paired_device")?.optString("label").orEmpty()
+        tvPairSuccess.text = getString(
+            R.string.pairing_paired_fmt,
+            label.ifEmpty { getString(R.string.pairing_overline_devices) },
+        )
+        pairSuccess.visibility = View.VISIBLE
+        loadDevices()
+    }
+
+    /** The countdown ran out, or the daemon dropped the session. */
+    private fun onSessionEnded() {
+        if (!sessionActive) return
+        sessionActive = false
+        mainHandler.removeCallbacks(poll)
+        clearQr()
+        showError(getString(R.string.pairing_expired), null)
+    }
+
+    /**
+     * Ask the daemon to end the session. It deletes the key; we clear the QR.
+     * Both halves, every time.
+     */
+    private fun cancelSession(reason: String) {
+        sessionActive = false
+        mainHandler.removeCallbacks(poll)
+        clearQr()
+        // Fire-and-forget on the IO executor: this runs from onPause, where
+        // blocking the main thread would stall the fragment transition. The
+        // daemon expires the session on its own timer regardless, so a dropped
+        // request costs at most the remainder of the 300 seconds.
+        val executor = io ?: return
+        if (executor.isShutdown) return
+        executor.execute { runCatching { OverlinkClient.cancelPairing(reason) } }
+    }
+
+    private fun clearQr() {
+        if (view == null) return
+        qrContainer.visibility = View.GONE
+        ivPairQr.setImageDrawable(null)
+        btnPairPhone.setText(R.string.pairing_action_pair)
+    }
+
+    /**
+     * Each failure gets its own message and its own next action. A generic
+     * "pairing failed" here would make the common tag misconfiguration close to
+     * undiagnosable.
+     */
+    private fun renderPairFailure(e: Throwable) {
+        val failure = e.overlinkFailure
+        val message = failure?.message ?: e.message.orEmpty()
+        when (failure?.reason) {
+            "not_configured" -> showError(message, R.string.pairing_error_action_setup) {
+                etClientId.requestFocus()
+            }
+            "tag_not_owned" -> showError(message, R.string.pairing_error_action_grant) {
+                tvAclGrant.requestFocus()
+                copyToClipboard("tailnet policy", aclGrant, R.string.pairing_grant_copied)
+            }
+            "car_not_on_tailnet", "car_identity_incomplete" ->
+                showError(message, R.string.pairing_error_action_tailscale) { loadStatus() }
+            "bad_credentials" -> showError(message, R.string.pairing_error_action_setup) {
+                etClientSecret.requestFocus()
+            }
+            else -> showError(message, R.string.pairing_error_action_retry) { startPairing() }
+        }
+    }
+
+    private fun showError(message: String, actionLabel: Int?, action: (() -> Unit)? = null) {
+        if (view == null) return
+        tvPairError.text = message
+        pairError.visibility = View.VISIBLE
+        if (actionLabel != null && action != null) {
+            btnPairErrorAction.setText(actionLabel)
+            btnPairErrorAction.visibility = View.VISIBLE
+            btnPairErrorAction.setOnClickListener { action() }
+        } else {
+            btnPairErrorAction.visibility = View.GONE
+        }
+    }
+
+    // ==================== PAIRED DEVICES ====================
+
+    private fun loadDevices() {
+        runIo {
+            val result = OverlinkClient.devices()
+            onMain { result.onSuccess { renderDevices(it) } }
+        }
+    }
+
+    private fun renderDevices(payload: JSONObject) {
+        if (view == null) return
+        val devices = payload.optJSONArray("devices")
+        devicesContainer.removeAllViews()
+
+        if (devices == null || devices.length() == 0) {
+            tvNoDevices.visibility = View.VISIBLE
+            return
+        }
+        tvNoDevices.visibility = View.GONE
+
+        val inflater = LayoutInflater.from(requireContext())
+        for (i in 0 until devices.length()) {
+            val d = devices.optJSONObject(i) ?: continue
+            val row = inflater.inflate(R.layout.item_paired_device, devicesContainer, false)
+            val revoked = d.optBoolean("revoked", false)
+            val deviceId = d.optString("device_id", "")
+            val label = d.optString("label", "").ifEmpty { deviceId }
+
+            row.findViewById<TextView>(R.id.tvDeviceLabel).text = label
+            row.findViewById<TextView>(R.id.tvDeviceMeta).text = getString(
+                R.string.pairing_device_meta_fmt,
+                if (revoked) getString(R.string.pairing_device_revoked) else relativeLastSeen(d.optLong("last_seen", 0)),
+                d.optString("app_version", "").ifEmpty { d.optString("platform", "") },
+            )
+
+            // A revoked row has nothing left to revoke; all it can do is go away.
+            row.findViewById<MaterialButton>(R.id.btnRevokeDevice).apply {
+                visibility = if (revoked) View.GONE else View.VISIBLE
+                setOnClickListener { confirmRevoke(deviceId, label) }
+            }
+            row.findViewById<MaterialButton>(R.id.btnForgetDevice).apply {
+                visibility = if (revoked) View.VISIBLE else View.GONE
+                setOnClickListener { forgetDevice(deviceId) }
+            }
+            devicesContainer.addView(row)
+        }
+    }
+
+    private fun confirmRevoke(deviceId: String, label: String) {
+        val ctx = context ?: return
+        MaterialAlertDialogBuilder(ctx, R.style.Theme_Overdrive_M3_Dialog)
+            .setIcon(R.drawable.ic_warning)
+            .setTitle(getString(R.string.pairing_revoke_title, label))
+            .setMessage(R.string.pairing_revoke_message)
+            .setPositiveButton(R.string.pairing_action_revoke) { _, _ -> revokeDevice(deviceId, label) }
+            .setNegativeButton(R.string.action_cancel, null)
+            .show()
+    }
+
+    private fun revokeDevice(deviceId: String, label: String) {
+        runIo {
+            val result = OverlinkClient.revoke(deviceId)
+            onMain {
+                result.onSuccess {
+                    renderDevices(it)
+                    toast(getString(R.string.pairing_revoked_fmt, label))
+                }.onFailure { e ->
+                    // The daemon leaves BOTH halves untouched when the tailnet
+                    // delete fails, so this really is "nothing happened" rather
+                    // than a partial state the user has to reason about.
+                    toast(getString(
+                        R.string.pairing_revoke_failed_fmt,
+                        e.overlinkFailure?.message ?: e.message.orEmpty(),
+                    ))
+                }
+            }
+        }
+    }
+
+    private fun forgetDevice(deviceId: String) {
+        runIo {
+            val result = OverlinkClient.forget(deviceId)
+            onMain { result.onSuccess { renderDevices(it) } }
+        }
+    }
+
+    private fun relativeLastSeen(epochSeconds: Long): CharSequence {
+        if (epochSeconds <= 0) return getString(R.string.pairing_device_never_seen)
+        return android.text.format.DateUtils.getRelativeTimeSpanString(
+            epochSeconds * 1000L,
+            System.currentTimeMillis(),
+            android.text.format.DateUtils.MINUTE_IN_MILLIS,
+        )
+    }
+
+    // ==================== PLUMBING ====================
+
+    private fun runIo(block: () -> Unit) {
+        val executor = io ?: return
+        if (executor.isShutdown) return
+        executor.execute { runCatching(block) }
+    }
+
+    /** Hop to the main thread, dropping the work if the view is already gone. */
+    private fun onMain(block: () -> Unit) {
+        mainHandler.post { if (view != null && isAdded) block() }
+    }
+
+    private fun copyToClipboard(label: String, value: String, toastRes: Int) {
+        if (value.isEmpty()) return
+        val ctx = context ?: return
+        val clip = ctx.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
+        clip.setPrimaryClip(ClipData.newPlainText(label, value))
+        toast(getString(toastRes))
+    }
+
+    private fun toast(message: String) {
+        val ctx = context?.applicationContext ?: return
+        if (message.isNotEmpty()) Toast.makeText(ctx, message, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/layout/dialog_tailscale_settings.xml
+++ b/app/src/main/res/layout/dialog_tailscale_settings.xml
@@ -108,6 +108,18 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- Overlink companion-app pairing. Lives here rather than on its own
+             settings rail row because it is meaningless until the car has
+             joined a tailnet, and this is where that happens. -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnPhonePairing"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/pairing_menu_entry"
+            app:icon="@drawable/ic_vpn_lock" />
+
         <com.google.android.material.switchmaterial.SwitchMaterial
             android:id="@+id/switchTailscaleProxy"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_phone_pairing.xml
+++ b/app/src/main/res/layout/fragment_phone_pairing.xml
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Settings → Tailscale → Phone pairing.
+
+  Composition (vertical):
+    HERO        : "Phone pairing" + one-line subtitle
+    CAR CARD    : the car's own tailnet identity (node ID / MagicDNS / address),
+                  plus the untagged-car warning — an untagged car cannot be named
+                  as a grant destination, and that is the most common first-run
+                  stumble. Also the manual-pairing fallback, so the owner never
+                  has to leave this screen to read those values.
+    PAIR CARD   : the Pair phone action, the QR, and a VISIBLE countdown.
+                  Failure text sits here too, one distinct message per cause.
+    OPTIONS     : sign-in-automatically (the device token in the payload) and
+                  local-network pairing.
+    SETUP CARD  : OAuth client ID + secret + phone tag. The secret is write-only:
+                  once stored it is never read back, only replaced.
+    GRANT CARD  : the ACL policy block to paste into the Tailscale console —
+                  offered as copy-to-clipboard and as its own QR, because nobody
+                  wants to transcribe JSON off a car's screen.
+    DEVICES     : paired phones, each with a single Revoke action that cuts
+                  registry AND tailnet together.
+
+  All values via ?attr/* tokens; flips light/dark with the app theme.
+-->
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/page_padding_horizontal"
+        android:paddingTop="@dimen/page_padding_top"
+        android:paddingBottom="@dimen/page_padding_bottom">
+
+        <!-- ============== HERO ============== -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:accessibilityHeading="true"
+            android:text="@string/pairing_title"
+            android:textAppearance="@style/TextAppearance.Overdrive.HeadlineSmall"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            android:text="@string/pairing_subtitle"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <!-- ============== CAR IDENTITY ============== -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/card_padding_standard">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:layout_width="@dimen/card_icon_standard"
+                        android:layout_height="@dimen/card_icon_standard"
+                        android:layout_marginTop="2dp"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_directions_car"
+                        app:tint="?attr/colorPrimary" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/pairing_car_title"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:id="@+id/tvCarState"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:text="@string/pairing_car_checking"
+                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+
+                        <!-- Node ID and MagicDNS name, so the owner can fall back
+                             to manual pairing without leaving this screen. -->
+                        <TextView
+                            android:id="@+id/tvCarIdentity"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:background="?attr/selectableItemBackground"
+                            android:fontFamily="monospace"
+                            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                            android:textColor="?attr/colorOnSurfaceVariant"
+                            android:textIsSelectable="true"
+                            android:visibility="gone"
+                            tools:text="node  nPGnBW3CNTRL" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <!-- Untagged-car warning. Distinct from every other failure
+                     because the fix is in the tailnet policy, not here. -->
+                <LinearLayout
+                    android:id="@+id/warnUntagged"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal"
+                    android:visibility="gone">
+
+                    <ImageView
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_marginTop="1dp"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_warning"
+                        app:tint="?attr/colorError" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp"
+                        android:text="@string/pairing_car_untagged"
+                        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                        android:textColor="?attr/colorError" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ============== PAIR ============== -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/section_overline_bottom"
+            android:letterSpacing="0.06"
+            android:text="@string/pairing_overline_pair"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/card_padding_standard">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnPairPhone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pairing_action_pair"
+                    app:icon="@drawable/ic_vpn_lock" />
+
+                <!-- Minting is up to three round trips over a car SIM, so the
+                     progress is visible rather than a frozen screen. -->
+                <LinearLayout
+                    android:id="@+id/pairProgress"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone">
+
+                    <ProgressBar
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        style="?android:attr/progressBarStyleSmall" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="14dp"
+                        android:text="@string/pairing_progress"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+                </LinearLayout>
+
+                <!-- One distinct message per cause; the action button below it
+                     changes with the cause (open setup, show the grant, retry). -->
+                <LinearLayout
+                    android:id="@+id/pairError"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:orientation="vertical"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:id="@+id/tvPairError"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                        android:textColor="?attr/colorError"
+                        tools:text="tag:overdrive-phone is not listed in tagOwners." />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnPairErrorAction"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:visibility="gone"
+                        tools:text="Show the grant" />
+                </LinearLayout>
+
+                <!-- QR + countdown. Both are cleared together, always. -->
+                <LinearLayout
+                    android:id="@+id/qrContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    android:visibility="gone">
+
+                    <ImageView
+                        android:id="@+id/ivPairQr"
+                        android:layout_width="@dimen/pairing_qr_size"
+                        android:layout_height="@dimen/pairing_qr_size"
+                        android:contentDescription="@string/pairing_qr_description" />
+
+                    <TextView
+                        android:id="@+id/tvCountdown"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                        android:textColor="?attr/colorPrimary"
+                        tools:text="Expires in 4:58" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:gravity="center_horizontal"
+                        android:text="@string/pairing_qr_hint"
+                        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnCancelPairing"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/action_cancel" />
+                </LinearLayout>
+
+                <!-- Success. Shown when the phone's registration lands. -->
+                <LinearLayout
+                    android:id="@+id/pairSuccess"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:visibility="gone">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:contentDescription="@null"
+                        android:src="@drawable/ic_check_circle"
+                        app:tint="?attr/colorPrimary" />
+
+                    <TextView
+                        android:id="@+id/tvPairSuccess"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp"
+                        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                        android:textColor="?attr/colorOnSurface"
+                        tools:text="Paired: Pixel 8" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ============== OPTIONS ============== -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <!-- §6: without this the user meets a PIN prompt on first load
+                     and every 30 days after. Defaulted on. -->
+                <LinearLayout
+                    android:id="@+id/rowShareToken"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:minHeight="64dp"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_padding_standard">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/pairing_share_token_title"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/pairing_share_token_subtitle"
+                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/swShareToken"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="false"
+                        android:focusable="false" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="@dimen/card_padding_standard"
+                    android:background="?attr/colorOutlineVariant" />
+
+                <!-- §4.6: for owners who would rather the key never appear on
+                     screen at all. -->
+                <LinearLayout
+                    android:id="@+id/rowLanPairing"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:minHeight="64dp"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_padding_standard">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/pairing_lan_title"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                            android:textColor="?attr/colorOnSurface" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/pairing_lan_subtitle"
+                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/swLanPairing"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="false"
+                        android:focusable="false" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ============== SETUP ============== -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/section_overline_bottom"
+            android:letterSpacing="0.06"
+            android:text="@string/pairing_overline_setup"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/card_padding_standard">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="14dp"
+                    android:text="@string/pairing_setup_body"
+                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilClientId"
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/pairing_client_id_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etClientId"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="monospace"
+                        android:imeOptions="actionNext"
+                        android:inputType="textVisiblePassword"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilClientSecret"
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/pairing_client_secret_hint"
+                    app:endIconMode="password_toggle">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etClientSecret"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="monospace"
+                        android:imeOptions="actionNext"
+                        android:inputType="textPassword"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPhoneTag"
+                    style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/pairing_phone_tag_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etPhoneTag"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="monospace"
+                        android:imeOptions="actionDone"
+                        android:inputType="text"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/pairing_secret_storage_note"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:gravity="end"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnForgetClient"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/pairing_action_forget_client" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnSaveSetup"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:text="@string/dialog_save" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ============== ACL GRANT ============== -->
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_padding_top"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="@dimen/card_padding_standard">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/pairing_grant_title"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                    android:textColor="?attr/colorOnSurface" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/pairing_grant_body"
+                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <!-- Wide content scrolls inside its own container so the page
+                     body never scrolls horizontally. -->
+                <HorizontalScrollView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:scrollbars="horizontal">
+
+                    <TextView
+                        android:id="@+id/tvAclGrant"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="monospace"
+                        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:textIsSelectable="true" />
+                </HorizontalScrollView>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnCopyGrant"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/pairing_action_copy_grant"
+                        app:icon="@drawable/ic_copy" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- ============== PAIRED DEVICES ============== -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/section_overline_bottom"
+            android:letterSpacing="0.06"
+            android:text="@string/pairing_overline_devices"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardCornerRadius="@dimen/card_radius_standard"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tvNoDevices"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/card_padding_standard"
+                    android:text="@string/pairing_no_devices"
+                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+
+                <LinearLayout
+                    android:id="@+id/devicesContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_paired_device.xml
+++ b/app/src/main/res/layout/item_paired_device.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  One paired phone in Settings → Tailscale → Phone pairing.
+
+  The Revoke button is deliberately the ONLY destructive control here.
+  Revocation is one action covering both halves — the registry row and the
+  tailnet node — because registry-only revocation leaves a phone with working
+  tailnet access, and tailnet-only deletion leaves a stale row that silently
+  re-registers on the next pair. Never offer the two separately.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="64dp"
+    android:orientation="horizontal"
+    android:padding="@dimen/card_padding_standard">
+
+    <ImageView
+        android:id="@+id/ivDeviceIcon"
+        android:layout_width="@dimen/card_icon_standard"
+        android:layout_height="@dimen/card_icon_standard"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_link"
+        app:tint="?attr/colorPrimary" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="14dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvDeviceLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textColor="?attr/colorOnSurface"
+            tools:text="Pixel 8 (Android 15)" />
+
+        <TextView
+            android:id="@+id/tvDeviceMeta"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            tools:text="Last seen 2 hours ago · Overlink 0.1.0" />
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnRevokeDevice"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pairing_action_revoke"
+        android:textColor="?attr/colorError" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnForgetDevice"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pairing_action_forget"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -253,6 +253,15 @@
         android:label="@string/settings_section_security"
         tools:layout="@layout/fragment_settings_security" />
 
+    <!-- Phone pairing — the Overlink companion app. Reachable from the
+         Tailscale settings dialog on the Daemons page, because pairing only
+         makes sense once the car is on a tailnet. -->
+    <fragment
+        android:id="@+id/phonePairingFragment"
+        android:name="com.overdrive.app.ui.fragment.settings.PhonePairingFragment"
+        android:label="@string/pairing_title"
+        tools:layout="@layout/fragment_phone_pairing" />
+
     <!-- Native video player (entered from Recordings) -->
     <fragment
         android:id="@+id/videoPlayerFragment"

--- a/app/src/main/res/values/dimens_overdrive.xml
+++ b/app/src/main/res/values/dimens_overdrive.xml
@@ -50,6 +50,11 @@
     <!-- PIN unlock keypad (PinLockActivity). 72dp keys give a 14.4mm hit
          target on the BYD Seal 15.6" panel — well above Material's 48dp
          minimum and comfortable for cluster-distance interaction. -->
+    <!-- Overlink pairing QR. Sized as large as the card allows, because
+         pairing has to work on a real head unit, in sunlight, at arm's
+         length — legibility beats layout tidiness here. -->
+    <dimen name="pairing_qr_size">280dp</dimen>
+
     <dimen name="pin_key_size">72dp</dimen>
     <dimen name="pin_key_margin">6dp</dimen>
     <dimen name="pin_key_corner">36dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -757,7 +757,7 @@
     <!-- Dashboard -->
     <string name="toast_access_code_copied">Access code copied</string>
     <string name="dialog_regenerate_token_title">Regenerate Token</string>
-    <string name="dialog_regenerate_token_message">This will invalidate the current token. All active sessions will be logged out. Continue?</string>
+    <string name="dialog_regenerate_token_message">This will invalidate the current token. All active sessions will be logged out, including every phone paired with Overlink — each one will show OverDrive\'s login screen until you pair it again or enter the new token by hand. Continue?</string>
     <string name="toast_token_regenerated_logged_out">New token generated. All sessions logged out.</string>
     <string name="toast_token_regenerated_restart">Token regenerated. Daemon may need restart to apply.</string>
     <string name="toast_token_regenerated_no_notify">Token regenerated. Could not notify daemon.</string>
@@ -1751,5 +1751,76 @@
     <string name="network_warn_body">This head unit has one WiFi radio, so it cannot host a hotspot and stay on a WiFi network at the same time. While the hotspot is on, the car disconnects from WiFi and uses the built-in SIM\'s mobile data for itself and for every connected device. WiFi comes back when you turn the hotspot off.</string>
     <string name="network_warn_continue">Turn on hotspot</string>
     <string name="network_warn_cancel">Cancel</string>
+
+    <!-- ============================================================
+         Overlink phone pairing (Settings → Tailscale → Phone pairing)
+         ============================================================ -->
+    <string name="pairing_title">Phone pairing</string>
+    <string name="pairing_subtitle">Show a code on this screen and the Overlink app joins your tailnet and opens this dashboard. One scan, no typing.</string>
+    <string name="pairing_menu_entry">Phone pairing…</string>
+
+    <!-- Car identity -->
+    <string name="pairing_car_title">This car</string>
+    <string name="pairing_car_checking">Checking the tailnet…</string>
+    <string name="pairing_car_ready">On the tailnet as %1$s</string>
+    <string name="pairing_car_not_joined">This car has not joined a tailnet yet. Log in from Tailscale settings first.</string>
+    <string name="pairing_car_unreachable">Tailscale is not running on this car.</string>
+    <string name="pairing_car_identity_fmt">node %1$s\naddress %2$s</string>
+    <string name="pairing_car_untagged">This car\'s node has no tag, so it cannot be named as a destination in the grant below. Tag it in the Tailscale admin console — phones will pair but nothing will route until you do.</string>
+
+    <!-- Pair action -->
+    <string name="pairing_overline_pair">Pair a phone</string>
+    <string name="pairing_action_pair">Pair phone</string>
+    <string name="pairing_action_pair_again">Pair another phone</string>
+    <string name="pairing_progress">Minting a pairing key…</string>
+    <string name="pairing_qr_description">Pairing QR code</string>
+    <string name="pairing_qr_hint">Scan this with Overlink on your phone.</string>
+    <string name="pairing_countdown_fmt">Expires in %1$d:%2$02d</string>
+    <string name="pairing_expired">That code expired. Tap Pair phone for a new one.</string>
+    <string name="pairing_paired_fmt">Paired: %1$s</string>
+
+    <!-- Failure states — one message and one action per cause -->
+    <string name="pairing_error_action_setup">Set up the OAuth client</string>
+    <string name="pairing_error_action_grant">Show the grant</string>
+    <string name="pairing_error_action_tailscale">Open Tailscale settings</string>
+    <string name="pairing_error_action_retry">Try again</string>
+
+    <!-- Options -->
+    <string name="pairing_share_token_title">Sign this phone in automatically</string>
+    <string name="pairing_share_token_subtitle">Turn off if you would rather enter the device token on the phone yourself. With it off you will see OverDrive\'s login screen on the phone, once every 30 days.</string>
+    <string name="pairing_lan_title">Pair over the local network</string>
+    <string name="pairing_lan_subtitle">The code on screen carries only an address, and the phone fetches the key over Wi-Fi. Use this if you would rather the key never appear on screen at all.</string>
+
+    <!-- Setup -->
+    <string name="pairing_overline_setup">Tailscale OAuth client</string>
+    <string name="pairing_setup_body">Create an OAuth client in the Tailscale admin console with the devices:core write scope, and give it the phone tag below. OverDrive uses it to mint a single-use, five-minute pairing key each time you pair.</string>
+    <string name="pairing_client_id_hint">OAuth client ID</string>
+    <string name="pairing_client_secret_hint">OAuth client secret</string>
+    <string name="pairing_phone_tag_hint">Phone tag</string>
+    <string name="pairing_secret_storage_note">The secret is stored on this head unit and never leaves it — it is never shown in a pairing code and never written to a log. Leave the secret field blank to keep the one already stored.</string>
+    <string name="pairing_action_forget_client">Forget client</string>
+    <string name="pairing_forget_client_title">Forget the OAuth client?</string>
+    <string name="pairing_forget_client_message">No new phones can be paired until you enter a client again. Phones you have already paired keep their tailnet access — revoke them individually to cut it.</string>
+    <string name="pairing_saved">Pairing settings saved</string>
+    <string name="pairing_bad_tag">Tags look like tag:overdrive-phone — lowercase letters, digits and hyphens.</string>
+
+    <!-- ACL grant -->
+    <string name="pairing_grant_title">Tailnet policy</string>
+    <string name="pairing_grant_body">Paste this into your tailnet policy file. It is the real security boundary: phones get access to this car\'s dashboard port and nothing else — no exit node, no subnet routes, no other hosts.</string>
+    <string name="pairing_action_copy_grant">Copy policy</string>
+    <string name="pairing_grant_copied">Policy copied</string>
+
+    <!-- Paired devices -->
+    <string name="pairing_overline_devices">Paired phones</string>
+    <string name="pairing_no_devices">No phones paired yet.</string>
+    <string name="pairing_action_revoke">Revoke</string>
+    <string name="pairing_action_forget">Remove</string>
+    <string name="pairing_device_meta_fmt">Last seen %1$s · %2$s</string>
+    <string name="pairing_device_revoked">Revoked</string>
+    <string name="pairing_device_never_seen">never</string>
+    <string name="pairing_revoke_title">Revoke %1$s?</string>
+    <string name="pairing_revoke_message">This removes the phone from your tailnet and from this list, in one step. It loses access immediately and has to be paired again from scratch.</string>
+    <string name="pairing_revoked_fmt">%1$s revoked</string>
+    <string name="pairing_revoke_failed_fmt">Could not revoke: %1$s</string>
 
 </resources>

--- a/app/src/test/java/com/overdrive/app/overlink/OverlinkPairingContractTest.java
+++ b/app/src/test/java/com/overdrive/app/overlink/OverlinkPairingContractTest.java
@@ -1,0 +1,207 @@
+package com.overdrive.app.overlink;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+/**
+ * Guards the parts of the Overlink pairing contract the phone parses strictly.
+ *
+ * <p>The phone's {@code core/pairing.go} rejects a malformed payload rather than
+ * guessing, so a car that drifts from these shapes fails loudly at pair time —
+ * which is the intended behaviour, but it means a unilateral car-side change
+ * surfaces to users as "pairing stopped working". These tests are the early
+ * warning for that.
+ *
+ * <p>Scope note: everything here is pure logic. Anything that reads the unified
+ * config or touches {@code android.util.Base64} needs an instrumented test —
+ * this module has no Robolectric.
+ */
+public class OverlinkPairingContractTest {
+
+    // ==================== §4.4 — ts_ip ====================
+
+    @Test
+    public void acceptsTailscaleAddressRanges() {
+        // 100.64.0.0/10
+        assertTrue(CarIdentity.isTailscaleAddress("100.64.0.1"));
+        assertTrue(CarIdentity.isTailscaleAddress("100.101.102.103"));
+        assertTrue(CarIdentity.isTailscaleAddress("100.127.255.255"));
+        // fd7a:115c:a1e0::/48
+        assertTrue(CarIdentity.isTailscaleAddress("fd7a:115c:a1e0::1"));
+        assertTrue(CarIdentity.isTailscaleAddress("FD7A:115C:A1E0:AB12::1"));
+    }
+
+    @Test
+    public void rejectsAddressesOutsideTailscaleRanges() {
+        // Just outside 100.64/10 on either side — the classic off-by-one.
+        assertFalse(CarIdentity.isTailscaleAddress("100.63.255.255"));
+        assertFalse(CarIdentity.isTailscaleAddress("100.128.0.1"));
+        // Ordinary LAN and routable addresses.
+        assertFalse(CarIdentity.isTailscaleAddress("192.168.1.42"));
+        assertFalse(CarIdentity.isTailscaleAddress("10.0.0.5"));
+        assertFalse(CarIdentity.isTailscaleAddress("8.8.8.8"));
+        // A different ULA prefix is not Tailscale's.
+        assertFalse(CarIdentity.isTailscaleAddress("fd00::1"));
+        // Malformed.
+        assertFalse(CarIdentity.isTailscaleAddress(""));
+        assertFalse(CarIdentity.isTailscaleAddress(null));
+        assertFalse(CarIdentity.isTailscaleAddress("100.64.0"));
+        assertFalse(CarIdentity.isTailscaleAddress("100.64.0.999"));
+    }
+
+    // ==================== §4.4 / §4.6 — lan_ip and addr ====================
+
+    @Test
+    public void acceptsPrivateLinkLocalAndLoopbackAddresses() {
+        assertTrue(LanAddress.isPrivateOrLocal("10.0.0.5"));
+        assertTrue(LanAddress.isPrivateOrLocal("172.16.0.1"));
+        assertTrue(LanAddress.isPrivateOrLocal("172.31.255.254"));
+        assertTrue(LanAddress.isPrivateOrLocal("192.168.1.42"));
+        assertTrue(LanAddress.isPrivateOrLocal("169.254.1.1"));
+        assertTrue(LanAddress.isPrivateOrLocal("127.0.0.1"));
+        assertTrue(LanAddress.isPrivateOrLocal("::1"));
+        assertTrue(LanAddress.isPrivateOrLocal("fe80::1%wlan0"));
+        assertTrue(LanAddress.isPrivateOrLocal("fd00::1"));
+    }
+
+    @Test
+    public void rejectsRoutableAddresses() {
+        // A routable value in lan_ip is rejected by the phone, so emitting one
+        // would only produce a pairing that fails later rather than here.
+        assertFalse(LanAddress.isPrivateOrLocal("8.8.8.8"));
+        assertFalse(LanAddress.isPrivateOrLocal("1.1.1.1"));
+        assertFalse(LanAddress.isPrivateOrLocal("2606:4700::1111"));
+        // 172.15 and 172.32 bracket the /12 — both are public.
+        assertFalse(LanAddress.isPrivateOrLocal("172.15.0.1"));
+        assertFalse(LanAddress.isPrivateOrLocal("172.32.0.1"));
+        assertFalse(LanAddress.isPrivateOrLocal(""));
+        assertFalse(LanAddress.isPrivateOrLocal(null));
+    }
+
+    @Test
+    public void extractsIpFromSocketAddressRenderings() {
+        assertEquals("10.0.0.5", LanAddress.extractIp(
+                new java.net.InetSocketAddress("10.0.0.5", 41234)));
+        assertEquals("127.0.0.1", LanAddress.extractIp(
+                new java.net.InetSocketAddress("127.0.0.1", 8080)));
+        assertEquals(null, LanAddress.extractIp(null));
+    }
+
+    // ==================== §4.4 — tag ====================
+
+    @Test
+    public void tagMatchesThePhonesRegex() {
+        assertTrue(OverlinkConfig.isValidTag("tag:overdrive-phone"));
+        assertTrue(OverlinkConfig.isValidTag("tag:overdrive-car"));
+        assertTrue(OverlinkConfig.isValidTag("tag:a"));
+        assertTrue(OverlinkConfig.isValidTag("tag:0abc-def"));
+
+        assertFalse("no prefix", OverlinkConfig.isValidTag("overdrive-phone"));
+        assertFalse("uppercase", OverlinkConfig.isValidTag("tag:Overdrive-Phone"));
+        assertFalse("leading hyphen", OverlinkConfig.isValidTag("tag:-phone"));
+        assertFalse("underscore", OverlinkConfig.isValidTag("tag:over_drive"));
+        assertFalse("empty label", OverlinkConfig.isValidTag("tag:"));
+        assertFalse(OverlinkConfig.isValidTag(null));
+    }
+
+    // ==================== §4.4 — the QR URI ====================
+
+    @Test
+    public void buildsThePlainUriFormWithEveryRequiredField() {
+        String uri = OverlinkPairingManager.buildUri(samplePayload());
+
+        assertTrue(uri.startsWith("overdrive://pair?"));
+        // `v` first, so a version mismatch is the first thing a parser sees.
+        assertTrue(uri.startsWith("overdrive://pair?v=1&"));
+
+        for (String required : new String[] {
+                "nonce=", "ak=", "tag=", "node_id=", "ts_ip=", "fqdn=", "port=" }) {
+            assertTrue("missing required field " + required, uri.contains("&" + required));
+        }
+        // Tag is percent-encoded, since ':' is not query-safe.
+        assertTrue(uri.contains("tag=tag%3Aoverdrive-phone"));
+        // caps is a comma-joined list, not a JSON array.
+        assertTrue(uri.contains("caps=registry%2Cevents"));
+        // The port comes from the running server, not a hardcoded 8080.
+        assertTrue(uri.contains("port=9090"));
+    }
+
+    @Test
+    public void omitsAbsentOptionalFields() {
+        JSONObject payload = samplePayload();
+        payload.remove("dt");
+        payload.remove("lan_ip");
+
+        String uri = OverlinkPairingManager.buildUri(payload);
+        assertFalse(uri.contains("dt="));
+        assertFalse(uri.contains("lan_ip="));
+    }
+
+    @Test
+    public void plainUriStaysInsideTheLegibilityBudget() {
+        // Pairing has to work on a real head unit, in sunlight, at arm's length,
+        // so a realistic payload must not spill into the compact base64 form.
+        String uri = OverlinkPairingManager.buildUri(samplePayload());
+        assertTrue("URI grew to " + uri.length() + " bytes",
+                uri.getBytes(java.nio.charset.StandardCharsets.UTF_8).length <= 800);
+    }
+
+    /** A realistic payload: everything the car sends, with plausible lengths. */
+    private static JSONObject samplePayload() {
+        JSONObject p = new JSONObject();
+        try {
+            p.put("v", 1);
+            p.put("nonce", "AbCdEfGhIjKlMnOpQrStUw");
+            p.put("ak", "tskey-auth-kBvQr7CNTRL-5tGhJk8mNpQrStUvWxYz1234");
+            p.put("tag", "tag:overdrive-phone");
+            p.put("node_id", "nPGnBW3CNTRL");
+            p.put("ts_ip", "100.101.102.103");
+            p.put("fqdn", "overdrive.tail1234.ts.net");
+            p.put("port", 9090);
+            p.put("caps", new JSONArray().put("registry").put("events").put("auth_token"));
+            p.put("car_name", "Seal");
+            p.put("car_model", "seal");
+            p.put("lan_ip", "192.168.1.42");
+            p.put("dt", "byd-a1b2c3d4-x7k9m2p5q3r6s8t1");
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+        return p;
+    }
+
+    // ==================== §11.6 — failure classification ====================
+
+    @Test
+    public void classifiesTheTagOwnershipFailureDistinctly() {
+        // The common first-run failure. A generic "mint failed" makes it close
+        // to undiagnosable, so it has to be separable from every other 4xx.
+        assertTrue(apiError(400, "requested tags [tag:overdrive-phone] are invalid or not permitted")
+                .isTagOwnershipError());
+        assertTrue(apiError(403, "calling user does not have access to the tagOwners entry")
+                .isTagOwnershipError());
+
+        assertFalse(apiError(500, "internal server error").isTagOwnershipError());
+        assertFalse(apiError(0, null).isTagOwnershipError());
+    }
+
+    @Test
+    public void separatesCredentialAndOfflineFailures() {
+        assertTrue(apiError(401, "invalid_client").isCredentialError());
+        assertTrue(apiError(403, "forbidden").isCredentialError());
+        assertFalse(apiError(500, "boom").isCredentialError());
+
+        // status 0 is the transport failure — the car has no internet, which is
+        // a different message and a different action from a rejected credential.
+        assertTrue(apiError(0, null).isOffline());
+        assertFalse(apiError(401, "invalid_client").isOffline());
+    }
+
+    private static TailscaleApiClient.ApiException apiError(int status, String apiMessage) {
+        return new TailscaleApiClient.ApiException(status, apiMessage, "test");
+    }
+}


### PR DESCRIPTION
## Overlink companion-app support

Implements the head-unit half of [Overlink](https://github.com/jkaberg/Overlink): one-scan phone pairing over Tailscale,
a paired-device registry, and unattended sign-in to the dashboard.

### What this brings

- **One-scan pairing.** Settings → Tailscale → Phone pairing mints a single-use,
  non-ephemeral, tagged Tailscale auth key on demand and renders it as a QR with a
  visible 300s countdown. The key is deleted on scan, on expiry, on screen sleep and
  on navigating away — the QR and the credential are always cleared together.
- **Device registry.** Phones register over the tunnel; the list survives an OverDrive
  reinstall and a userdata-preserving OTA because it lives in the unified config.
  Revocation is one button covering both halves — registry row *and* tailnet node —
  and fails without marking either if the Tailscale call fails.
- **No PIN prompt on the phone.** The pairing payload optionally carries OverDrive's
  device token, so the phone logs itself in and the dashboard opens straight into the
  app. Defaulted on, with a one-line opt-out. Without it the user meets a login screen
  on first load and every 30 days after.
- **Misconfiguration caught at pair time.** After a phone registers, the car looks its
  node up via the Tailscale API and reports back whether it actually landed
  non-ephemeral, unexpiring and tagged. The phone cannot see this about itself; the car
  can. Turns a failure that surfaces days later into a message while the user is still
  at the head unit.
- **Capability flags** so an older phone and a newer car degrade cleanly in both
  directions, and vice versa.
- **Optional local-network pairing**, where the QR carries an address and a single-use
  token instead of the key, so the key never appears on screen.
- **Event feed** (`/api/overlink/v1/events?since=&limit=`) layered over the existing
  notification log, using its monotonic row id as the phone's backfill cursor and the
  existing signed-thumbnail tokens for images.

### Endpoints

All under `/api/overlink/v1`. Two are in `AuthMiddleware.PUBLIC_PATHS` because neither
can rely on a JWT — `/pair/claim` runs before the tunnel exists, and
`/devices/register` runs before the phone has a session when the car omits the device
token. Each carries its own single-use credential (claim token, pairing nonce) and is
additionally restricted by source address. Everything else stays behind normal auth.

### Notes for review

- **OAuth credentials go in the unified config, not AndroidKeyStore.** The daemon is a
  separate `app_process` JVM running as shell UID; Keystore and
  EncryptedSharedPreferences are per-UID, so a secret written by the UI would be
  unreadable by the daemon that needs it. This matches how AuthManager, PinManager and
  the Telegram bot token are already stored. The secret is never returned by an API,
  never placed in a QR and never logged.
- **Registration accepts loopback as well as a Tailscale peer address.** `tailscaled`
  runs with `--tun userspace-networking`, so inbound tailnet connections arrive
  re-originated from loopback. Routable and ordinary-LAN sources are still refused, and
  the nonce/JWT remain the real guard. Worth confirming on hardware.
- `/events/stream` returns 501 rather than 404 — SSE is optional, and the distinct code
  lets the phone tell "not built" from "wrong URL" and fall back to the cursor feed.
- The regenerate-token dialog now says it signs out paired phones, because it does.

### Testing

`OverlinkPairingContractTest` covers the parts the phone parses strictly: Tailscale
address ranges, private/routable classification, the tag regex, the QR URI shape and
size budget, and the failure classification that keeps "tag not in tagOwners"
distinguishable from a generic mint failure. Pairing itself needs a real tailnet and a
head unit.
