### PR TITLE
Fix silent GL/EGL init failure leaving surveillance stuck uninitialized

### DIFF
--- a/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
+++ b/app/src/main/java/com/overdrive/app/daemon/CameraDaemon.java
@@ -4217,6 +4217,23 @@ public class CameraDaemon {
 
             gpuPipeline.init(assetManager, com.overdrive.app.daemon.DaemonBootstrap.getContext());
 
+            // init() can return normally while an internal GL/EGL step still
+            // failed silently, leaving isInitialized() false forever with
+            // gpuPipeline itself non-null. Every exit/retry check below this
+            // point tests "gpuPipeline != null", so that silent failure was
+            // never distinguished from success and never retried -- confirmed
+            // live: surveillance stuck uninitialized for over an hour with the
+            // existing exponential-backoff retry (below) never once firing,
+            // because nothing here ever threw to trigger it. Throwing funnels
+            // this case through the same catch block and retry schedule that
+            // every other init failure already uses correctly.
+            if (!gpuPipeline.isInitialized()) {
+                throw new IllegalStateException(
+                        "GpuSurveillancePipeline.init() returned without completing "
+                        + "initialization (isInitialized() still false) -- likely a "
+                        + "GL/EGL failure swallowed internally");
+            }
+
             log("GPU Surveillance initialized: profile=" + resolvedCamera.getProfile().getDisplayName()
                 + ", panoCam=" + resolvedCamera.getPanoCameraId()
                 + ", size=" + resolvedCamera.getPanoWidth() + "x" + resolvedCamera.getPanoHeight()


### PR DESCRIPTION
## Problem

`GpuSurveillancePipeline.init()` can return normally while an internal
GL/EGL step fails silently, leaving `isInitialized()` false forever —
but `gpuPipeline` itself stays non-null. Every exit/retry check in
`initSurveillance()` only tests `gpuPipeline != null`, never
`isInitialized()`, so this specific failure mode was never
distinguished from a real success and the existing exponential-backoff
retry (`scheduleInitSurveillanceRetry()`) never got a chance to fire.

Confirmed live on a BYD Sealion 7: surveillance sat stuck
uninitialized for over an hour, with zero retry attempts logged,
until the process was manually killed and restarted.

## Fix

Throw immediately if `isInitialized()` is still `false` right after
`init()` returns:

```java
gpuPipeline.init(assetManager, ...);

if (!gpuPipeline.isInitialized()) {
    throw new IllegalStateException(
            "GpuSurveillancePipeline.init() returned without completing "
            + "initialization (isInitialized() still false) -- likely a "
            + "GL/EGL failure swallowed internally");
}
```

This funnels the failure through the *existing* `catch (Exception e)`
block and retry schedule immediately below, which already handles
every other `initSurveillance()` failure correctly (sets
`gpuPipeline = null`, calls `scheduleInitSurveillanceRetry()` with its
unbounded exponential backoff). No new retry mechanism, no changes to
the retry logic itself — just closing the one gap that let a silent
failure slip past all of it.

One-line change, purely additive, no behavior change for the success
path.