### PR TITLE
fix(vehicle): expose AC temperature setpoint in /api/vehicle/state

### DIFF
--- a/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
+++ b/app/src/main/java/com/overdrive/app/server/VehicleControlApiHandler.java
@@ -952,6 +952,20 @@ public class VehicleControlApiHandler {
         }
         if (data.acWindMode != BydVehicleData.UNAVAILABLE) climate.put("windMode", data.acWindMode);
         if (data.acFanLevel != BydVehicleData.UNAVAILABLE && vehiclePoweredOn) climate.put("fanLevel", data.acFanLevel);
+        // AC temperature SETPOINT (the dial) — distinct from insideTempC, which is the
+        // MEASURED cabin air. The collector already reads both dials every poll, but they
+        // were never surfaced here, so clients had no way to show the temperature the car
+        // is actually set to and fell back to a hardcoded default. Gated on power like
+        // fanLevel, since a parked car reports the last cached dial value. Key names match
+        // BydVehicleData.toJson() so both serializations agree. tempUnit rides along
+        // because the setpoint is expressed in the head unit's display unit (0 = F).
+        if (data.acSetpointDriver != BydVehicleData.UNAVAILABLE && vehiclePoweredOn) {
+            climate.put("setpointDriver", data.acSetpointDriver);
+        }
+        if (data.acSetpointPassenger != BydVehicleData.UNAVAILABLE && vehiclePoweredOn) {
+            climate.put("setpointPassenger", data.acSetpointPassenger);
+        }
+        if (data.tempUnit != BydVehicleData.UNAVAILABLE) climate.put("tempUnit", data.tempUnit);
         Boolean remoteClimateActive = remoteClimateActive();
         if (remoteClimateActive != null) {
             climate.put("remoteClimateActive", remoteClimateActive.booleanValue());


### PR DESCRIPTION
## Problem

`GET /api/vehicle/state` reports `acOn`, `insideTempC`, `windMode` and `fanLevel`, but never the AC temperature **setpoint** — the value the dial is actually asking for (as opposed to `insideTempC`, which is the *measured* cabin air).

The data is already collected: `BydDataCollector.readAcSetpointNow()` reads areas 1/2 on every poll and stores `acSetpointDriver` / `acSetpointPassenger`, and `BydVehicleData.toJson()` serializes them as `setpointDriver` / `setpointPassenger`. But `toJson()` isn't reachable from any HTTP handler, so **no client can see the setpoint**.

As a result the bundled web UI falls back to a hardcoded default — `acTemp: 22` in `shared/vehicle-control.js` is the only assignment to that field, and nothing ever populates it from a response. A car set to 25 °C shows **22** in every client.

## Evidence

Reproduced on a **BYD Sealion 6 DM-i (DiLink 3.0, Android 10)** with the AC dial set to 25 °C. The daemon reads the correct value every poll:

```
BYDAutoAcDevice: getTemperatureUnit unit is: 1
BYDAutoAcDevice: getTemprature area is: 1
BYDAutoAcDevice: getTemprature temprature is: 25
BYDAutoAcDevice: getTemprature area is: 2
BYDAutoAcDevice: getTemprature temprature is: 25
```

…while the HTTP response from the *same* process contained only:

```json
"climate": { "acOn": true, "windMode": 1 }
```

## Change

Adds to the climate block:

- `setpointDriver` / `setpointPassenger` — gated on `vehiclePoweredOn` exactly like `fanLevel`, since a parked car reports the last cached dial value.
- `tempUnit` — the setpoint is expressed in the head unit's display unit (`0` = Fahrenheit), so a client can't interpret the number without it.

Key names match `BydVehicleData.toJson()` so both serializations stay consistent.

## Notes

- Read-only: no new reads are issued (the collector already polls these), and behaviour is unchanged when the values are `UNAVAILABLE`.
- Enables clients to show the real setpoint instead of a placeholder, and makes a relative "+1 °C" step safe — stepping from a fabricated 22 moves a 25 °C dial to 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
