### PR TITLE
Trip crash-recovery checkpoints (SoC/energy, not just GPS)

### DIFF
--- a/app/src/main/java/com/overdrive/app/trips/TripAnalyticsManager.java
+++ b/app/src/main/java/com/overdrive/app/trips/TripAnalyticsManager.java
@@ -354,6 +354,14 @@ public class TripAnalyticsManager {
                 Thread recoveryThread = new Thread(() -> {
                     try {
                         TripDatabase.RecoveryResult r = db.recoverTripsFromDisk(tripsDirs);
+                        // A surviving checkpoint alongside a just-recovered row means the
+                        // crash happened mid-trip after at least one checkpoint tick — fill
+                        // in the real SoC/energy data the GPS-only recovery above can't see.
+                        try {
+                            db.enrichRecoveredTripsFromCheckpoints();
+                        } catch (Throwable t) {
+                            logger.warn("Checkpoint enrichment failed: " + t.getMessage());
+                        }
                         if (r.recovered > 0) {
                             logger.info("Auto-recovery: recovered " + r.recovered
                                 + " orphaned trips from disk (scanned=" + r.scanned
@@ -399,6 +407,11 @@ public class TripAnalyticsManager {
             @Override
             public double getRecordedDistanceKm() {
                 return recorder != null ? recorder.getTotalDistanceKm() : 0;
+            }
+
+            @Override
+            public void onTripCheckpoint(TripRecord trip) {
+                handleTripCheckpoint(trip);
             }
         });
 
@@ -454,6 +467,24 @@ public class TripAnalyticsManager {
     }
 
     /**
+     * Handle a periodic live-trip checkpoint from TripDetector (see
+     * TripDetector.checkpointNow / TripListener.onTripCheckpoint). Persists
+     * just the SoC/energy readings — real crash-recovery insurance for the gap
+     * this system had before: a mid-drive daemon crash left NOTHING durable
+     * except the GPS telemetry file, so recovery could only ever reconstruct
+     * distance/speed/elevation, never energy or SoC.
+     */
+    private void handleTripCheckpoint(TripRecord trip) {
+        if (database == null || trip == null || trip.startTime <= 0) return;
+        try {
+            database.upsertTripCheckpoint(trip.startTime, trip.socStart, trip.kwhStart,
+                    trip.elecConStart, trip.socEnd, trip.kwhEnd, trip.elecConEnd);
+        } catch (Throwable t) {
+            logger.debug("handleTripCheckpoint failed: " + t.getMessage());
+        }
+    }
+
+    /**
      * Handle trip ended event from TripDetector.
      *
      * 1. Stop recorder, get samples
@@ -467,6 +498,14 @@ public class TripAnalyticsManager {
     private void handleTripEnded(TripRecord trip) {
         logger.info("Trip ended — duration=" + trip.durationSeconds + "s, distance="
                 + trip.distanceKm + "km");
+        // NOTE: the checkpoint is deliberately NOT cleared here. Scoring, the
+        // last-charge-rate lookup, and cost math all happen below, well before
+        // insertTrip() actually runs — a crash anywhere in that stretch used to
+        // leave the trip with NEITHER a real row NOR a checkpoint to recover
+        // from (confirmed live: a 12-minute trip crashed during this window and
+        // came back with distance/duration only, zero SoC/energy, because the
+        // checkpoint had already been wiped up here before the row existed).
+        // It's cleared only once insertTrip() actually succeeds, below.
 
         // Release telemetry polling ref (acquired in handleTripStarted)
         if (telemetryDataCollector != null) {
@@ -792,7 +831,18 @@ public class TripAnalyticsManager {
                         + " SD=" + trip.speedDisciplineScore
                         + " E=" + trip.efficiencyScore
                         + " C=" + trip.consistencyScore + "]");
+
+                // The row is durably in place now — the checkpoint's only job
+                // (crash-recovery insurance) is done. Left alone until now so a
+                // crash during scoring/insert above still has it available.
+                try {
+                    if (database != null) database.clearTripCheckpoint(trip.startTime);
+                } catch (Throwable ignored) {}
             } else {
+                // insertTrip failed — deliberately leave the checkpoint in place.
+                // Next-boot disk recovery will rebuild a row from the .jsonl.gz
+                // (distance/speed/elevation only); enrichRecoveredTripsFromCheckpoints()
+                // needs this checkpoint to still exist to fill in SoC/energy for it.
                 // Previously there was no else branch, so a failed insert
                 // produced NO log line at all here — the trip simply vanished
                 // and the only trace was a lower-level "Failed to insert trip".
@@ -912,6 +962,11 @@ public class TripAnalyticsManager {
      */
     private void handleTripDiscarded(TripRecord trip, String reason) {
         logger.info("Trip discarded: " + reason);
+        // A discarded trip (below min duration/distance) never gets a `trips`
+        // row either — no crash to recover from, so no reason to keep insurance.
+        try {
+            if (database != null && trip != null) database.clearTripCheckpoint(trip.startTime);
+        } catch (Throwable ignored) {}
 
         // Release telemetry polling ref (acquired in handleTripStarted)
         if (telemetryDataCollector != null) {

--- a/app/src/main/java/com/overdrive/app/trips/TripDatabase.java
+++ b/app/src/main/java/com/overdrive/app/trips/TripDatabase.java
@@ -256,6 +256,28 @@ public class TripDatabase {
 
     private void createTables() throws Exception {
         try (Statement stmt = connection.createStatement()) {
+            // Live-trip checkpoint: periodically refreshed while a trip is
+            // ACTIVE (see TripDetector's checkpoint timer), cleared on normal
+            // completion. `trips` itself can't hold an open/in-progress row
+            // (end_time is NOT NULL, and every reader assumes a completed
+            // trip), so this is a separate, deliberately tiny table — a mid-
+            // drive daemon crash previously left NOTHING durable except the
+            // GPS telemetry file, so recovery could only reconstruct
+            // distance/speed/elevation and never energy/SoC. One row per
+            // in-progress trip; start_time is the same join key `trips` uses.
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS trip_checkpoints (" +
+                "start_time BIGINT PRIMARY KEY," +
+                "soc_start REAL," +
+                "kwh_start REAL," +
+                "elec_con_start REAL," +
+                "soc_now REAL," +
+                "kwh_now REAL," +
+                "elec_con_now REAL," +
+                "checkpoint_at_ms BIGINT" +
+                ")"
+            );
+
             // Trip catalog
             stmt.execute(
                 "CREATE TABLE IF NOT EXISTS trips (" +
@@ -567,6 +589,169 @@ public class TripDatabase {
             reconnect();
         }
         return -1;
+    }
+
+    // ==================== TRIP CHECKPOINT (crash recovery) ====================
+
+    /**
+     * Create or refresh the in-progress checkpoint for a live trip. Called once
+     * at trip start and then periodically while ACTIVE (see TripDetector).
+     * Cheap by design — six doubles and a timestamp, upserted on the trip's
+     * start_time — so it can run every checkpoint tick without meaningfully
+     * competing with the trip-file / telemetry I/O already happening live.
+     */
+    public synchronized void upsertTripCheckpoint(long startTime, double socStart, double kwhStart,
+            double elecConStart, double socNow, double kwhNow, double elecConNow) {
+        if (!ensureConnection() || startTime <= 0) return;
+        try (PreparedStatement p = connection.prepareStatement(
+                "MERGE INTO trip_checkpoints (start_time, soc_start, kwh_start, elec_con_start, " +
+                "soc_now, kwh_now, elec_con_now, checkpoint_at_ms) KEY(start_time) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) {
+            p.setLong(1, startTime);
+            p.setDouble(2, socStart);
+            p.setDouble(3, kwhStart);
+            p.setDouble(4, elecConStart);
+            p.setDouble(5, socNow);
+            p.setDouble(6, kwhNow);
+            p.setDouble(7, elecConNow);
+            p.setLong(8, System.currentTimeMillis());
+            p.executeUpdate();
+        } catch (Exception e) {
+            logger.debug("upsertTripCheckpoint failed: " + e.getMessage());
+        }
+    }
+
+    /** Remove a trip's checkpoint row. Called once the trip completes normally — no longer needed. */
+    public synchronized void clearTripCheckpoint(long startTime) {
+        if (!ensureConnection() || startTime <= 0) return;
+        try (PreparedStatement p = connection.prepareStatement(
+                "DELETE FROM trip_checkpoints WHERE start_time = ?")) {
+            p.setLong(1, startTime);
+            p.executeUpdate();
+        } catch (Exception e) {
+            logger.debug("clearTripCheckpoint failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Checkpoint start_times with no matching row in `trips` — left behind by a
+     * mid-trip daemon crash (normal completion always clears its own checkpoint
+     * first). Matched on whole-second start_time, same tolerance the disk-file
+     * recovery's dedup already uses for the identical reason (ms rounding).
+     */
+    public synchronized java.util.List<Long> orphanedTripCheckpointStartTimes() {
+        java.util.List<Long> out = new java.util.ArrayList<>();
+        if (!ensureConnection()) return out;
+        try (PreparedStatement p = connection.prepareStatement(
+                "SELECT c.start_time FROM trip_checkpoints c WHERE NOT EXISTS (" +
+                "SELECT 1 FROM trips t WHERE t.start_time / 1000 = c.start_time / 1000)")) {
+            try (ResultSet rs = p.executeQuery()) {
+                while (rs.next()) out.add(rs.getLong(1));
+            }
+        } catch (Exception e) {
+            logger.debug("orphanedTripCheckpointStartTimes failed: " + e.getMessage());
+        }
+        return out;
+    }
+
+    /**
+     * {tripId, startTime} pairs where a checkpoint survives AND a `trips` row
+     * now exists for that same start_time. Normal completion always clears its
+     * checkpoint BEFORE insertTrip() runs (see TripAnalyticsManager.
+     * handleTripEnded), so a checkpoint found alongside an existing row can
+     * only mean that row was just created by disk-file recovery after a
+     * mid-trip crash — the exact case that needs enrichment.
+     */
+    public synchronized java.util.List<long[]> checkpointedTripsNeedingEnrichment() {
+        java.util.List<long[]> out = new java.util.ArrayList<>();
+        if (!ensureConnection()) return out;
+        try (PreparedStatement p = connection.prepareStatement(
+                "SELECT t.id, c.start_time FROM trip_checkpoints c " +
+                "JOIN trips t ON t.start_time / 1000 = c.start_time / 1000")) {
+            try (ResultSet rs = p.executeQuery()) {
+                while (rs.next()) out.add(new long[]{rs.getLong(1), rs.getLong(2)});
+            }
+        } catch (Exception e) {
+            logger.debug("checkpointedTripsNeedingEnrichment failed: " + e.getMessage());
+        }
+        return out;
+    }
+
+    /** One checkpoint's saved readings: {socStart, kwhStart, elecConStart, socNow, kwhNow, elecConNow}, or null. */
+    public synchronized double[] getTripCheckpoint(long startTime) {
+        if (!ensureConnection() || startTime <= 0) return null;
+        try (PreparedStatement p = connection.prepareStatement(
+                "SELECT soc_start, kwh_start, elec_con_start, soc_now, kwh_now, elec_con_now " +
+                "FROM trip_checkpoints WHERE start_time = ?")) {
+            p.setLong(1, startTime);
+            try (ResultSet rs = p.executeQuery()) {
+                if (!rs.next()) return null;
+                return new double[]{rs.getDouble(1), rs.getDouble(2), rs.getDouble(3),
+                        rs.getDouble(4), rs.getDouble(5), rs.getDouble(6)};
+            }
+        } catch (Exception e) {
+            logger.debug("getTripCheckpoint failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Best-effort enrichment for a just-recovered (GPS-only) trip row: if a
+     * checkpoint survives for the same start_time, the crash happened after at
+     * least one checkpoint tick, so real (if slightly stale) SoC/energy data
+     * exists — fill it in instead of leaving the recovered row's energy fields
+     * at the all-zero "recovered" default. Deliberately additive and separate
+     * from the disk-file recovery pass itself (recoverTripsFromDiskLocked) —
+     * that pass's dedup logic is already delicate, so this only ever runs
+     * AFTER it, patching fields on a row that already exists, never touching
+     * how that row got created or its dedup keys.
+     */
+    public synchronized void enrichRecoveredTripFromCheckpoint(long tripId, long startTime) {
+        double[] cp = getTripCheckpoint(startTime);
+        if (cp == null) return;
+        double socStart = cp[0], kwhStart = cp[1], elecConStart = cp[2];
+        double socNow = cp[3], kwhNow = cp[4], elecConNow = cp[5];
+        double energyUsedKwh = -1;
+        // Prefer the metered HAL counter delta (finer-grained than remaining-kWh,
+        // which is derived from an integer SoC) — same preference order startTrip()
+        // itself uses. Both sides must be real (>0) before trusting the delta.
+        if (elecConStart > 0 && elecConNow > 0 && elecConNow >= elecConStart) {
+            energyUsedKwh = elecConNow - elecConStart;
+        } else if (kwhStart > 0 && kwhNow > 0 && kwhStart >= kwhNow) {
+            energyUsedKwh = kwhStart - kwhNow;
+        }
+        if (!ensureConnection()) return;
+        try (PreparedStatement p = connection.prepareStatement(
+                "UPDATE trips SET soc_start = ?, soc_end = ?, kwh_start = ?, kwh_end = ?, " +
+                "elec_con_start = ?, elec_con_end = ? WHERE id = ?")) {
+            p.setDouble(1, socStart > 0 ? socStart : 0);
+            p.setDouble(2, socNow > 0 ? socNow : 0);
+            p.setDouble(3, kwhStart > 0 ? kwhStart : 0);
+            p.setDouble(4, kwhNow > 0 ? kwhNow : 0);
+            p.setDouble(5, elecConStart > 0 ? elecConStart : 0);
+            p.setDouble(6, elecConNow > 0 ? elecConNow : 0);
+            p.setLong(7, tripId);
+            p.executeUpdate();
+            logger.info("Enriched recovered trip id=" + tripId + " from checkpoint (energyUsedKwh~="
+                    + (energyUsedKwh >= 0 ? String.format(java.util.Locale.US, "%.2f", energyUsedKwh) : "unknown") + ")");
+        } catch (Exception e) {
+            logger.debug("enrichRecoveredTripFromCheckpoint failed: " + e.getMessage());
+        } finally {
+            // Job done either way — a retry loop finding the same trip row
+            // again next boot would just re-run this for no further benefit.
+            clearTripCheckpoint(startTime);
+        }
+    }
+
+    /**
+     * Run after recoverTripsFromDisk(): enrich every just-recovered trip that
+     * still has a surviving checkpoint with its real SoC/energy readings.
+     * Safe to call unconditionally — a no-op when nothing needs enrichment.
+     */
+    public void enrichRecoveredTripsFromCheckpoints() {
+        for (long[] pair : checkpointedTripsNeedingEnrichment()) {
+            enrichRecoveredTripFromCheckpoint(pair[0], pair[1]);
+        }
     }
 
     /**

--- a/app/src/main/java/com/overdrive/app/trips/TripDetector.java
+++ b/app/src/main/java/com/overdrive/app/trips/TripDetector.java
@@ -53,6 +53,9 @@ public class TripDetector {
     // Debounce timer
     private final ScheduledExecutorService scheduler;
     private volatile ScheduledFuture<?> parkDebounceTask;
+    // Periodic durable checkpoint while ACTIVE — see startTrip() and TripListener.onTripCheckpoint.
+    private static final long CHECKPOINT_INTERVAL_MS = 60_000; // 1 minute
+    private volatile ScheduledFuture<?> checkpointTask;
     // PHEV-only: integrates seconds where engineSpeedRpm > 600 across the
     // active trip. Used by the cost-breakdown UI to label the trip's HEV
     // mode share. Idle on BEVs (sampler is started only when isPhev=true).
@@ -80,6 +83,14 @@ public class TripDetector {
         void onTripDiscarded(TripRecord trip, String reason);
         /** Called before finalization to get the GPS distance from the recorder. */
         default double getRecordedDistanceKm() { return 0; }
+        /**
+         * Periodic durable checkpoint while a trip is ACTIVE (see startTrip's
+         * checkpoint timer) — SoC/energy readings only, so a mid-drive daemon
+         * crash leaves behind real (if slightly stale) energy data instead of
+         * nothing but the GPS telemetry file. No-op default so existing
+         * listeners that don't own a TripDatabase aren't forced to implement it.
+         */
+        default void onTripCheckpoint(TripRecord trip) {}
     }
 
     /**
@@ -321,6 +332,48 @@ public class TripDetector {
                 logger.error("Listener.onTripStarted failed: " + e.getMessage());
             }
         }
+
+        checkpointNow(); // immediate first checkpoint, then periodic
+        checkpointTask = scheduler.scheduleAtFixedRate(
+                this::checkpointNow, CHECKPOINT_INTERVAL_MS, CHECKPOINT_INTERVAL_MS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Refresh the live trip's current SoC/kWh/elec-counter readings and hand
+     * them to the listener for durable persistence. Reuses socEnd/kwhEnd/
+     * elecConEnd as the "current reading" slot — harmless, since trip-end
+     * overwrites them again with the real final values regardless.
+     */
+    private void checkpointNow() {
+        TripRecord trip = activeTrip;
+        if (trip == null || state != State.ACTIVE) return;
+        try {
+            BatterySocData socData = VehicleDataMonitor.getInstance().getBatterySoc();
+            if (socData != null) trip.socEnd = socData.socPercent;
+            double kwhRemaining = VehicleDataMonitor.getInstance().getBatteryRemainPowerKwh();
+            if (kwhRemaining > 0) trip.kwhEnd = kwhRemaining;
+            double elecConNow = VehicleDataMonitor.getInstance().getTotalElecCon();
+            if (!Double.isNaN(elecConNow) && elecConNow > 0) trip.elecConEnd = elecConNow;
+        } catch (Exception e) {
+            logger.debug("checkpointNow: read failed: " + e.getMessage());
+        }
+        if (listener != null) {
+            try {
+                listener.onTripCheckpoint(trip);
+            } catch (Exception e) {
+                logger.debug("Listener.onTripCheckpoint failed: " + e.getMessage());
+            }
+        }
+    }
+
+    /** Stop the periodic checkpoint timer. Called whenever a trip stops being ACTIVE. */
+    private void stopCheckpointTimer() {
+        ScheduledFuture<?> t = checkpointTask;
+        if (t != null) {
+            t.cancel(false);
+            checkpointTask = null;
+        }
     }
 
     /**
@@ -556,6 +609,7 @@ public class TripDetector {
         }
 
         // Trip is valid — notify listener
+        stopCheckpointTimer();
         TripRecord completedTrip = activeTrip;
         activeTrip = null;
         startOdometerKm = -1;
@@ -575,6 +629,7 @@ public class TripDetector {
      * Discard a trip that doesn't meet minimum thresholds.
      */
     private void discardTrip(String reason) {
+        stopCheckpointTimer();
         TripRecord discardedTrip = activeTrip;
         activeTrip = null;
         startOdometerKm = -1;


### PR DESCRIPTION
## Problem

A mid-drive daemon crash previously left nothing durable for a trip
except the GPS telemetry file, so next-boot recovery could only ever
reconstruct distance/speed/elevation — never energy or SoC. A
recovered trip always showed zero energy/SoC data, with no way to
tell "genuinely unavailable" from "just never saved."

## Fix

Adds a small `trip_checkpoints` table (one row per in-progress trip,
keyed on `start_time`), refreshed every 60s while a trip is ACTIVE via
a new `TripDetector` checkpoint timer, and a
`TripListener.onTripCheckpoint` callback so `TripAnalyticsManager` can
persist just the SoC/kWh/elec-counter readings — cheap by design, six
doubles and a timestamp.

On next boot, after the existing disk-file recovery reconstructs a
trip's distance/speed/elevation from its GPS telemetry, a new
enrichment pass (`enrichRecoveredTripsFromCheckpoints`) checks for a
surviving checkpoint on the same `start_time` and fills in the real
(if slightly stale) SoC/energy data — a surviving checkpoint is proof
the crash happened after at least one checkpoint tick.

## Ordering fix (found live during testing)

The checkpoint must not be cleared until the trip's real database row
is actually inserted, not at the top of `handleTripEnded()`. Scoring,
the last-charge-rate lookup, and cost math all run between "trip
ended" and "row inserted" — a crash anywhere in that stretch used to
strand the trip with *neither* a real row *nor* a checkpoint to
recover from. Confirmed live: a 12-minute trip crashed during this
window and came back recovered with distance/duration only, zero
SoC/energy, because the checkpoint had already been wiped before the
row existed. The checkpoint is now cleared only once `insertTrip()`
succeeds; if it fails, the checkpoint is deliberately left in place
for next-boot recovery to use.

## Scope note

This PR is deliberately limited to the checkpoint/crash-recovery
mechanism. A separate, unrelated "GPS/CAN fused-motion trip
start/stop" improvement in our fork's history was NOT included here,
since it depends on DiLink5-specific telemetry classes not yet in
this repo.